### PR TITLE
Website/industry demo fixes

### DIFF
--- a/samples/data/measles.csv
+++ b/samples/data/measles.csv
@@ -1,0 +1,6104 @@
+country,year,case_count,source,case_rate
+Alabama,1896,1,Project Tycho - https://zenodo.org/records/11452259,
+Alabama,1899,1,Project Tycho - https://zenodo.org/records/11452259,
+Alabama,1900,2,Project Tycho - https://zenodo.org/records/11452259,0.10918043704928951
+Alabama,1904,2,Project Tycho - https://zenodo.org/records/11452259,0.1010112233570272
+Alabama,1907,3,Project Tycho - https://zenodo.org/records/11452259,0.14562696778440218
+Alabama,1908,4,Project Tycho - https://zenodo.org/records/11452259,0.1930436713045409
+Alabama,1909,1,Project Tycho - https://zenodo.org/records/11452259,0.04739093923154644
+Alabama,1910,622,Project Tycho - https://zenodo.org/records/11452259,28.90133122691262
+Alabama,1911,594,Project Tycho - https://zenodo.org/records/11452259,27.158196494580935
+Alabama,1912,111,Project Tycho - https://zenodo.org/records/11452259,5.001764135728953
+Alabama,1913,7,Project Tycho - https://zenodo.org/records/11452259,0.30684541434870527
+Alabama,1914,4,Project Tycho - https://zenodo.org/records/11452259,0.17106181489743133
+Alabama,1915,2,Project Tycho - https://zenodo.org/records/11452259,0.0852026438380383
+Alabama,1916,66,Project Tycho - https://zenodo.org/records/11452259,2.7950006754584966
+Alabama,1917,5223,Project Tycho - https://zenodo.org/records/11452259,220.99882328598974
+Alabama,1918,1681,Project Tycho - https://zenodo.org/records/11452259,71.67395131543658
+Alabama,1919,373,Project Tycho - https://zenodo.org/records/11452259,15.94468860194149
+Alabama,1920,285,Project Tycho - https://zenodo.org/records/11452259,12.06932109857078
+Alabama,1921,485,Project Tycho - https://zenodo.org/records/11452259,20.171335741693778
+Alabama,1922,118,Project Tycho - https://zenodo.org/records/11452259,4.843143709207801
+Alabama,1923,4999,Project Tycho - https://zenodo.org/records/11452259,202.6788146918017
+Alabama,1924,1617,Project Tycho - https://zenodo.org/records/11452259,64.58954879586626
+Alabama,1925,53,Project Tycho - https://zenodo.org/records/11452259,2.089465388597196
+Alabama,1926,1797,Project Tycho - https://zenodo.org/records/11452259,69.93396163633795
+Alabama,1927,1843,Project Tycho - https://zenodo.org/records/11452259,70.56952246680112
+Alabama,1928,10318,Project Tycho - https://zenodo.org/records/11452259,390.4428904428904
+Alabama,1929,3091,Project Tycho - https://zenodo.org/records/11452259,116.78941330983692
+Alabama,1930,6069,Project Tycho - https://zenodo.org/records/11452259,229.04937903048972
+Alabama,1931,10650,Project Tycho - https://zenodo.org/records/11452259,401.6368682280347
+Alabama,1932,310,Project Tycho - https://zenodo.org/records/11452259,11.673211823984534
+Alabama,1933,2224,Project Tycho - https://zenodo.org/records/11452259,83.49410829681405
+Alabama,1934,18272,Project Tycho - https://zenodo.org/records/11452259,679.8415736963223
+Alabama,1935,8015,Project Tycho - https://zenodo.org/records/11452259,294.48300871618267
+Alabama,1936,588,Project Tycho - https://zenodo.org/records/11452259,21.41496855313844
+Alabama,1937,900,Project Tycho - https://zenodo.org/records/11452259,32.55253074224834
+Alabama,1938,16746,Project Tycho - https://zenodo.org/records/11452259,600.260880131709
+Alabama,1939,4613,Project Tycho - https://zenodo.org/records/11452259,163.76658167702945
+Alabama,1940,3600,Project Tycho - https://zenodo.org/records/11452259,126.41137421453764
+Alabama,1941,10128,Project Tycho - https://zenodo.org/records/11452259,348.6520371427332
+Alabama,1942,3742,Project Tycho - https://zenodo.org/records/11452259,127.10852561243584
+Alabama,1943,4194,Project Tycho - https://zenodo.org/records/11452259,144.37664334287354
+Alabama,1944,7667,Project Tycho - https://zenodo.org/records/11452259,273.35262881301423
+Alabama,1945,369,Project Tycho - https://zenodo.org/records/11452259,13.284013284013284
+Alabama,1946,4278,Project Tycho - https://zenodo.org/records/11452259,146.81299463161366
+Alabama,1947,4385,Project Tycho - https://zenodo.org/records/11452259,148.89936711826584
+Alabama,1948,2110,Project Tycho - https://zenodo.org/records/11452259,70.99670285928286
+Alabama,1949,11066,Project Tycho - https://zenodo.org/records/11452259,368.4981684981685
+Alabama,1950,1633,Project Tycho - https://zenodo.org/records/11452259,53.347568063068394
+Alabama,1951,3300,Project Tycho - https://zenodo.org/records/11452259,107.7706210102418
+Alabama,1952,16029,Project Tycho - https://zenodo.org/records/11452259,521.9356914272169
+Alabama,1953,2987,Project Tycho - https://zenodo.org/records/11452259,97.74045149086093
+Alabama,1954,8451,Project Tycho - https://zenodo.org/records/11452259,280.11139490900604
+Alabama,1955,2125,Project Tycho - https://zenodo.org/records/11452259,69.60252861892207
+Alabama,1956,7324,Project Tycho - https://zenodo.org/records/11452259,238.2508406604792
+Alabama,1957,9127,Project Tycho - https://zenodo.org/records/11452259,293.273789574851
+Alabama,1958,7650,Project Tycho - https://zenodo.org/records/11452259,241.61737724810757
+Alabama,1959,3467,Project Tycho - https://zenodo.org/records/11452259,108.1003889992654
+Alabama,1960,2075,Project Tycho - https://zenodo.org/records/11452259,63.3148159110285
+Alabama,1961,2724,Project Tycho - https://zenodo.org/records/11452259,82.06510015918941
+Alabama,1962,2254,Project Tycho - https://zenodo.org/records/11452259,67.76251133759409
+Alabama,1963,1167,Project Tycho - https://zenodo.org/records/11452259,34.71811095396563
+Alabama,1964,18105,Project Tycho - https://zenodo.org/records/11452259,532.7514900416226
+Alabama,1965,2346,Project Tycho - https://zenodo.org/records/11452259,68.07018134348951
+Alabama,1966,1813,Project Tycho - https://zenodo.org/records/11452259,52.286051131316725
+Alabama,1967,1345,Project Tycho - https://zenodo.org/records/11452259,38.85645875235233
+Alabama,1968,158,Project Tycho - https://zenodo.org/records/11452259,4.580445671565811
+Alabama,1969,12,Project Tycho - https://zenodo.org/records/11452259,0.34848872058174385
+Alabama,1970,486,Project Tycho - https://zenodo.org/records/11452259,14.09595341722456
+Alabama,1971,1948,Project Tycho - https://zenodo.org/records/11452259,55.64803247925411
+Alabama,1972,142,Project Tycho - https://zenodo.org/records/11452259,4.007971912584439
+Alabama,1973,15,Project Tycho - https://zenodo.org/records/11452259,0.4186016528067659
+Alabama,1974,21,Project Tycho - https://zenodo.org/records/11452259,0.5784924761544024
+Alabama,1975,5,Project Tycho - https://zenodo.org/records/11452259,0.13577762015504719
+Alabama,1976,0,https://stacks.cdc.gov/view/cdc/1130,0.0
+Alabama,1977,79,Project Tycho - https://zenodo.org/records/11452259,2.087636882254373
+Alabama,1978,60,Project Tycho - https://zenodo.org/records/11452259,1.5642650939197797
+Alabama,1979,94,Project Tycho - https://zenodo.org/records/11452259,2.4288690203957817
+Alabama,1980,22,Project Tycho - https://zenodo.org/records/11452259,0.5634859082419547
+Alabama,1981,2,https://stacks.cdc.gov/view/cdc/1307,0.05098855332472137
+Alabama,1982,2,Project Tycho - https://zenodo.org/records/11452259,0.05090106334866389
+Alabama,1983,5,Project Tycho - https://zenodo.org/records/11452259,0.1269668433706548
+Alabama,1984,3,https://stacks.cdc.gov/view/cdc/35267,0.07583856598372353
+Alabama,1985,0,https://stacks.cdc.gov/view/cdc/35429,0.0
+Alabama,1986,2,Project Tycho - https://zenodo.org/records/11452259,0.05005556167345754
+Alabama,1987,4,Project Tycho - https://zenodo.org/records/11452259,0.09952033685643619
+Alabama,1988,1,Project Tycho - https://zenodo.org/records/11452259,0.024827036245238486
+Alabama,1989,61,Project Tycho - https://zenodo.org/records/11452259,1.5120522961877445
+Alabama,1990,28,Project Tycho - https://zenodo.org/records/11452259,0.6909219761552956
+Alabama,1991,2,Project Tycho - https://zenodo.org/records/11452259,0.04883866537602354
+Alabama,1992,0,https://stacks.cdc.gov/view/cdc/36063,0.0
+Alabama,1993,1,Project Tycho - https://zenodo.org/records/11452259,0.023824800044409428
+Alabama,1994,0,https://stacks.cdc.gov/view/cdc/5648,0.0
+Alabama,1995,0,https://stacks.cdc.gov/view/cdc/5644,0.0
+Alabama,1996,0,https://stacks.cdc.gov/view/cdc/5642,0.0
+Alabama,1997,1,"https://www.cdc.gov/mmwr/preview/mmwrhtml/00056071.htm#:~:text=As%20of%20January%201%2C%201997,and%20control%20of%20the%20disease.",0.0231235205282522
+Alabama,1998,1,https://stacks.cdc.gov/view/cdc/5637,0.022960066933187123
+Alabama,1999,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.0
+Alabama,2000,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4953a1.htm,0.0
+Alabama,2001,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5053a1.htm,0.0
+Alabama,2002,12,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.2675842427666962
+Alabama,2003,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.0
+Alabama,2004,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0
+Alabama,2005,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.0
+Alabama,2006,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.0
+Alabama,2007,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.0
+Alabama,2008,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.0
+Alabama,2009,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.0
+Alabama,2010,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.0
+Alabama,2011,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.0
+Alabama,2012,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.0
+Alabama,2013,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.0
+Alabama,2014,1,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.02062459524231837
+Alabama,2015,0,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.0
+Alabama,2016,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.020526757654941098
+Alabama,2017,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Alabama,2018,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Alabama,2019,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Alabama,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Alabama,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Alabama,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Alaska,1914,1,Project Tycho - https://zenodo.org/records/11452259,
+Alaska,1954,1487,Project Tycho - https://zenodo.org/records/11452259,690.9369700067374
+Alaska,1955,537,Project Tycho - https://zenodo.org/records/11452259,241.65024165024164
+Alaska,1956,2511,Project Tycho - https://zenodo.org/records/11452259,1119.8622805765663
+Alaska,1957,986,Project Tycho - https://zenodo.org/records/11452259,426.41341342640044
+Alaska,1958,1231,Project Tycho - https://zenodo.org/records/11452259,549.0045668617097
+Alaska,1959,1829,Project Tycho - https://zenodo.org/records/11452259,815.7021549878693
+Alaska,1960,1456,Project Tycho - https://zenodo.org/records/11452259,635.1726875744342
+Alaska,1961,1002,Project Tycho - https://zenodo.org/records/11452259,420.5878155457987
+Alaska,1962,1406,Project Tycho - https://zenodo.org/records/11452259,570.973741705449
+Alaska,1963,1968,Project Tycho - https://zenodo.org/records/11452259,767.982017982018
+Alaska,1964,1038,Project Tycho - https://zenodo.org/records/11452259,394.2825235600901
+Alaska,1965,215,Project Tycho - https://zenodo.org/records/11452259,79.25653682111246
+Alaska,1966,641,Project Tycho - https://zenodo.org/records/11452259,236.29507024340973
+Alaska,1967,148,Project Tycho - https://zenodo.org/records/11452259,53.184225846096346
+Alaska,1968,4,Project Tycho - https://zenodo.org/records/11452259,1.40210666526456
+Alaska,1969,18,Project Tycho - https://zenodo.org/records/11452259,6.075006075006075
+Alaska,1970,73,Project Tycho - https://zenodo.org/records/11452259,24.101556696435942
+Alaska,1971,40,Project Tycho - https://zenodo.org/records/11452259,12.665241826961132
+Alaska,1972,7,Project Tycho - https://zenodo.org/records/11452259,2.1552520413315763
+Alaska,1973,5,Project Tycho - https://zenodo.org/records/11452259,1.5111538263926039
+Alaska,1974,1,Project Tycho - https://zenodo.org/records/11452259,0.29290810886808594
+Alaska,1976,11,Project Tycho - https://zenodo.org/records/11452259,2.740620227272161
+Alaska,1977,49,Project Tycho - https://zenodo.org/records/11452259,12.133548270474124
+Alaska,1978,2,Project Tycho - https://zenodo.org/records/11452259,0.49361996199126296
+Alaska,1979,18,Project Tycho - https://zenodo.org/records/11452259,4.464784016073223
+Alaska,1980,4,Project Tycho - https://zenodo.org/records/11452259,0.9859016070196194
+Alaska,1982,1,Project Tycho - https://zenodo.org/records/11452259,0.22219506504760528
+Alaska,1983,2,Project Tycho - https://zenodo.org/records/11452259,0.40907742813020936
+Alaska,1987,1,Project Tycho - https://zenodo.org/records/11452259,0.18523732606215082
+Alaska,1988,1,Project Tycho - https://zenodo.org/records/11452259,0.18432364282501787
+Alaska,1990,24,Project Tycho - https://zenodo.org/records/11452259,4.334688525537637
+Alaska,1991,1,Project Tycho - https://zenodo.org/records/11452259,0.17548724032275614
+Alaska,1993,1,Project Tycho - https://zenodo.org/records/11452259,0.1673390909136547
+Alaska,1994,2,Project Tycho - https://zenodo.org/records/11452259,0.33265471770920657
+Alaska,1995,0,https://stacks.cdc.gov/view/cdc/5644,0.0
+Alaska,1996,6,Project Tycho - https://zenodo.org/records/11452259,0.9908805955852967
+Alaska,1997,0,"https://www.cdc.gov/mmwr/preview/mmwrhtml/00056071.htm#:~:text=As%20of%20January%201%2C%201997,and%20control%20of%20the%20disease.",0.0
+Alaska,1998,7,Project Tycho - https://zenodo.org/records/11452259,1.1366957877301809
+Alaska,1999,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.0
+Alaska,2000,1,Project Tycho - https://zenodo.org/records/11452259,0.1590862088165577
+Alaska,2001,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5053a1.htm,0.0
+Alaska,2002,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.0
+Alaska,2003,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.0
+Alaska,2004,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0
+Alaska,2005,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.0
+Alaska,2006,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.0
+Alaska,2007,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.0
+Alaska,2008,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.0
+Alaska,2009,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.0
+Alaska,2010,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.0
+Alaska,2011,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.0
+Alaska,2012,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.0
+Alaska,2013,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.0
+Alaska,2014,0,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.0
+Alaska,2015,0,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.0
+Alaska,2016,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Alaska,2017,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Alaska,2018,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Alaska,2019,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.1361774446574865
+Alaska,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Alaska,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Alaska,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+American Samoa,1986,2,Project Tycho - https://zenodo.org/records/11452259,
+American Samoa,1987,2,Project Tycho - https://zenodo.org/records/11452259,
+American Samoa,1988,1,Project Tycho - https://zenodo.org/records/11452259,
+American Samoa,1993,1,Project Tycho - https://zenodo.org/records/11452259,
+Arizona,1914,5,Project Tycho - https://zenodo.org/records/11452259,1.9743102747055317
+Arizona,1915,10,Project Tycho - https://zenodo.org/records/11452259,3.7984828859353574
+Arizona,1919,2,Project Tycho - https://zenodo.org/records/11452259,0.6072954401221878
+Arizona,1920,3,Project Tycho - https://zenodo.org/records/11452259,0.8814714697067638
+Arizona,1921,7,Project Tycho - https://zenodo.org/records/11452259,1.992309684617377
+Arizona,1924,1,Project Tycho - https://zenodo.org/records/11452259,0.261518586125916
+Arizona,1925,26,Project Tycho - https://zenodo.org/records/11452259,6.609166914510427
+Arizona,1926,12,Project Tycho - https://zenodo.org/records/11452259,2.9746928009955305
+Arizona,1927,44,Project Tycho - https://zenodo.org/records/11452259,10.617401921749748
+Arizona,1928,848,Project Tycho - https://zenodo.org/records/11452259,200.74712017839983
+Arizona,1929,240,Project Tycho - https://zenodo.org/records/11452259,55.75819529307902
+Arizona,1930,2297,Project Tycho - https://zenodo.org/records/11452259,528.7339388721877
+Arizona,1931,2158,Project Tycho - https://zenodo.org/records/11452259,502.527775255048
+Arizona,1932,91,Project Tycho - https://zenodo.org/records/11452259,21.340162185232607
+Arizona,1933,1312,Project Tycho - https://zenodo.org/records/11452259,307.67354711016685
+Arizona,1934,1028,Project Tycho - https://zenodo.org/records/11452259,239.94696891893153
+Arizona,1935,575,Project Tycho - https://zenodo.org/records/11452259,132.35612313953328
+Arizona,1936,2376,Project Tycho - https://zenodo.org/records/11452259,535.8073078163371
+Arizona,1937,3793,Project Tycho - https://zenodo.org/records/11452259,836.470372894214
+Arizona,1938,604,Project Tycho - https://zenodo.org/records/11452259,129.48424965592346
+Arizona,1939,485,Project Tycho - https://zenodo.org/records/11452259,100.10650506518276
+Arizona,1940,2124,Project Tycho - https://zenodo.org/records/11452259,425.22607652868174
+Arizona,1941,2949,Project Tycho - https://zenodo.org/records/11452259,601.2354991946829
+Arizona,1942,3813,Project Tycho - https://zenodo.org/records/11452259,726.9448109142766
+Arizona,1943,1002,Project Tycho - https://zenodo.org/records/11452259,144.65303482644524
+Arizona,1944,4644,Project Tycho - https://zenodo.org/records/11452259,760.5509244853507
+Arizona,1945,335,Project Tycho - https://zenodo.org/records/11452259,56.34096543187452
+Arizona,1946,3268,Project Tycho - https://zenodo.org/records/11452259,529.9894910284521
+Arizona,1947,1464,Project Tycho - https://zenodo.org/records/11452259,223.9720463303924
+Arizona,1948,4303,Project Tycho - https://zenodo.org/records/11452259,623.0001882175795
+Arizona,1949,3795,Project Tycho - https://zenodo.org/records/11452259,530.9816234185982
+Arizona,1950,2570,Project Tycho - https://zenodo.org/records/11452259,339.6074824646253
+Arizona,1951,10688,Project Tycho - https://zenodo.org/records/11452259,1360.1684939264558
+Arizona,1952,3386,Project Tycho - https://zenodo.org/records/11452259,401.7360311897129
+Arizona,1953,5852,Project Tycho - https://zenodo.org/records/11452259,653.9321975563587
+Arizona,1954,4959,Project Tycho - https://zenodo.org/records/11452259,530.980273745547
+Arizona,1955,10107,Project Tycho - https://zenodo.org/records/11452259,1022.9891688858255
+Arizona,1956,6924,Project Tycho - https://zenodo.org/records/11452259,656.8929645852724
+Arizona,1957,7786,Project Tycho - https://zenodo.org/records/11452259,691.3974913974914
+Arizona,1958,9806,Project Tycho - https://zenodo.org/records/11452259,821.1403014420616
+Arizona,1959,9067,Project Tycho - https://zenodo.org/records/11452259,718.3141996781965
+Arizona,1960,4305,Project Tycho - https://zenodo.org/records/11452259,325.5639137546783
+Arizona,1961,7952,Project Tycho - https://zenodo.org/records/11452259,564.6095198334004
+Arizona,1962,6360,Project Tycho - https://zenodo.org/records/11452259,431.92701248445644
+Arizona,1963,8829,Project Tycho - https://zenodo.org/records/11452259,579.8934793017633
+Arizona,1964,6265,Project Tycho - https://zenodo.org/records/11452259,402.2327287108778
+Arizona,1965,1593,Project Tycho - https://zenodo.org/records/11452259,100.46771410407774
+Arizona,1966,5438,Project Tycho - https://zenodo.org/records/11452259,336.5902994155782
+Arizona,1967,1023,Project Tycho - https://zenodo.org/records/11452259,62.08857970704872
+Arizona,1968,246,Project Tycho - https://zenodo.org/records/11452259,14.610835062678108
+Arizona,1969,538,Project Tycho - https://zenodo.org/records/11452259,30.941999853916954
+Arizona,1970,1006,Project Tycho - https://zenodo.org/records/11452259,56.606725058998165
+Arizona,1971,505,Project Tycho - https://zenodo.org/records/11452259,26.611034673914705
+Arizona,1972,870,Project Tycho - https://zenodo.org/records/11452259,43.27714434519442
+Arizona,1973,9,Project Tycho - https://zenodo.org/records/11452259,0.42321832140327903
+Arizona,1974,21,Project Tycho - https://zenodo.org/records/11452259,0.9436425230484687
+Arizona,1975,83,Project Tycho - https://zenodo.org/records/11452259,3.6290007000036293
+Arizona,1976,231,Project Tycho - https://zenodo.org/records/11452259,9.836053009087065
+Arizona,1977,242,Project Tycho - https://zenodo.org/records/11452259,9.968603019745249
+Arizona,1978,58,Project Tycho - https://zenodo.org/records/11452259,2.303570017209257
+Arizona,1979,84,Project Tycho - https://zenodo.org/records/11452259,3.1839818422064083
+Arizona,1980,327,Project Tycho - https://zenodo.org/records/11452259,11.932081279732138
+Arizona,1981,7,Project Tycho - https://zenodo.org/records/11452259,0.24885199243347744
+Arizona,1982,16,Project Tycho - https://zenodo.org/records/11452259,0.5531069051940195
+Arizona,1983,1,Project Tycho - https://zenodo.org/records/11452259,0.03364858694441556
+Arizona,1984,1,Project Tycho - https://zenodo.org/records/11452259,0.03257114678447868
+Arizona,1985,248,Project Tycho - https://zenodo.org/records/11452259,7.7822940885003735
+Arizona,1986,256,Project Tycho - https://zenodo.org/records/11452259,7.73047225334207
+Arizona,1987,36,Project Tycho - https://zenodo.org/records/11452259,1.0463473757026513
+Arizona,1988,3,Project Tycho - https://zenodo.org/records/11452259,0.08477646424496103
+Arizona,1989,118,Project Tycho - https://zenodo.org/records/11452259,3.2544479063557437
+Arizona,1990,281,Project Tycho - https://zenodo.org/records/11452259,7.630198751742931
+Arizona,1991,316,Project Tycho - https://zenodo.org/records/11452259,8.390518077318093
+Arizona,1992,3,https://stacks.cdc.gov/view/cdc/36063,0.07749535027898326
+Arizona,1993,3,Project Tycho - https://zenodo.org/records/11452259,0.07504910087424697
+Arizona,1994,10,Project Tycho - https://zenodo.org/records/11452259,0.24086472362699882
+Arizona,1995,12,Project Tycho - https://zenodo.org/records/11452259,0.27834387251479514
+Arizona,1996,8,Project Tycho - https://zenodo.org/records/11452259,0.18031257184329033
+Arizona,1997,5,Project Tycho - https://zenodo.org/records/11452259,0.109727110869809
+Arizona,1998,10,Project Tycho - https://zenodo.org/records/11452259,0.2140436614822438
+Arizona,1999,1,Project Tycho - https://zenodo.org/records/11452259,0.02090689948589934
+Arizona,2000,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4953a1.htm,0.0
+Arizona,2001,2,Project Tycho - https://zenodo.org/records/11452259,0.03788775751835188
+Arizona,2002,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.0
+Arizona,2003,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.018129493168263087
+Arizona,2004,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0
+Arizona,2005,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.017108885739333123
+Arizona,2006,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.0
+Arizona,2007,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.0
+Arizona,2008,14,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.2226944050575808
+Arizona,2009,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.0
+Arizona,2010,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.015591505062015992
+Arizona,2011,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.030864726232193173
+Arizona,2012,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.030474332993036615
+Arizona,2013,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.015057238586763723
+Arizona,2014,3,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.044512994455906535
+Arizona,2015,7,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.10234453791587338
+Arizona,2016,31,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.4459333824435452
+Arizona,2017,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Arizona,2018,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Arizona,2019,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.01370025540016117
+Arizona,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Arizona,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Arizona,2022,5,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.06770532961459554
+Arkansas,1904,4,Project Tycho - https://zenodo.org/records/11452259,0.2816070469347425
+Arkansas,1907,1,Project Tycho - https://zenodo.org/records/11452259,0.067318126617318
+Arkansas,1910,2,Project Tycho - https://zenodo.org/records/11452259,0.12621617169943133
+Arkansas,1912,3,Project Tycho - https://zenodo.org/records/11452259,0.18319089223734702
+Arkansas,1913,35,Project Tycho - https://zenodo.org/records/11452259,2.1012641204948896
+Arkansas,1914,915,Project Tycho - https://zenodo.org/records/11452259,54.15200912831245
+Arkansas,1915,122,Project Tycho - https://zenodo.org/records/11452259,7.160876726094118
+Arkansas,1916,26,Project Tycho - https://zenodo.org/records/11452259,1.510996275394181
+Arkansas,1917,767,Project Tycho - https://zenodo.org/records/11452259,44.11247934563997
+Arkansas,1918,327,Project Tycho - https://zenodo.org/records/11452259,18.677720221459502
+Arkansas,1919,36,Project Tycho - https://zenodo.org/records/11452259,2.064525600690928
+Arkansas,1920,432,Project Tycho - https://zenodo.org/records/11452259,24.576789952644166
+Arkansas,1921,1540,Project Tycho - https://zenodo.org/records/11452259,86.9678653737444
+Arkansas,1922,21,Project Tycho - https://zenodo.org/records/11452259,1.183917662472967
+Arkansas,1923,1476,Project Tycho - https://zenodo.org/records/11452259,82.65277323573287
+Arkansas,1924,1710,Project Tycho - https://zenodo.org/records/11452259,94.9050949050949
+Arkansas,1925,102,Project Tycho - https://zenodo.org/records/11452259,5.623515557290392
+Arkansas,1926,325,Project Tycho - https://zenodo.org/records/11452259,17.780685907739578
+Arkansas,1927,1251,Project Tycho - https://zenodo.org/records/11452259,67.92120922555705
+Arkansas,1928,10317,Project Tycho - https://zenodo.org/records/11452259,558.0234600267086
+Arkansas,1929,1486,Project Tycho - https://zenodo.org/records/11452259,80.15742356995057
+Arkansas,1930,1229,Project Tycho - https://zenodo.org/records/11452259,66.04476749716126
+Arkansas,1931,952,Project Tycho - https://zenodo.org/records/11452259,51.46368782732419
+Arkansas,1932,112,Project Tycho - https://zenodo.org/records/11452259,6.094123741182565
+Arkansas,1933,6859,Project Tycho - https://zenodo.org/records/11452259,369.5872627911463
+Arkansas,1934,8572,Project Tycho - https://zenodo.org/records/11452259,455.987037456686
+Arkansas,1935,2002,Project Tycho - https://zenodo.org/records/11452259,105.82010582010582
+Arkansas,1936,107,Project Tycho - https://zenodo.org/records/11452259,5.649741379128271
+Arkansas,1937,403,Project Tycho - https://zenodo.org/records/11452259,21.155932874272338
+Arkansas,1938,7778,Project Tycho - https://zenodo.org/records/11452259,403.02021629822457
+Arkansas,1939,1868,Project Tycho - https://zenodo.org/records/11452259,95.79742639290895
+Arkansas,1940,1125,Project Tycho - https://zenodo.org/records/11452259,57.4872697634846
+Arkansas,1941,6016,Project Tycho - https://zenodo.org/records/11452259,305.23057440274306
+Arkansas,1942,5487,Project Tycho - https://zenodo.org/records/11452259,277.2644654283501
+Arkansas,1943,2968,Project Tycho - https://zenodo.org/records/11452259,160.88089880819126
+Arkansas,1944,4272,Project Tycho - https://zenodo.org/records/11452259,241.38757170431379
+Arkansas,1945,1227,Project Tycho - https://zenodo.org/records/11452259,69.5672091812841
+Arkansas,1946,3523,Project Tycho - https://zenodo.org/records/11452259,195.85311738901052
+Arkansas,1947,2450,Project Tycho - https://zenodo.org/records/11452259,133.3089568383686
+Arkansas,1948,3928,Project Tycho - https://zenodo.org/records/11452259,215.0178588534753
+Arkansas,1949,12313,Project Tycho - https://zenodo.org/records/11452259,667.0661225975759
+Arkansas,1950,1995,Project Tycho - https://zenodo.org/records/11452259,104.45529313453841
+Arkansas,1951,7465,Project Tycho - https://zenodo.org/records/11452259,392.29576315320656
+Arkansas,1952,3307,Project Tycho - https://zenodo.org/records/11452259,179.74408616410793
+Arkansas,1953,13201,Project Tycho - https://zenodo.org/records/11452259,740.8883251579881
+Arkansas,1954,2619,Project Tycho - https://zenodo.org/records/11452259,150.8871751086284
+Arkansas,1955,2994,Project Tycho - https://zenodo.org/records/11452259,173.39182556573863
+Arkansas,1956,8676,Project Tycho - https://zenodo.org/records/11452259,508.6462832941706
+Arkansas,1957,1320,Project Tycho - https://zenodo.org/records/11452259,76.09240153960292
+Arkansas,1958,3001,Project Tycho - https://zenodo.org/records/11452259,173.6965236385862
+Arkansas,1959,816,Project Tycho - https://zenodo.org/records/11452259,46.42282546610565
+Arkansas,1960,1596,Project Tycho - https://zenodo.org/records/11452259,89.12272746817186
+Arkansas,1961,1842,Project Tycho - https://zenodo.org/records/11452259,101.89146401770988
+Arkansas,1962,1321,Project Tycho - https://zenodo.org/records/11452259,71.21858174205718
+Arkansas,1963,1437,Project Tycho - https://zenodo.org/records/11452259,76.56343656343657
+Arkansas,1964,1081,Project Tycho - https://zenodo.org/records/11452259,56.92778491935055
+Arkansas,1965,1195,Project Tycho - https://zenodo.org/records/11452259,63.030950042565664
+Arkansas,1966,1377,Project Tycho - https://zenodo.org/records/11452259,72.43940893229993
+Arkansas,1967,1269,Project Tycho - https://zenodo.org/records/11452259,66.68765216897779
+Arkansas,1968,3,Project Tycho - https://zenodo.org/records/11452259,0.15757113548911655
+Arkansas,1969,3,Project Tycho - https://zenodo.org/records/11452259,0.15666508086790365
+Arkansas,1970,33,Project Tycho - https://zenodo.org/records/11452259,1.7140675602325937
+Arkansas,1971,442,Project Tycho - https://zenodo.org/records/11452259,22.38786314430953
+Arkansas,1972,13,Project Tycho - https://zenodo.org/records/11452259,0.643355425168856
+Arkansas,1973,36,Project Tycho - https://zenodo.org/records/11452259,1.7464579649398562
+Arkansas,1974,14,Project Tycho - https://zenodo.org/records/11452259,0.6655561387095057
+Arkansas,1975,2,Project Tycho - https://zenodo.org/records/11452259,0.0925204180997694
+Arkansas,1976,20,Project Tycho - https://zenodo.org/records/11452259,0.9206700083919072
+Arkansas,1977,8,Project Tycho - https://zenodo.org/records/11452259,0.36179139198785826
+Arkansas,1978,18,Project Tycho - https://zenodo.org/records/11452259,0.8016496167669471
+Arkansas,1979,10,Project Tycho - https://zenodo.org/records/11452259,0.4398303310514936
+Arkansas,1980,9,Project Tycho - https://zenodo.org/records/11452259,0.3928370956942436
+Arkansas,1981,14,Project Tycho - https://zenodo.org/records/11452259,0.6098905072285095
+Arkansas,1982,0,https://stacks.cdc.gov/view/cdc/35066,0.0
+Arkansas,1983,3,Project Tycho - https://zenodo.org/records/11452259,0.1299789520750273
+Arkansas,1984,9,Project Tycho - https://zenodo.org/records/11452259,0.38758237740446416
+Arkansas,1985,0,https://stacks.cdc.gov/view/cdc/35429,0.0
+Arkansas,1986,286,Project Tycho - https://zenodo.org/records/11452259,12.25198827064899
+Arkansas,1987,0,https://stacks.cdc.gov/view/cdc/35629,0.0
+Arkansas,1988,1,https://stacks.cdc.gov/view/cdc/35958,0.042643959611052974
+Arkansas,1989,25,Project Tycho - https://zenodo.org/records/11452259,1.0644168017766393
+Arkansas,1990,51,Project Tycho - https://zenodo.org/records/11452259,2.164045696158649
+Arkansas,1991,5,Project Tycho - https://zenodo.org/records/11452259,0.21070055405817695
+Arkansas,1992,0,https://stacks.cdc.gov/view/cdc/36063,0.0
+Arkansas,1993,0,https://stacks.cdc.gov/view/cdc/5650,0.0
+Arkansas,1994,1,Project Tycho - https://zenodo.org/records/11452259,0.04076549445487362
+Arkansas,1995,2,Project Tycho - https://zenodo.org/records/11452259,0.08056067003920485
+Arkansas,1996,0,https://stacks.cdc.gov/view/cdc/5642,0.0
+Arkansas,1997,0,"https://www.cdc.gov/mmwr/preview/mmwrhtml/00056071.htm#:~:text=As%20of%20January%201%2C%201997,and%20control%20of%20the%20disease.",0.0
+Arkansas,1998,0,https://stacks.cdc.gov/view/cdc/5637,0.0
+Arkansas,1999,1,Project Tycho - https://zenodo.org/records/11452259,0.03915543297294673
+Arkansas,2000,1,Project Tycho - https://zenodo.org/records/11452259,0.037295814738261705
+Arkansas,2001,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5053a1.htm,0.0
+Arkansas,2002,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.0
+Arkansas,2003,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.0
+Arkansas,2004,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0
+Arkansas,2005,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.0
+Arkansas,2006,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.0
+Arkansas,2007,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.0
+Arkansas,2008,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.06950651762615781
+Arkansas,2009,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.0
+Arkansas,2010,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.0
+Arkansas,2011,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.0
+Arkansas,2012,4,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.13532587146478076
+Arkansas,2013,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.0
+Arkansas,2014,0,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.0
+Arkansas,2015,0,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.0
+Arkansas,2016,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Arkansas,2017,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Arkansas,2018,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.03316559282004714
+Arkansas,2019,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Arkansas,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Arkansas,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Arkansas,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+California,1889,3,Project Tycho - https://zenodo.org/records/11452259,
+California,1890,14,Project Tycho - https://zenodo.org/records/11452259,
+California,1891,8,Project Tycho - https://zenodo.org/records/11452259,
+California,1892,20,Project Tycho - https://zenodo.org/records/11452259,
+California,1893,1,Project Tycho - https://zenodo.org/records/11452259,
+California,1894,6,Project Tycho - https://zenodo.org/records/11452259,
+California,1895,2,Project Tycho - https://zenodo.org/records/11452259,
+California,1896,1,Project Tycho - https://zenodo.org/records/11452259,
+California,1897,8,Project Tycho - https://zenodo.org/records/11452259,
+California,1898,1,Project Tycho - https://zenodo.org/records/11452259,
+California,1899,4,Project Tycho - https://zenodo.org/records/11452259,
+California,1900,9,Project Tycho - https://zenodo.org/records/11452259,0.6034234222153685
+California,1901,44,Project Tycho - https://zenodo.org/records/11452259,2.835873803615739
+California,1902,26,Project Tycho - https://zenodo.org/records/11452259,1.600371286138384
+California,1903,35,Project Tycho - https://zenodo.org/records/11452259,2.054349880436837
+California,1904,18,Project Tycho - https://zenodo.org/records/11452259,1.0034608248893964
+California,1905,3,Project Tycho - https://zenodo.org/records/11452259,0.1583202851031694
+California,1906,256,Project Tycho - https://zenodo.org/records/11452259,12.942523063980552
+California,1907,1282,Project Tycho - https://zenodo.org/records/11452259,62.35244794154239
+California,1908,2296,Project Tycho - https://zenodo.org/records/11452259,106.14096685359988
+California,1909,2595,Project Tycho - https://zenodo.org/records/11452259,113.60243612653778
+California,1910,8812,Project Tycho - https://zenodo.org/records/11452259,365.8851539150791
+California,1911,2710,Project Tycho - https://zenodo.org/records/11452259,106.83870194525286
+California,1912,3815,Project Tycho - https://zenodo.org/records/11452259,142.84815634140972
+California,1913,6781,Project Tycho - https://zenodo.org/records/11452259,240.9898888020553
+California,1914,5739,Project Tycho - https://zenodo.org/records/11452259,195.40786411952055
+California,1915,8047,Project Tycho - https://zenodo.org/records/11452259,267.25269411439626
+California,1916,1749,Project Tycho - https://zenodo.org/records/11452259,56.89523761812918
+California,1917,12032,Project Tycho - https://zenodo.org/records/11452259,379.0596032790924
+California,1918,11542,Project Tycho - https://zenodo.org/records/11452259,353.4785263785877
+California,1919,1531,Project Tycho - https://zenodo.org/records/11452259,45.806245267161714
+California,1920,8184,Project Tycho - https://zenodo.org/records/11452259,230.04569993877814
+California,1921,6987,Project Tycho - https://zenodo.org/records/11452259,183.9267451915673
+California,1922,621,Project Tycho - https://zenodo.org/records/11452259,15.544465556993744
+California,1923,12901,Project Tycho - https://zenodo.org/records/11452259,301.82931822276083
+California,1924,6784,Project Tycho - https://zenodo.org/records/11452259,149.24516135703098
+California,1925,1104,Project Tycho - https://zenodo.org/records/11452259,23.317063486196677
+California,1926,4781,Project Tycho - https://zenodo.org/records/11452259,96.90046208609812
+California,1927,14978,Project Tycho - https://zenodo.org/records/11452259,290.7137548676309
+California,1928,5244,Project Tycho - https://zenodo.org/records/11452259,98.0307118031669
+California,1929,6262,Project Tycho - https://zenodo.org/records/11452259,113.10331324795254
+California,1930,56227,Project Tycho - https://zenodo.org/records/11452259,983.5550546459319
+California,1931,32996,Project Tycho - https://zenodo.org/records/11452259,565.9862115906072
+California,1932,18199,Project Tycho - https://zenodo.org/records/11452259,308.4631689993074
+California,1933,35840,Project Tycho - https://zenodo.org/records/11452259,600.4393057889621
+California,1934,31061,Project Tycho - https://zenodo.org/records/11452259,512.045710065512
+California,1935,35350,Project Tycho - https://zenodo.org/records/11452259,571.8977378896408
+California,1936,64931,Project Tycho - https://zenodo.org/records/11452259,1022.9637890890059
+California,1937,6380,Project Tycho - https://zenodo.org/records/11452259,97.63520792932557
+California,1938,24751,Project Tycho - https://zenodo.org/records/11452259,371.4884874740644
+California,1939,85576,Project Tycho - https://zenodo.org/records/11452259,1259.992770678106
+California,1940,11155,Project Tycho - https://zenodo.org/records/11452259,160.34325386843372
+California,1941,14564,Project Tycho - https://zenodo.org/records/11452259,201.04256666368042
+California,1942,116180,Project Tycho - https://zenodo.org/records/11452259,1500.5033750993673
+California,1943,24908,Project Tycho - https://zenodo.org/records/11452259,292.53605552688555
+California,1944,70521,Project Tycho - https://zenodo.org/records/11452259,787.5969754113969
+California,1945,36100,Project Tycho - https://zenodo.org/records/11452259,385.95821986232943
+California,1946,70167,Project Tycho - https://zenodo.org/records/11452259,733.3079097908055
+California,1947,8429,Project Tycho - https://zenodo.org/records/11452259,85.64462388709744
+California,1948,59944,Project Tycho - https://zenodo.org/records/11452259,595.0329479741245
+California,1949,33161,Project Tycho - https://zenodo.org/records/11452259,320.478592704577
+California,1950,15729,Project Tycho - https://zenodo.org/records/11452259,147.16949249121208
+California,1951,60807,Project Tycho - https://zenodo.org/records/11452259,545.5923634475818
+California,1952,47228,Project Tycho - https://zenodo.org/records/11452259,405.5076852670321
+California,1953,70179,Project Tycho - https://zenodo.org/records/11452259,572.2707624593185
+California,1954,60293,Project Tycho - https://zenodo.org/records/11452259,472.5621154304663
+California,1955,67434,Project Tycho - https://zenodo.org/records/11452259,512.9569280943681
+California,1956,32954,Project Tycho - https://zenodo.org/records/11452259,240.07204055333568
+California,1957,49864,Project Tycho - https://zenodo.org/records/11452259,349.23013049765717
+California,1958,34913,Project Tycho - https://zenodo.org/records/11452259,234.3959803637223
+California,1959,38951,Project Tycho - https://zenodo.org/records/11452259,251.58135328174768
+California,1960,22222,Project Tycho - https://zenodo.org/records/11452259,139.88531946944045
+California,1961,37112,Project Tycho - https://zenodo.org/records/11452259,224.73737694686957
+California,1962,27974,Project Tycho - https://zenodo.org/records/11452259,163.69525507294955
+California,1963,20102,Project Tycho - https://zenodo.org/records/11452259,113.66265611228255
+California,1964,32483,Project Tycho - https://zenodo.org/records/11452259,178.78105586771775
+California,1965,13864,Project Tycho - https://zenodo.org/records/11452259,74.52327064917864
+California,1966,15197,Project Tycho - https://zenodo.org/records/11452259,80.50598251043685
+California,1967,5276,Project Tycho - https://zenodo.org/records/11452259,27.48607254239294
+California,1968,1636,Project Tycho - https://zenodo.org/records/11452259,8.427171467286966
+California,1969,894,Project Tycho - https://zenodo.org/records/11452259,4.531007524260023
+California,1970,1949,Project Tycho - https://zenodo.org/records/11452259,9.7493677167371
+California,1971,2838,Project Tycho - https://zenodo.org/records/11452259,13.934795370623329
+California,1972,3219,Project Tycho - https://zenodo.org/records/11452259,15.621622655167265
+California,1973,839,Project Tycho - https://zenodo.org/records/11452259,4.01635340386669
+California,1974,1086,Project Tycho - https://zenodo.org/records/11452259,5.1238407782047855
+California,1975,5189,Project Tycho - https://zenodo.org/records/11452259,24.068403432268433
+California,1976,2324,Project Tycho - https://zenodo.org/records/11452259,10.583917073096977
+California,1977,8664,Project Tycho - https://zenodo.org/records/11452259,38.722223821247056
+California,1978,646,Project Tycho - https://zenodo.org/records/11452259,2.8260459771432376
+California,1979,976,Project Tycho - https://zenodo.org/records/11452259,4.192415370769312
+California,1980,898,Project Tycho - https://zenodo.org/records/11452259,3.7692133341168375
+California,1981,345,Project Tycho - https://zenodo.org/records/11452259,1.419156339939033
+California,1982,750,Project Tycho - https://zenodo.org/records/11452259,3.0187368164216384
+California,1983,156,Project Tycho - https://zenodo.org/records/11452259,0.6145267990015988
+California,1984,308,Project Tycho - https://zenodo.org/records/11452259,1.190557318821625
+California,1985,255,Project Tycho - https://zenodo.org/records/11452259,0.9634439152849432
+California,1986,429,Project Tycho - https://zenodo.org/records/11452259,1.5813138683548462
+California,1987,731,Project Tycho - https://zenodo.org/records/11452259,2.6290297028207403
+California,1988,723,Project Tycho - https://zenodo.org/records/11452259,2.5374909016210565
+California,1989,797,Project Tycho - https://zenodo.org/records/11452259,2.7250302266370374
+California,1990,6664,Project Tycho - https://zenodo.org/records/11452259,22.228106874098756
+California,1991,1939,Project Tycho - https://zenodo.org/records/11452259,6.368960622414642
+California,1992,48,Project Tycho - https://zenodo.org/records/11452259,0.1553056536596564
+California,1993,45,Project Tycho - https://zenodo.org/records/11452259,0.14433089879180605
+California,1994,45,Project Tycho - https://zenodo.org/records/11452259,0.14354755647607464
+California,1995,7,Project Tycho - https://zenodo.org/records/11452259,0.022204586845913935
+California,1996,36,Project Tycho - https://zenodo.org/records/11452259,0.11316267710076844
+California,1997,7,Project Tycho - https://zenodo.org/records/11452259,0.02170547683444225
+California,1998,2,Project Tycho - https://zenodo.org/records/11452259,0.0061133146893537485
+California,1999,2,Project Tycho - https://zenodo.org/records/11452259,0.006028042574617974
+California,2000,1,Project Tycho - https://zenodo.org/records/11452259,0.0029392776971958468
+California,2001,10,Project Tycho - https://zenodo.org/records/11452259,0.028973802669918534
+California,2002,5,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.014323891959581184
+California,2003,5,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.0141689572202909
+California,2004,6,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.016849128689432648
+California,2005,4,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.011153317121986897
+California,2006,6,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.016640216580184226
+California,2007,4,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.011023364820931915
+California,2008,17,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.04639618835116707
+California,2009,9,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.024325514302186133
+California,2010,27,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.07227586444677685
+California,2011,31,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.08228498065254485
+California,2012,8,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.021062334109436465
+California,2013,17,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.044395671881617325
+California,2014,92,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.23818590161078912
+California,2015,109,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.2798948211754555
+California,2016,24,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.061242714190332406
+California,2017,15,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.03809318517488403
+California,2018,22,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.055728793294306286
+California,2019,73,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.18491758008140782
+California,2020,5,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.012638556814319303
+California,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+California,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Colorado,1888,2,Project Tycho - https://zenodo.org/records/11452259,
+Colorado,1889,7,Project Tycho - https://zenodo.org/records/11452259,
+Colorado,1890,13,Project Tycho - https://zenodo.org/records/11452259,
+Colorado,1895,1,Project Tycho - https://zenodo.org/records/11452259,
+Colorado,1896,8,Project Tycho - https://zenodo.org/records/11452259,
+Colorado,1897,19,Project Tycho - https://zenodo.org/records/11452259,
+Colorado,1898,1,Project Tycho - https://zenodo.org/records/11452259,
+Colorado,1899,2,Project Tycho - https://zenodo.org/records/11452259,
+Colorado,1902,13,Project Tycho - https://zenodo.org/records/11452259,2.0913064391325262
+Colorado,1903,2,Project Tycho - https://zenodo.org/records/11452259,0.3064420242334353
+Colorado,1910,13,Project Tycho - https://zenodo.org/records/11452259,1.6153001227628092
+Colorado,1911,1377,Project Tycho - https://zenodo.org/records/11452259,167.55473515522237
+Colorado,1912,47,Project Tycho - https://zenodo.org/records/11452259,5.64339506647199
+Colorado,1913,15,Project Tycho - https://zenodo.org/records/11452259,1.794612573055687
+Colorado,1915,46,Project Tycho - https://zenodo.org/records/11452259,5.2942449255813315
+Colorado,1916,336,Project Tycho - https://zenodo.org/records/11452259,37.63053090407351
+Colorado,1917,4961,Project Tycho - https://zenodo.org/records/11452259,544.6202149498853
+Colorado,1918,2488,Project Tycho - https://zenodo.org/records/11452259,274.3393471870293
+Colorado,1919,333,Project Tycho - https://zenodo.org/records/11452259,35.46560049758344
+Colorado,1920,4097,Project Tycho - https://zenodo.org/records/11452259,436.80972176169615
+Colorado,1921,3104,Project Tycho - https://zenodo.org/records/11452259,322.6742040477733
+Colorado,1922,119,Project Tycho - https://zenodo.org/records/11452259,12.319286930685895
+Colorado,1923,4538,Project Tycho - https://zenodo.org/records/11452259,460.7181436449729
+Colorado,1924,3373,Project Tycho - https://zenodo.org/records/11452259,332.31068734027315
+Colorado,1925,157,Project Tycho - https://zenodo.org/records/11452259,15.391870151438354
+Colorado,1926,1151,Project Tycho - https://zenodo.org/records/11452259,113.17422734745568
+Colorado,1927,7720,Project Tycho - https://zenodo.org/records/11452259,750.2225401058085
+Colorado,1928,3562,Project Tycho - https://zenodo.org/records/11452259,350.9311201618894
+Colorado,1929,990,Project Tycho - https://zenodo.org/records/11452259,98.11616954474097
+Colorado,1930,18037,Project Tycho - https://zenodo.org/records/11452259,1732.594328748175
+Colorado,1931,6656,Project Tycho - https://zenodo.org/records/11452259,629.6733569460841
+Colorado,1932,3837,Project Tycho - https://zenodo.org/records/11452259,359.5841306910725
+Colorado,1933,447,Project Tycho - https://zenodo.org/records/11452259,41.69499967819296
+Colorado,1934,21147,Project Tycho - https://zenodo.org/records/11452259,1965.1975931045697
+Colorado,1935,19996,Project Tycho - https://zenodo.org/records/11452259,1853.0634486107585
+Colorado,1936,1046,Project Tycho - https://zenodo.org/records/11452259,95.8674353169766
+Colorado,1937,1917,Project Tycho - https://zenodo.org/records/11452259,173.46783651131477
+Colorado,1938,13756,Project Tycho - https://zenodo.org/records/11452259,1235.8145451670632
+Colorado,1939,8327,Project Tycho - https://zenodo.org/records/11452259,742.7394034536892
+Colorado,1940,2244,Project Tycho - https://zenodo.org/records/11452259,198.38568511134883
+Colorado,1941,13238,Project Tycho - https://zenodo.org/records/11452259,1176.5814256917458
+Colorado,1942,8829,Project Tycho - https://zenodo.org/records/11452259,792.4689865390675
+Colorado,1943,19562,Project Tycho - https://zenodo.org/records/11452259,1694.922596917393
+Colorado,1944,8543,Project Tycho - https://zenodo.org/records/11452259,750.6126239635474
+Colorado,1945,1034,Project Tycho - https://zenodo.org/records/11452259,92.55976997912482
+Colorado,1946,20665,Project Tycho - https://zenodo.org/records/11452259,1716.0727883919903
+Colorado,1947,2354,Project Tycho - https://zenodo.org/records/11452259,190.10900175006884
+Colorado,1948,14738,Project Tycho - https://zenodo.org/records/11452259,1165.7384578999781
+Colorado,1949,7221,Project Tycho - https://zenodo.org/records/11452259,557.0491284776999
+Colorado,1950,5561,Project Tycho - https://zenodo.org/records/11452259,419.27883437317405
+Colorado,1951,12315,Project Tycho - https://zenodo.org/records/11452259,927.8052264477603
+Colorado,1952,4922,Project Tycho - https://zenodo.org/records/11452259,360.2258547313492
+Colorado,1953,12274,Project Tycho - https://zenodo.org/records/11452259,856.865007808404
+Colorado,1954,1906,Project Tycho - https://zenodo.org/records/11452259,127.53488975860041
+Colorado,1955,4902,Project Tycho - https://zenodo.org/records/11452259,316.75956643615115
+Colorado,1956,14242,Project Tycho - https://zenodo.org/records/11452259,875.5552140167525
+Colorado,1957,2877,Project Tycho - https://zenodo.org/records/11452259,172.72391070467992
+Colorado,1958,9394,Project Tycho - https://zenodo.org/records/11452259,562.9643302108809
+Colorado,1959,7037,Project Tycho - https://zenodo.org/records/11452259,411.10935847777955
+Colorado,1960,6806,Project Tycho - https://zenodo.org/records/11452259,384.3527868400678
+Colorado,1961,3926,Project Tycho - https://zenodo.org/records/11452259,212.69403048144912
+Colorado,1962,9216,Project Tycho - https://zenodo.org/records/11452259,484.82323363839953
+Colorado,1963,6052,Project Tycho - https://zenodo.org/records/11452259,312.2910147703536
+Colorado,1964,3224,Project Tycho - https://zenodo.org/records/11452259,163.49133100402136
+Colorado,1965,6009,Project Tycho - https://zenodo.org/records/11452259,302.4179850376324
+Colorado,1966,1445,Project Tycho - https://zenodo.org/records/11452259,71.92608089469076
+Colorado,1967,1637,Project Tycho - https://zenodo.org/records/11452259,79.6573129744099
+Colorado,1968,496,Project Tycho - https://zenodo.org/records/11452259,23.372853561532807
+Colorado,1969,139,Project Tycho - https://zenodo.org/records/11452259,6.410948239203087
+Colorado,1970,132,Project Tycho - https://zenodo.org/records/11452259,5.9679763812813516
+Colorado,1971,833,Project Tycho - https://zenodo.org/records/11452259,36.12586720512857
+Colorado,1972,527,Project Tycho - https://zenodo.org/records/11452259,21.894265239675732
+Colorado,1973,159,Project Tycho - https://zenodo.org/records/11452259,6.3641672567197
+Colorado,1974,157,Project Tycho - https://zenodo.org/records/11452259,6.171512220970013
+Colorado,1975,1170,Project Tycho - https://zenodo.org/records/11452259,45.19506887033187
+Colorado,1976,347,Project Tycho - https://zenodo.org/records/11452259,13.169190318709585
+Colorado,1977,514,Project Tycho - https://zenodo.org/records/11452259,19.045247654914935
+Colorado,1978,24,Project Tycho - https://zenodo.org/records/11452259,0.8665780349909767
+Colorado,1979,72,Project Tycho - https://zenodo.org/records/11452259,2.524470711406365
+Colorado,1980,22,Project Tycho - https://zenodo.org/records/11452259,0.7555694916150676
+Colorado,1981,8,Project Tycho - https://zenodo.org/records/11452259,0.2683775736989978
+Colorado,1982,6,Project Tycho - https://zenodo.org/records/11452259,0.19578251825264104
+Colorado,1983,3,Project Tycho - https://zenodo.org/records/11452259,0.0956399957535842
+Colorado,1984,5,Project Tycho - https://zenodo.org/records/11452259,0.15757158240631344
+Colorado,1985,15,Project Tycho - https://zenodo.org/records/11452259,0.4670087869259956
+Colorado,1986,10,Project Tycho - https://zenodo.org/records/11452259,0.30857654565220277
+Colorado,1987,9,Project Tycho - https://zenodo.org/records/11452259,0.2757572600758639
+Colorado,1988,116,Project Tycho - https://zenodo.org/records/11452259,3.55224230702214
+Colorado,1989,101,Project Tycho - https://zenodo.org/records/11452259,3.08012002099361
+Colorado,1990,137,Project Tycho - https://zenodo.org/records/11452259,4.142520860011521
+Colorado,1991,13,Project Tycho - https://zenodo.org/records/11452259,0.38564979320271475
+Colorado,1992,23,Project Tycho - https://zenodo.org/records/11452259,0.6640769590125927
+Colorado,1993,3,https://stacks.cdc.gov/view/cdc/5650,0.08416459902301733
+Colorado,1994,15,Project Tycho - https://zenodo.org/records/11452259,0.41010913550908074
+Colorado,1995,8,Project Tycho - https://zenodo.org/records/11452259,0.2138009016518525
+Colorado,1996,6,Project Tycho - https://zenodo.org/records/11452259,0.1572109519437562
+Colorado,1997,0,"https://www.cdc.gov/mmwr/preview/mmwrhtml/00056071.htm#:~:text=As%20of%20January%201%2C%201997,and%20control%20of%20the%20disease.",0.0
+Colorado,1998,0,https://stacks.cdc.gov/view/cdc/5637,0.0
+Colorado,1999,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.0
+Colorado,2000,2,Project Tycho - https://zenodo.org/records/11452259,0.04617607815947694
+Colorado,2001,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5053a1.htm,0.0
+Colorado,2002,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.0
+Colorado,2003,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.0
+Colorado,2004,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.021836025424121122
+Colorado,2005,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.0
+Colorado,2006,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.021163380663823297
+Colorado,2007,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.0
+Colorado,2008,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.0
+Colorado,2009,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.0
+Colorado,2010,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.0
+Colorado,2011,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.0
+Colorado,2012,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.0
+Colorado,2013,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.037907189553385075
+Colorado,2014,1,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.018663718794495472
+Colorado,2015,1,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.018315749603189286
+Colorado,2016,2,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.036040016672111715
+Colorado,2017,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Colorado,2018,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Colorado,2019,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.017348328766096648
+Colorado,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Colorado,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Colorado,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Connecticut,1894,2,Project Tycho - https://zenodo.org/records/11452259,
+Connecticut,1895,2,Project Tycho - https://zenodo.org/records/11452259,
+Connecticut,1896,23,Project Tycho - https://zenodo.org/records/11452259,
+Connecticut,1906,26,Project Tycho - https://zenodo.org/records/11452259,2.514426522170956
+Connecticut,1907,108,Project Tycho - https://zenodo.org/records/11452259,10.207389582980879
+Connecticut,1908,372,Project Tycho - https://zenodo.org/records/11452259,34.50588408805679
+Connecticut,1909,128,Project Tycho - https://zenodo.org/records/11452259,11.656529432281484
+Connecticut,1910,316,Project Tycho - https://zenodo.org/records/11452259,28.135857012862363
+Connecticut,1911,519,Project Tycho - https://zenodo.org/records/11452259,45.124588205528156
+Connecticut,1912,648,Project Tycho - https://zenodo.org/records/11452259,55.04699382250402
+Connecticut,1913,814,Project Tycho - https://zenodo.org/records/11452259,67.3167891710938
+Connecticut,1914,563,Project Tycho - https://zenodo.org/records/11452259,45.61537408252737
+Connecticut,1915,513,Project Tycho - https://zenodo.org/records/11452259,40.73827603239368
+Connecticut,1916,4025,Project Tycho - https://zenodo.org/records/11452259,310.74026437241275
+Connecticut,1917,2808,Project Tycho - https://zenodo.org/records/11452259,211.3937306100079
+Connecticut,1918,1307,Project Tycho - https://zenodo.org/records/11452259,98.2463736414075
+Connecticut,1919,3072,Project Tycho - https://zenodo.org/records/11452259,225.82274237903377
+Connecticut,1920,3512,Project Tycho - https://zenodo.org/records/11452259,252.22800204827521
+Connecticut,1921,1709,Project Tycho - https://zenodo.org/records/11452259,120.65672843058002
+Connecticut,1922,4302,Project Tycho - https://zenodo.org/records/11452259,300.32860221539465
+Connecticut,1923,3556,Project Tycho - https://zenodo.org/records/11452259,244.1544709585947
+Connecticut,1924,1189,Project Tycho - https://zenodo.org/records/11452259,80.20338877867574
+Connecticut,1925,2031,Project Tycho - https://zenodo.org/records/11452259,134.72583193698733
+Connecticut,1926,3111,Project Tycho - https://zenodo.org/records/11452259,202.99752500928204
+Connecticut,1927,779,Project Tycho - https://zenodo.org/records/11452259,49.9821309069864
+Connecticut,1928,14140,Project Tycho - https://zenodo.org/records/11452259,895.7434448873892
+Connecticut,1929,10419,Project Tycho - https://zenodo.org/records/11452259,652.9856592591849
+Connecticut,1930,2378,Project Tycho - https://zenodo.org/records/11452259,147.27987449624152
+Connecticut,1931,18371,Project Tycho - https://zenodo.org/records/11452259,1127.3124909488547
+Connecticut,1932,6343,Project Tycho - https://zenodo.org/records/11452259,387.09000223966626
+Connecticut,1933,6300,Project Tycho - https://zenodo.org/records/11452259,383.29514577992046
+Connecticut,1934,6511,Project Tycho - https://zenodo.org/records/11452259,394.2118487573033
+Connecticut,1935,31358,Project Tycho - https://zenodo.org/records/11452259,1880.3525406166464
+Connecticut,1936,4269,Project Tycho - https://zenodo.org/records/11452259,255.06789860856847
+Connecticut,1937,11201,Project Tycho - https://zenodo.org/records/11452259,666.8540041603212
+Connecticut,1938,1586,Project Tycho - https://zenodo.org/records/11452259,94.08643612919147
+Connecticut,1939,23069,Project Tycho - https://zenodo.org/records/11452259,1358.841630068045
+Connecticut,1940,2564,Project Tycho - https://zenodo.org/records/11452259,149.96712888984553
+Connecticut,1941,7046,Project Tycho - https://zenodo.org/records/11452259,403.14782582823824
+Connecticut,1942,14882,Project Tycho - https://zenodo.org/records/11452259,829.6391108891108
+Connecticut,1943,11061,Project Tycho - https://zenodo.org/records/11452259,616.6266768945341
+Connecticut,1944,11316,Project Tycho - https://zenodo.org/records/11452259,635.8096346847752
+Connecticut,1945,3696,Project Tycho - https://zenodo.org/records/11452259,208.72287689698658
+Connecticut,1946,9360,Project Tycho - https://zenodo.org/records/11452259,490.59020727436257
+Connecticut,1947,19366,Project Tycho - https://zenodo.org/records/11452259,983.5614309432306
+Connecticut,1948,3054,Project Tycho - https://zenodo.org/records/11452259,151.48704324473937
+Connecticut,1949,19012,Project Tycho - https://zenodo.org/records/11452259,934.6952260338087
+Connecticut,1950,4103,Project Tycho - https://zenodo.org/records/11452259,203.3185068899355
+Connecticut,1951,5037,Project Tycho - https://zenodo.org/records/11452259,248.12465640868007
+Connecticut,1952,29468,Project Tycho - https://zenodo.org/records/11452259,1414.6353406324574
+Connecticut,1953,2254,Project Tycho - https://zenodo.org/records/11452259,103.86292674115552
+Connecticut,1954,5026,Project Tycho - https://zenodo.org/records/11452259,223.25384708666166
+Connecticut,1955,28902,Project Tycho - https://zenodo.org/records/11452259,1255.353342309864
+Connecticut,1956,2764,Project Tycho - https://zenodo.org/records/11452259,119.22447155607777
+Connecticut,1957,9647,Project Tycho - https://zenodo.org/records/11452259,408.53593206285024
+Connecticut,1958,15750,Project Tycho - https://zenodo.org/records/11452259,643.2651567565713
+Connecticut,1959,13030,Project Tycho - https://zenodo.org/records/11452259,515.9327394761401
+Connecticut,1960,11057,Project Tycho - https://zenodo.org/records/11452259,434.1963068378162
+Connecticut,1961,6906,Project Tycho - https://zenodo.org/records/11452259,266.7865776914501
+Connecticut,1962,17729,Project Tycho - https://zenodo.org/records/11452259,669.1079981597549
+Connecticut,1963,5837,Project Tycho - https://zenodo.org/records/11452259,213.83090690021385
+Connecticut,1964,5234,Project Tycho - https://zenodo.org/records/11452259,186.8753119646615
+Connecticut,1965,9222,Project Tycho - https://zenodo.org/records/11452259,322.463675631334
+Connecticut,1966,944,Project Tycho - https://zenodo.org/records/11452259,32.485599140783435
+Connecticut,1967,106,Project Tycho - https://zenodo.org/records/11452259,3.6079763507361466
+Connecticut,1968,715,Project Tycho - https://zenodo.org/records/11452259,24.098708309234624
+Connecticut,1969,634,Project Tycho - https://zenodo.org/records/11452259,21.112221112221114
+Connecticut,1970,116,Project Tycho - https://zenodo.org/records/11452259,3.821762234333987
+Connecticut,1971,1191,Project Tycho - https://zenodo.org/records/11452259,38.87078255273013
+Connecticut,1972,1541,Project Tycho - https://zenodo.org/records/11452259,50.16656536775087
+Connecticut,1973,1782,Project Tycho - https://zenodo.org/records/11452259,58.02894999838808
+Connecticut,1974,174,Project Tycho - https://zenodo.org/records/11452259,5.65463626552222
+Connecticut,1975,129,Project Tycho - https://zenodo.org/records/11452259,4.180734785204217
+Connecticut,1976,237,Project Tycho - https://zenodo.org/records/11452259,7.678804361560878
+Connecticut,1977,812,Project Tycho - https://zenodo.org/records/11452259,26.288466712229027
+Connecticut,1978,329,Project Tycho - https://zenodo.org/records/11452259,10.631017107213001
+Connecticut,1979,4,Project Tycho - https://zenodo.org/records/11452259,0.12907339500460147
+Connecticut,1980,9,Project Tycho - https://zenodo.org/records/11452259,0.288805235204588
+Connecticut,1981,6,Project Tycho - https://zenodo.org/records/11452259,0.1915730832155159
+Connecticut,1982,2,Project Tycho - https://zenodo.org/records/11452259,0.06365064452642648
+Connecticut,1983,7,Project Tycho - https://zenodo.org/records/11452259,0.22113298432230322
+Connecticut,1984,3,Project Tycho - https://zenodo.org/records/11452259,0.09424496276381521
+Connecticut,1985,7,Project Tycho - https://zenodo.org/records/11452259,0.21845426753532407
+Connecticut,1986,9,Project Tycho - https://zenodo.org/records/11452259,0.2789000059808557
+Connecticut,1987,22,Project Tycho - https://zenodo.org/records/11452259,0.676811038664984
+Connecticut,1988,11,Project Tycho - https://zenodo.org/records/11452259,0.33585489114637657
+Connecticut,1989,78,Project Tycho - https://zenodo.org/records/11452259,2.373211192063982
+Connecticut,1990,196,https://stacks.cdc.gov/view/cdc/35905,5.953203567669853
+Connecticut,1991,20,Project Tycho - https://zenodo.org/records/11452259,0.6075467021149916
+Connecticut,1992,6,Project Tycho - https://zenodo.org/records/11452259,0.18302330710304304
+Connecticut,1993,1,Project Tycho - https://zenodo.org/records/11452259,0.030528786050298618
+Connecticut,1994,4,Project Tycho - https://zenodo.org/records/11452259,0.12226381229570481
+Connecticut,1995,1,Project Tycho - https://zenodo.org/records/11452259,0.030594531288721204
+Connecticut,1996,1,Project Tycho - https://zenodo.org/records/11452259,0.030578262463623336
+Connecticut,1997,1,"https://www.cdc.gov/mmwr/preview/mmwrhtml/00056071.htm#:~:text=As%20of%20January%201%2C%201997,and%20control%20of%20the%20disease.",0.030564383568342877
+Connecticut,1998,0,https://stacks.cdc.gov/view/cdc/5637,0.0
+Connecticut,1999,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.06087700015188812
+Connecticut,2000,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4953a1.htm,0.0
+Connecticut,2001,1,Project Tycho - https://zenodo.org/records/11452259,0.029101347479692348
+Connecticut,2002,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.0
+Connecticut,2003,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.0
+Connecticut,2004,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0
+Connecticut,2005,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.0
+Connecticut,2006,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.0
+Connecticut,2007,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.0
+Connecticut,2008,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.0
+Connecticut,2009,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.0
+Connecticut,2010,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.02791150489902734
+Connecticut,2011,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.027837938656318378
+Connecticut,2012,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.027786993797387246
+Connecticut,2013,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.0
+Connecticut,2014,5,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.13891620907667396
+Connecticut,2015,0,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.0
+Connecticut,2016,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.027906387465120506
+Connecticut,2017,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Connecticut,2018,3,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.08384256044000576
+Connecticut,2019,4,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.1120577500820823
+Connecticut,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Connecticut,2021,2,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.055398393391193256
+Connecticut,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Delaware,1890,2,Project Tycho - https://zenodo.org/records/11452259,
+Delaware,1893,1,Project Tycho - https://zenodo.org/records/11452259,
+Delaware,1895,6,Project Tycho - https://zenodo.org/records/11452259,
+Delaware,1898,5,Project Tycho - https://zenodo.org/records/11452259,
+Delaware,1899,1,Project Tycho - https://zenodo.org/records/11452259,
+Delaware,1900,1,Project Tycho - https://zenodo.org/records/11452259,0.54000054000054
+Delaware,1903,5,Project Tycho - https://zenodo.org/records/11452259,2.6289499973710497
+Delaware,1904,1,Project Tycho - https://zenodo.org/records/11452259,0.5203130203130203
+Delaware,1906,1,Project Tycho - https://zenodo.org/records/11452259,0.5096943872454077
+Delaware,1908,4,Project Tycho - https://zenodo.org/records/11452259,2.0080422090472343
+Delaware,1909,1,Project Tycho - https://zenodo.org/records/11452259,0.49701542238855667
+Delaware,1910,1,Project Tycho - https://zenodo.org/records/11452259,0.4921187187197039
+Delaware,1911,10,Project Tycho - https://zenodo.org/records/11452259,4.8260917826135215
+Delaware,1915,4,Project Tycho - https://zenodo.org/records/11452259,1.8414764958543761
+Delaware,1916,1099,Project Tycho - https://zenodo.org/records/11452259,501.32515885940546
+Delaware,1917,79,Project Tycho - https://zenodo.org/records/11452259,35.55003555003555
+Delaware,1918,460,Project Tycho - https://zenodo.org/records/11452259,208.88202706384524
+Delaware,1919,42,Project Tycho - https://zenodo.org/records/11452259,18.9855393475303
+Delaware,1920,504,Project Tycho - https://zenodo.org/records/11452259,229.9070792221477
+Delaware,1921,9,Project Tycho - https://zenodo.org/records/11452259,4.162504162504162
+Delaware,1922,41,Project Tycho - https://zenodo.org/records/11452259,19.13973876590699
+Delaware,1923,2,Project Tycho - https://zenodo.org/records/11452259,0.9293032548846503
+Delaware,1924,52,Project Tycho - https://zenodo.org/records/11452259,23.720571665777143
+Delaware,1925,287,Project Tycho - https://zenodo.org/records/11452259,129.15012915012915
+Delaware,1926,1283,Project Tycho - https://zenodo.org/records/11452259,569.6525696525697
+Delaware,1927,30,Project Tycho - https://zenodo.org/records/11452259,13.087349331890819
+Delaware,1928,1024,Project Tycho - https://zenodo.org/records/11452259,439.0459326081644
+Delaware,1929,907,Project Tycho - https://zenodo.org/records/11452259,383.9380958025026
+Delaware,1930,312,Project Tycho - https://zenodo.org/records/11452259,130.41351953485844
+Delaware,1931,3197,Project Tycho - https://zenodo.org/records/11452259,1319.7546255397497
+Delaware,1932,62,Project Tycho - https://zenodo.org/records/11452259,25.280841607372217
+Delaware,1933,352,Project Tycho - https://zenodo.org/records/11452259,141.79369018078697
+Delaware,1934,4109,Project Tycho - https://zenodo.org/records/11452259,1641.9580419580418
+Delaware,1935,1252,Project Tycho - https://zenodo.org/records/11452259,496.3290677576392
+Delaware,1936,1655,Project Tycho - https://zenodo.org/records/11452259,653.4967009275309
+Delaware,1937,2494,Project Tycho - https://zenodo.org/records/11452259,980.9088549246029
+Delaware,1938,688,Project Tycho - https://zenodo.org/records/11452259,267.4368433123297
+Delaware,1939,234,Project Tycho - https://zenodo.org/records/11452259,88.88449953088735
+Delaware,1940,147,Project Tycho - https://zenodo.org/records/11452259,54.592247900798085
+Delaware,1941,4959,Project Tycho - https://zenodo.org/records/11452259,1801.4712560167106
+Delaware,1942,282,Project Tycho - https://zenodo.org/records/11452259,100.97429452268162
+Delaware,1943,2151,Project Tycho - https://zenodo.org/records/11452259,762.0039534933152
+Delaware,1944,421,Project Tycho - https://zenodo.org/records/11452259,147.57172651909494
+Delaware,1945,287,Project Tycho - https://zenodo.org/records/11452259,100.24940094870165
+Delaware,1946,959,Project Tycho - https://zenodo.org/records/11452259,320.4153705825947
+Delaware,1947,83,Project Tycho - https://zenodo.org/records/11452259,27.185928825273088
+Delaware,1948,1483,Project Tycho - https://zenodo.org/records/11452259,474.84566715335944
+Delaware,1949,741,Project Tycho - https://zenodo.org/records/11452259,234.25941147460134
+Delaware,1950,633,Project Tycho - https://zenodo.org/records/11452259,196.99926241982317
+Delaware,1951,688,Project Tycho - https://zenodo.org/records/11452259,207.64733755670312
+Delaware,1952,544,Project Tycho - https://zenodo.org/records/11452259,159.37142036848783
+Delaware,1953,449,Project Tycho - https://zenodo.org/records/11452259,127.79243548474318
+Delaware,1954,1942,Project Tycho - https://zenodo.org/records/11452259,527.1902011032446
+Delaware,1955,105,Project Tycho - https://zenodo.org/records/11452259,26.96532259514265
+Delaware,1956,883,Project Tycho - https://zenodo.org/records/11452259,216.2053632641868
+Delaware,1957,323,Project Tycho - https://zenodo.org/records/11452259,75.74585039373773
+Delaware,1958,508,Project Tycho - https://zenodo.org/records/11452259,117.20381235392782
+Delaware,1959,616,Project Tycho - https://zenodo.org/records/11452259,139.54299668585384
+Delaware,1960,956,Project Tycho - https://zenodo.org/records/11452259,212.7048897650234
+Delaware,1961,1701,Project Tycho - https://zenodo.org/records/11452259,368.6118653580693
+Delaware,1962,616,Project Tycho - https://zenodo.org/records/11452259,131.21207151057897
+Delaware,1963,1189,Project Tycho - https://zenodo.org/records/11452259,245.92384840832045
+Delaware,1964,394,Project Tycho - https://zenodo.org/records/11452259,79.19645746607517
+Delaware,1965,519,Project Tycho - https://zenodo.org/records/11452259,102.26459930601942
+Delaware,1966,264,Project Tycho - https://zenodo.org/records/11452259,51.111679018655764
+Delaware,1967,56,Project Tycho - https://zenodo.org/records/11452259,10.656010656010656
+Delaware,1968,24,Project Tycho - https://zenodo.org/records/11452259,4.489892130341569
+Delaware,1969,506,Project Tycho - https://zenodo.org/records/11452259,93.6100936100936
+Delaware,1970,268,Project Tycho - https://zenodo.org/records/11452259,48.846992264677795
+Delaware,1971,42,Project Tycho - https://zenodo.org/records/11452259,7.430051373498068
+Delaware,1972,55,Project Tycho - https://zenodo.org/records/11452259,9.59048623765225
+Delaware,1973,10,Project Tycho - https://zenodo.org/records/11452259,1.7290986554528855
+Delaware,1974,16,Project Tycho - https://zenodo.org/records/11452259,2.749145617088689
+Delaware,1975,35,Project Tycho - https://zenodo.org/records/11452259,5.960744241495295
+Delaware,1976,111,Project Tycho - https://zenodo.org/records/11452259,18.789483306136542
+Delaware,1977,24,Project Tycho - https://zenodo.org/records/11452259,4.051179906147666
+Delaware,1978,9,Project Tycho - https://zenodo.org/records/11452259,1.511665015032669
+Delaware,1979,1,Project Tycho - https://zenodo.org/records/11452259,0.16790412003129732
+Delaware,1980,4,Project Tycho - https://zenodo.org/records/11452259,0.6716897867888695
+Delaware,1981,0,https://stacks.cdc.gov/view/cdc/1307,0.0
+Delaware,1982,0,https://stacks.cdc.gov/view/cdc/35066,0.0
+Delaware,1983,0,https://stacks.cdc.gov/view/cdc/35188,0.0
+Delaware,1984,0,https://stacks.cdc.gov/view/cdc/35267,0.0
+Delaware,1985,0,https://stacks.cdc.gov/view/cdc/35429,0.0
+Delaware,1986,1,Project Tycho - https://zenodo.org/records/11452259,0.15918852059740268
+Delaware,1987,17,Project Tycho - https://zenodo.org/records/11452259,2.6663195223210154
+Delaware,1988,0,https://stacks.cdc.gov/view/cdc/35958,0.0
+Delaware,1989,6,Project Tycho - https://zenodo.org/records/11452259,0.9105657496763697
+Delaware,1990,5,Project Tycho - https://zenodo.org/records/11452259,0.7465672836298698
+Delaware,1991,19,Project Tycho - https://zenodo.org/records/11452259,2.789297904356443
+Delaware,1992,1,Project Tycho - https://zenodo.org/records/11452259,0.14474964102089027
+Delaware,1993,2,Project Tycho - https://zenodo.org/records/11452259,0.28564328295537966
+Delaware,1994,0,https://stacks.cdc.gov/view/cdc/5648,0.0
+Delaware,1995,0,https://stacks.cdc.gov/view/cdc/5644,0.0
+Delaware,1996,1,Project Tycho - https://zenodo.org/records/11452259,0.13739717538886834
+Delaware,1997,0,"https://www.cdc.gov/mmwr/preview/mmwrhtml/00056071.htm#:~:text=As%20of%20January%201%2C%201997,and%20control%20of%20the%20disease.",0.0
+Delaware,1998,1,https://stacks.cdc.gov/view/cdc/5637,0.13426242934439656
+Delaware,1999,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.0
+Delaware,2000,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4953a1.htm,0.0
+Delaware,2001,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5053a1.htm,0.0
+Delaware,2002,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.0
+Delaware,2003,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.0
+Delaware,2004,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0
+Delaware,2005,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.1182040082979214
+Delaware,2006,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.0
+Delaware,2007,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.0
+Delaware,2008,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.0
+Delaware,2009,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.0
+Delaware,2010,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.0
+Delaware,2011,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.11007190997878914
+Delaware,2012,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.10911872444575872
+Delaware,2013,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.0
+Delaware,2014,0,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.0
+Delaware,2015,1,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.10604375153100666
+Delaware,2016,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Delaware,2017,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Delaware,2018,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Delaware,2019,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Delaware,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Delaware,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Delaware,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+District of Columbia,1889,4,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1890,16,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1891,69,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1892,2,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1893,16,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1894,4,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1895,8,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1896,57,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1897,1,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1898,17,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1899,22,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1900,37,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1901,12,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1902,8,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1903,28,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1904,2,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1905,6,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1906,24,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1907,507,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1908,1165,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1909,6557,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1910,210,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1911,3153,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1912,1644,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1913,6162,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1914,924,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1915,1931,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1916,2650,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1917,3769,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1918,6370,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1919,178,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1920,547,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1921,4163,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1922,531,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1923,7566,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1924,431,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1925,800,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1926,6358,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1927,160,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1928,6062,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1929,842,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1930,1800,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1931,8398,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1932,546,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1933,1187,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1934,12822,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1935,1944,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1936,4153,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1937,4178,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1938,925,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1939,7485,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1940,193,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1941,8056,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1942,3087,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1943,4333,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1944,6070,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1945,397,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1946,8946,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1947,1132,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1948,5435,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1949,2248,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1950,1806,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1951,1604,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1952,4450,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1953,582,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1954,3032,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1955,453,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1956,1597,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1957,910,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1958,1385,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1959,397,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1960,1210,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1961,394,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1962,675,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1963,231,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1964,334,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1965,157,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1966,390,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1967,27,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1968,6,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1969,43,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1970,345,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1971,16,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1972,2,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1973,10,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1974,1,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1975,2,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1976,13,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1977,1,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1978,1,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1979,1,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1980,5,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1981,1,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1982,1,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1985,8,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1986,1,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1987,1,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1989,11,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1990,23,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1992,2,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,1997,1,Project Tycho - https://zenodo.org/records/11452259,
+District of Columbia,2008,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,
+District of Columbia,2009,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,
+District of Columbia,2012,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,
+District of Columbia,2013,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,
+District of Columbia,2015,3,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,
+District of Columbia,2016,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,
+District of Columbia,2017,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,
+District of Columbia,2018,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,
+District of Columbia,2019,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,
+District of Columbia,2020,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,
+District of Columbia,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,
+District of Columbia,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,
+Florida,1889,5,Project Tycho - https://zenodo.org/records/11452259,
+Florida,1890,2,Project Tycho - https://zenodo.org/records/11452259,
+Florida,1891,1,Project Tycho - https://zenodo.org/records/11452259,
+Florida,1892,1,Project Tycho - https://zenodo.org/records/11452259,
+Florida,1896,11,Project Tycho - https://zenodo.org/records/11452259,
+Florida,1898,1,Project Tycho - https://zenodo.org/records/11452259,
+Florida,1899,5,Project Tycho - https://zenodo.org/records/11452259,
+Florida,1904,3,Project Tycho - https://zenodo.org/records/11452259,0.5003343901507508
+Florida,1906,4,Project Tycho - https://zenodo.org/records/11452259,0.6363063687904452
+Florida,1907,24,Project Tycho - https://zenodo.org/records/11452259,3.717213019538601
+Florida,1908,34,Project Tycho - https://zenodo.org/records/11452259,4.965794439478651
+Florida,1909,3,Project Tycho - https://zenodo.org/records/11452259,0.4139506901937841
+Florida,1910,25,Project Tycho - https://zenodo.org/records/11452259,3.303574732146161
+Florida,1911,265,Project Tycho - https://zenodo.org/records/11452259,34.24777034091394
+Florida,1912,37,Project Tycho - https://zenodo.org/records/11452259,4.61461135618439
+Florida,1915,31,Project Tycho - https://zenodo.org/records/11452259,3.358897068224617
+Florida,1916,1,Project Tycho - https://zenodo.org/records/11452259,0.10811699123387436
+Florida,1918,303,Project Tycho - https://zenodo.org/records/11452259,34.99390782627777
+Florida,1919,775,https://www.jstor.org/stable/4575902,86.21667864429557
+Florida,1921,71,Project Tycho - https://zenodo.org/records/11452259,7.114249842434396
+Florida,1922,25,Project Tycho - https://zenodo.org/records/11452259,2.3922437715541163
+Florida,1923,435,Project Tycho - https://zenodo.org/records/11452259,39.6139867425191
+Florida,1924,471,Project Tycho - https://zenodo.org/records/11452259,40.5628853904716
+Florida,1925,6,Project Tycho - https://zenodo.org/records/11452259,0.47420933496882867
+Florida,1926,194,Project Tycho - https://zenodo.org/records/11452259,14.167119430277326
+Florida,1927,1502,Project Tycho - https://zenodo.org/records/11452259,105.81801837090978
+Florida,1928,1834,Project Tycho - https://zenodo.org/records/11452259,127.85539652252842
+Florida,1929,1848,Project Tycho - https://zenodo.org/records/11452259,127.76151184455682
+Florida,1930,6649,Project Tycho - https://zenodo.org/records/11452259,451.5538845926337
+Florida,1931,6369,Project Tycho - https://zenodo.org/records/11452259,426.16459227309866
+Florida,1932,248,Project Tycho - https://zenodo.org/records/11452259,16.28877368522339
+Florida,1933,1008,Project Tycho - https://zenodo.org/records/11452259,64.88357003820921
+Florida,1934,11428,Project Tycho - https://zenodo.org/records/11452259,720.2891745478496
+Florida,1935,1713,Project Tycho - https://zenodo.org/records/11452259,106.09353448783082
+Florida,1936,490,Project Tycho - https://zenodo.org/records/11452259,29.649333101786162
+Florida,1937,828,Project Tycho - https://zenodo.org/records/11452259,48.400984620996326
+Florida,1938,10711,Project Tycho - https://zenodo.org/records/11452259,604.1953529248842
+Florida,1939,3909,Project Tycho - https://zenodo.org/records/11452259,212.69580093109505
+Florida,1940,3206,Project Tycho - https://zenodo.org/records/11452259,167.24789570742573
+Florida,1941,10142,Project Tycho - https://zenodo.org/records/11452259,502.3236555214741
+Florida,1942,4582,Project Tycho - https://zenodo.org/records/11452259,212.8043969048153
+Florida,1943,1363,Project Tycho - https://zenodo.org/records/11452259,55.5544007196394
+Florida,1944,4976,Project Tycho - https://zenodo.org/records/11452259,205.41442029045334
+Florida,1945,712,Project Tycho - https://zenodo.org/records/11452259,28.855525812929464
+Florida,1946,3723,Project Tycho - https://zenodo.org/records/11452259,152.42953767543932
+Florida,1947,1402,Project Tycho - https://zenodo.org/records/11452259,55.40345730219148
+Florida,1948,4331,Project Tycho - https://zenodo.org/records/11452259,167.83061779182802
+Florida,1949,3843,Project Tycho - https://zenodo.org/records/11452259,143.896583176943
+Florida,1950,2497,Project Tycho - https://zenodo.org/records/11452259,88.77243752688592
+Florida,1951,2303,Project Tycho - https://zenodo.org/records/11452259,77.20467452011076
+Florida,1952,4696,Project Tycho - https://zenodo.org/records/11452259,148.60021195149483
+Florida,1953,1368,Project Tycho - https://zenodo.org/records/11452259,41.288017118832826
+Florida,1954,10945,Project Tycho - https://zenodo.org/records/11452259,311.95623207035476
+Florida,1955,1427,Project Tycho - https://zenodo.org/records/11452259,38.04575461901322
+Florida,1956,5261,Project Tycho - https://zenodo.org/records/11452259,129.86766137247977
+Florida,1957,5181,Project Tycho - https://zenodo.org/records/11452259,118.38573137749717
+Florida,1958,12316,Project Tycho - https://zenodo.org/records/11452259,265.7385810733543
+Florida,1959,3592,Project Tycho - https://zenodo.org/records/11452259,74.63418445115617
+Florida,1960,3723,Project Tycho - https://zenodo.org/records/11452259,74.3261534628441
+Florida,1961,6759,Project Tycho - https://zenodo.org/records/11452259,128.78595750997047
+Florida,1962,4116,Project Tycho - https://zenodo.org/records/11452259,75.33690201334026
+Florida,1963,3737,Project Tycho - https://zenodo.org/records/11452259,66.33380833807273
+Florida,1964,7019,Project Tycho - https://zenodo.org/records/11452259,121.29368642082704
+Florida,1965,3708,Project Tycho - https://zenodo.org/records/11452259,62.21524528545019
+Florida,1966,3931,Project Tycho - https://zenodo.org/records/11452259,64.33605712766919
+Florida,1967,1815,Project Tycho - https://zenodo.org/records/11452259,29.048170669445902
+Florida,1968,565,Project Tycho - https://zenodo.org/records/11452259,8.774064424616267
+Florida,1969,610,Project Tycho - https://zenodo.org/records/11452259,9.176187462590113
+Florida,1970,1444,Project Tycho - https://zenodo.org/records/11452259,21.240888592863207
+Florida,1971,2232,Project Tycho - https://zenodo.org/records/11452259,31.149422047036186
+Florida,1972,1370,Project Tycho - https://zenodo.org/records/11452259,18.22057105131631
+Florida,1973,392,Project Tycho - https://zenodo.org/records/11452259,4.94848963133626
+Florida,1974,228,Project Tycho - https://zenodo.org/records/11452259,2.7446533430599995
+Florida,1975,82,Project Tycho - https://zenodo.org/records/11452259,0.9616579921988427
+Florida,1976,337,Project Tycho - https://zenodo.org/records/11452259,3.8842578750735073
+Florida,1977,304,Project Tycho - https://zenodo.org/records/11452259,3.429200931885353
+Florida,1978,1094,Project Tycho - https://zenodo.org/records/11452259,12.007286908523133
+Florida,1979,598,Project Tycho - https://zenodo.org/records/11452259,6.3377098505286105
+Florida,1980,407,Project Tycho - https://zenodo.org/records/11452259,4.132116453803445
+Florida,1981,299,Project Tycho - https://zenodo.org/records/11452259,2.930520399656335
+Florida,1982,208,Project Tycho - https://zenodo.org/records/11452259,1.9843772270579756
+Florida,1983,156,Project Tycho - https://zenodo.org/records/11452259,1.4497332862479788
+Florida,1984,17,Project Tycho - https://zenodo.org/records/11452259,0.1538327335063258
+Florida,1985,115,Project Tycho - https://zenodo.org/records/11452259,1.0121039714167757
+Florida,1986,395,Project Tycho - https://zenodo.org/records/11452259,3.3820890727527604
+Florida,1987,79,Project Tycho - https://zenodo.org/records/11452259,0.657824615630579
+Florida,1988,123,Project Tycho - https://zenodo.org/records/11452259,0.9984819016225818
+Florida,1989,130,Project Tycho - https://zenodo.org/records/11452259,1.0276393890067248
+Florida,1990,320,Project Tycho - https://zenodo.org/records/11452259,2.4556104290695777
+Florida,1991,291,Project Tycho - https://zenodo.org/records/11452259,2.1875116986772545
+Florida,1992,40,Project Tycho - https://zenodo.org/records/11452259,0.2958956535813471
+Florida,1993,25,Project Tycho - https://zenodo.org/records/11452259,0.18211876387107565
+Florida,1994,16,Project Tycho - https://zenodo.org/records/11452259,0.11448394323342297
+Florida,1995,9,Project Tycho - https://zenodo.org/records/11452259,0.06338212066434604
+Florida,1996,1,https://stacks.cdc.gov/view/cdc/5642,0.006924566610418411
+Florida,1997,14,Project Tycho - https://zenodo.org/records/11452259,0.09525084070773279
+Florida,1998,4,Project Tycho - https://zenodo.org/records/11452259,0.026804014008313802
+Florida,1999,4,Project Tycho - https://zenodo.org/records/11452259,0.026443911966894863
+Florida,2000,5,Project Tycho - https://zenodo.org/records/11452259,0.03112634669695302
+Florida,2001,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5053a1.htm,0.0
+Florida,2002,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.011971704397787651
+Florida,2003,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.0
+Florida,2004,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0057363352034359725
+Florida,2005,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.0
+Florida,2006,4,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.021995961981299474
+Florida,2007,5,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.027194295463518335
+Florida,2008,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.00539204711872727
+Florida,2009,5,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.026779073075591537
+Florida,2010,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.005300824718212134
+Florida,2011,8,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.04194045482955346
+Florida,2012,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.0
+Florida,2013,7,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.03576678807447402
+Florida,2014,0,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.0
+Florida,2015,5,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.02470437509542065
+Florida,2016,5,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.024215579877899233
+Florida,2017,3,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.014287030053148703
+Florida,2018,15,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.07050137759691824
+Florida,2019,3,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.013944701264524104
+Florida,2020,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.004626710732076574
+Florida,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Florida,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Georgia,1888,1,Project Tycho - https://zenodo.org/records/11452259,
+Georgia,1903,4,Project Tycho - https://zenodo.org/records/11452259,0.17033265115106547
+Georgia,1906,8,Project Tycho - https://zenodo.org/records/11452259,0.3240879153287912
+Georgia,1907,137,Project Tycho - https://zenodo.org/records/11452259,5.463598277969536
+Georgia,1908,213,Project Tycho - https://zenodo.org/records/11452259,8.367566369925788
+Georgia,1909,2,Project Tycho - https://zenodo.org/records/11452259,0.07744193790705418
+Georgia,1910,3,Project Tycho - https://zenodo.org/records/11452259,0.11447681424763166
+Georgia,1911,2,Project Tycho - https://zenodo.org/records/11452259,0.07556739780642958
+Georgia,1912,2,Project Tycho - https://zenodo.org/records/11452259,0.07466375179379664
+Georgia,1913,3,Project Tycho - https://zenodo.org/records/11452259,0.10965982425916565
+Georgia,1915,5,Project Tycho - https://zenodo.org/records/11452259,0.17775818487562262
+Georgia,1917,329,Project Tycho - https://zenodo.org/records/11452259,11.392420404552121
+Georgia,1918,876,Project Tycho - https://zenodo.org/records/11452259,29.756031116112723
+Georgia,1919,512,Project Tycho - https://zenodo.org/records/11452259,17.8218993550004
+Georgia,1920,1161,Project Tycho - https://zenodo.org/records/11452259,39.63910320711414
+Georgia,1921,1028,Project Tycho - https://zenodo.org/records/11452259,34.636527047994164
+Georgia,1922,162,Project Tycho - https://zenodo.org/records/11452259,5.458285390831765
+Georgia,1923,5324,Project Tycho - https://zenodo.org/records/11452259,180.05014619774266
+Georgia,1924,945,Project Tycho - https://zenodo.org/records/11452259,32.33068301561452
+Georgia,1925,23,Project Tycho - https://zenodo.org/records/11452259,0.7969831070767595
+Georgia,1926,649,Project Tycho - https://zenodo.org/records/11452259,22.59852381846108
+Georgia,1927,1624,Project Tycho - https://zenodo.org/records/11452259,56.11821592451132
+Georgia,1928,5758,Project Tycho - https://zenodo.org/records/11452259,198.14838967439727
+Georgia,1929,1374,Project Tycho - https://zenodo.org/records/11452259,47.28306485109792
+Georgia,1930,5369,Project Tycho - https://zenodo.org/records/11452259,184.31740081224615
+Georgia,1931,4040,Project Tycho - https://zenodo.org/records/11452259,138.02886579904364
+Georgia,1932,1257,Project Tycho - https://zenodo.org/records/11452259,42.785153517691846
+Georgia,1933,6096,Project Tycho - https://zenodo.org/records/11452259,206.4376301664437
+Georgia,1934,27062,Project Tycho - https://zenodo.org/records/11452259,912.1108311391712
+Georgia,1935,97,Project Tycho - https://zenodo.org/records/11452259,3.279292619394142
+Georgia,1936,43,Project Tycho - https://zenodo.org/records/11452259,1.442479615750267
+Georgia,1937,286,Project Tycho - https://zenodo.org/records/11452259,9.407780234253726
+Georgia,1938,12211,Project Tycho - https://zenodo.org/records/11452259,394.6554900938595
+Georgia,1939,3474,Project Tycho - https://zenodo.org/records/11452259,111.23491892722662
+Georgia,1940,3227,Project Tycho - https://zenodo.org/records/11452259,103.35928899571091
+Georgia,1941,10747,Project Tycho - https://zenodo.org/records/11452259,337.72455917784634
+Georgia,1942,6346,Project Tycho - https://zenodo.org/records/11452259,197.55875162543907
+Georgia,1943,4635,Project Tycho - https://zenodo.org/records/11452259,142.692438532192
+Georgia,1944,6525,Project Tycho - https://zenodo.org/records/11452259,205.24186141314604
+Georgia,1945,669,Project Tycho - https://zenodo.org/records/11452259,21.42775467559052
+Georgia,1946,4630,Project Tycho - https://zenodo.org/records/11452259,142.6704079387608
+Georgia,1947,4173,Project Tycho - https://zenodo.org/records/11452259,127.40926555107484
+Georgia,1948,1314,Project Tycho - https://zenodo.org/records/11452259,40.27883745588563
+Georgia,1949,9599,Project Tycho - https://zenodo.org/records/11452259,288.40332599731096
+Georgia,1950,2289,Project Tycho - https://zenodo.org/records/11452259,66.12820378002564
+Georgia,1951,7813,Project Tycho - https://zenodo.org/records/11452259,221.0477146755821
+Georgia,1952,9574,Project Tycho - https://zenodo.org/records/11452259,266.86483159697445
+Georgia,1953,4030,Project Tycho - https://zenodo.org/records/11452259,113.15272698072025
+Georgia,1954,6773,Project Tycho - https://zenodo.org/records/11452259,187.84657874052655
+Georgia,1955,2478,Project Tycho - https://zenodo.org/records/11452259,68.08373145006809
+Georgia,1956,4826,Project Tycho - https://zenodo.org/records/11452259,130.26692302563688
+Georgia,1957,5927,Project Tycho - https://zenodo.org/records/11452259,157.22461288048117
+Georgia,1958,6541,Project Tycho - https://zenodo.org/records/11452259,171.7787995390519
+Georgia,1959,445,Project Tycho - https://zenodo.org/records/11452259,11.493160407327936
+Georgia,1960,217,Project Tycho - https://zenodo.org/records/11452259,5.479858867118725
+Georgia,1961,415,Project Tycho - https://zenodo.org/records/11452259,10.32591319017222
+Georgia,1962,416,Project Tycho - https://zenodo.org/records/11452259,10.17093528106744
+Georgia,1963,200,Project Tycho - https://zenodo.org/records/11452259,4.789074779487052
+Georgia,1964,211,Project Tycho - https://zenodo.org/records/11452259,4.950427684105467
+Georgia,1965,655,Project Tycho - https://zenodo.org/records/11452259,15.104932002438929
+Georgia,1966,244,Project Tycho - https://zenodo.org/records/11452259,5.566481930948704
+Georgia,1967,42,Project Tycho - https://zenodo.org/records/11452259,0.9518612059446905
+Georgia,1968,4,Project Tycho - https://zenodo.org/records/11452259,0.08915671566273975
+Georgia,1969,2,Project Tycho - https://zenodo.org/records/11452259,0.04390248292687317
+Georgia,1970,18,Project Tycho - https://zenodo.org/records/11452259,0.3919419351087868
+Georgia,1971,1135,Project Tycho - https://zenodo.org/records/11452259,24.065674058327136
+Georgia,1972,176,Project Tycho - https://zenodo.org/records/11452259,3.6557762615076466
+Georgia,1973,50,Project Tycho - https://zenodo.org/records/11452259,1.0172352197757037
+Georgia,1974,3,Project Tycho - https://zenodo.org/records/11452259,0.059947030803581956
+Georgia,1975,40,Project Tycho - https://zenodo.org/records/11452259,0.7890886401023921
+Georgia,1976,5,Project Tycho - https://zenodo.org/records/11452259,0.09731519066770676
+Georgia,1977,770,Project Tycho - https://zenodo.org/records/11452259,14.737079026725024
+Georgia,1978,30,Project Tycho - https://zenodo.org/records/11452259,0.565926045538937
+Georgia,1979,370,Project Tycho - https://zenodo.org/records/11452259,6.8432534306431645
+Georgia,1980,846,Project Tycho - https://zenodo.org/records/11452259,15.40517803360004
+Georgia,1981,110,Project Tycho - https://zenodo.org/records/11452259,1.9734789545513178
+Georgia,1982,0,https://stacks.cdc.gov/view/cdc/35066,0.0
+Georgia,1983,8,Project Tycho - https://zenodo.org/records/11452259,0.13951919592297007
+Georgia,1984,4,Project Tycho - https://zenodo.org/records/11452259,0.06848391004775382
+Georgia,1985,8,Project Tycho - https://zenodo.org/records/11452259,0.13403426552489578
+Georgia,1986,93,Project Tycho - https://zenodo.org/records/11452259,1.5269055535032634
+Georgia,1987,10,Project Tycho - https://zenodo.org/records/11452259,0.1609094602694429
+Georgia,1988,0,https://stacks.cdc.gov/view/cdc/35958,0.0
+Georgia,1989,17,Project Tycho - https://zenodo.org/records/11452259,0.26490024947370555
+Georgia,1990,357,Project Tycho - https://zenodo.org/records/11452259,5.481313863256112
+Georgia,1991,15,Project Tycho - https://zenodo.org/records/11452259,0.22631602770108178
+Georgia,1992,3,Project Tycho - https://zenodo.org/records/11452259,0.044337816921173126
+Georgia,1993,1,Project Tycho - https://zenodo.org/records/11452259,0.014490682925599326
+Georgia,1994,2,Project Tycho - https://zenodo.org/records/11452259,0.02835694876395605
+Georgia,1995,5,Project Tycho - https://zenodo.org/records/11452259,0.06948569192323333
+Georgia,1996,2,Project Tycho - https://zenodo.org/records/11452259,0.027249601031778894
+Georgia,1997,1,Project Tycho - https://zenodo.org/records/11452259,0.013344756444850125
+Georgia,1998,2,Project Tycho - https://zenodo.org/records/11452259,0.02616377107851512
+Georgia,1999,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.0
+Georgia,2000,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4953a1.htm,0.0
+Georgia,2001,2,Project Tycho - https://zenodo.org/records/11452259,0.023850936417577427
+Georgia,2002,3,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.035224646356292126
+Georgia,2003,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.011585585909146994
+Georgia,2004,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.011392089401472153
+Georgia,2005,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.0
+Georgia,2006,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.0
+Georgia,2007,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.0
+Georgia,2008,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.010510442808108639
+Georgia,2009,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.010383713519158887
+Georgia,2010,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.01028603297640456
+Georgia,2011,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.0
+Georgia,2012,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.02017454410321781
+Georgia,2013,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.0
+Georgia,2014,0,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.0
+Georgia,2015,1,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.009810138503459447
+Georgia,2016,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.009691096305269533
+Georgia,2017,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Georgia,2018,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Georgia,2019,18,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.1691944314728714
+Georgia,2020,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.009307849681950775
+Georgia,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Georgia,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Guam,1972,10,Project Tycho - https://zenodo.org/records/11452259,
+Guam,1977,46,Project Tycho - https://zenodo.org/records/11452259,
+Guam,1979,48,Project Tycho - https://zenodo.org/records/11452259,
+Guam,1981,4,Project Tycho - https://zenodo.org/records/11452259,
+Guam,1986,5,Project Tycho - https://zenodo.org/records/11452259,
+Guam,1987,1,Project Tycho - https://zenodo.org/records/11452259,
+Guam,2000,2,Project Tycho - https://zenodo.org/records/11452259,
+Hawaii,1919,135,https://www.jstor.org/stable/4575902,
+Hawaii,1950,68,Project Tycho - https://zenodo.org/records/11452259,13.640977496399184
+Hawaii,1951,4908,Project Tycho - https://zenodo.org/records/11452259,953.9099033262457
+Hawaii,1953,44,Project Tycho - https://zenodo.org/records/11452259,8.618832148243914
+Hawaii,1954,504,Project Tycho - https://zenodo.org/records/11452259,99.7022779200997
+Hawaii,1955,6395,Project Tycho - https://zenodo.org/records/11452259,1185.2711296125026
+Hawaii,1956,5610,Project Tycho - https://zenodo.org/records/11452259,1002.575242289017
+Hawaii,1957,4604,Project Tycho - https://zenodo.org/records/11452259,787.5685957877739
+Hawaii,1958,574,Project Tycho - https://zenodo.org/records/11452259,94.7812518060452
+Hawaii,1959,3686,Project Tycho - https://zenodo.org/records/11452259,592.0124891185984
+Hawaii,1960,5322,Project Tycho - https://zenodo.org/records/11452259,828.1438187980244
+Hawaii,1961,210,Project Tycho - https://zenodo.org/records/11452259,31.834629710198755
+Hawaii,1962,2769,Project Tycho - https://zenodo.org/records/11452259,404.42014126224655
+Hawaii,1963,3426,Project Tycho - https://zenodo.org/records/11452259,501.84419685885956
+Hawaii,1964,860,Project Tycho - https://zenodo.org/records/11452259,122.73440844869415
+Hawaii,1965,4054,Project Tycho - https://zenodo.org/records/11452259,575.2769957315411
+Hawaii,1966,144,Project Tycho - https://zenodo.org/records/11452259,20.261428712132936
+Hawaii,1967,175,Project Tycho - https://zenodo.org/records/11452259,24.180522105833308
+Hawaii,1968,34,Project Tycho - https://zenodo.org/records/11452259,4.6275250634923655
+Hawaii,1969,53,Project Tycho - https://zenodo.org/records/11452259,7.05960705960706
+Hawaii,1970,192,Project Tycho - https://zenodo.org/records/11452259,24.912999135830344
+Hawaii,1971,488,Project Tycho - https://zenodo.org/records/11452259,60.81413679442204
+Hawaii,1972,98,Project Tycho - https://zenodo.org/records/11452259,11.819204760486228
+Hawaii,1973,16,Project Tycho - https://zenodo.org/records/11452259,1.8769517365322848
+Hawaii,1974,63,Project Tycho - https://zenodo.org/records/11452259,7.251005645425824
+Hawaii,1975,65,Project Tycho - https://zenodo.org/records/11452259,7.3276921377245365
+Hawaii,1976,6,Project Tycho - https://zenodo.org/records/11452259,0.6629138377739353
+Hawaii,1977,44,Project Tycho - https://zenodo.org/records/11452259,4.786890881734421
+Hawaii,1978,16,Project Tycho - https://zenodo.org/records/11452259,1.7157900945293107
+Hawaii,1979,79,Project Tycho - https://zenodo.org/records/11452259,8.27867486709583
+Hawaii,1980,6,Project Tycho - https://zenodo.org/records/11452259,0.6194015136108322
+Hawaii,1981,8,Project Tycho - https://zenodo.org/records/11452259,0.8170159920667747
+Hawaii,1982,5,Project Tycho - https://zenodo.org/records/11452259,0.5026272325445101
+Hawaii,1983,1,Project Tycho - https://zenodo.org/records/11452259,0.09864569327700007
+Hawaii,1984,174,Project Tycho - https://zenodo.org/records/11452259,16.910459118965083
+Hawaii,1985,25,Project Tycho - https://zenodo.org/records/11452259,2.402143865356954
+Hawaii,1986,29,Project Tycho - https://zenodo.org/records/11452259,2.7545252575718573
+Hawaii,1987,4,Project Tycho - https://zenodo.org/records/11452259,0.3741867285322058
+Hawaii,1988,15,Project Tycho - https://zenodo.org/records/11452259,1.3877234581698517
+Hawaii,1989,17,Project Tycho - https://zenodo.org/records/11452259,1.551545065082752
+Hawaii,1990,42,Project Tycho - https://zenodo.org/records/11452259,3.770823700524773
+Hawaii,1991,19,Project Tycho - https://zenodo.org/records/11452259,1.6776404957692554
+Hawaii,1992,46,Project Tycho - https://zenodo.org/records/11452259,3.9962643615750495
+Hawaii,1993,17,Project Tycho - https://zenodo.org/records/11452259,1.4621530289360085
+Hawaii,1994,4,Project Tycho - https://zenodo.org/records/11452259,0.3404035143258819
+Hawaii,1995,1,Project Tycho - https://zenodo.org/records/11452259,0.08462599541327105
+Hawaii,1996,13,Project Tycho - https://zenodo.org/records/11452259,1.096474581188882
+Hawaii,1997,1,Project Tycho - https://zenodo.org/records/11452259,0.08399754391181602
+Hawaii,1998,0,https://stacks.cdc.gov/view/cdc/5637,0.0
+Hawaii,1999,1,Project Tycho - https://zenodo.org/records/11452259,0.08426857405775094
+Hawaii,2000,2,Project Tycho - https://zenodo.org/records/11452259,0.1646453703368315
+Hawaii,2001,4,Project Tycho - https://zenodo.org/records/11452259,0.3259524125775258
+Hawaii,2002,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.08058978830674408
+Hawaii,2003,19,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,1.5170811358945389
+Hawaii,2004,3,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.2353232792769614
+Hawaii,2005,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.07727849857150695
+Hawaii,2006,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.0
+Hawaii,2007,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.1518614416206653
+Hawaii,2008,4,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.29995238255926876
+Hawaii,2009,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.0
+Hawaii,2010,4,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.29296131152919946
+Hawaii,2011,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.0
+Hawaii,2012,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.0
+Hawaii,2013,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.0
+Hawaii,2014,15,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,1.0587612493382743
+Hawaii,2015,0,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.0
+Hawaii,2016,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.06991476690766286
+Hawaii,2017,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Hawaii,2018,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Hawaii,2019,2,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.1411402722595852
+Hawaii,2020,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.06883719521471354
+Hawaii,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Hawaii,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Idaho,1918,51,Project Tycho - https://zenodo.org/records/11452259,12.580012580012578
+Idaho,1919,9,Project Tycho - https://zenodo.org/records/11452259,2.1205209884455165
+Idaho,1920,90,Project Tycho - https://zenodo.org/records/11452259,20.764454944593513
+Idaho,1921,328,Project Tycho - https://zenodo.org/records/11452259,75.32697187869601
+Idaho,1922,3,Project Tycho - https://zenodo.org/records/11452259,0.6873860084869259
+Idaho,1923,7,Project Tycho - https://zenodo.org/records/11452259,1.603900686469494
+Idaho,1924,578,Project Tycho - https://zenodo.org/records/11452259,133.04667682547867
+Idaho,1925,5,Project Tycho - https://zenodo.org/records/11452259,1.14564334747821
+Idaho,1926,47,Project Tycho - https://zenodo.org/records/11452259,10.646949422459626
+Idaho,1927,287,Project Tycho - https://zenodo.org/records/11452259,64.14167487992992
+Idaho,1928,87,Project Tycho - https://zenodo.org/records/11452259,19.35703494723539
+Idaho,1929,839,Project Tycho - https://zenodo.org/records/11452259,187.50824119951636
+Idaho,1930,916,Project Tycho - https://zenodo.org/records/11452259,204.71698324047316
+Idaho,1931,131,Project Tycho - https://zenodo.org/records/11452259,28.825799750909887
+Idaho,1932,100,Project Tycho - https://zenodo.org/records/11452259,21.764727647080587
+Idaho,1933,1176,Project Tycho - https://zenodo.org/records/11452259,253.1950807812877
+Idaho,1934,1249,Project Tycho - https://zenodo.org/records/11452259,263.79540121612007
+Idaho,1935,942,Project Tycho - https://zenodo.org/records/11452259,195.64634949250336
+Idaho,1936,1527,Project Tycho - https://zenodo.org/records/11452259,308.17667181303545
+Idaho,1937,1239,Project Tycho - https://zenodo.org/records/11452259,244.13456366119087
+Idaho,1938,778,Project Tycho - https://zenodo.org/records/11452259,151.5054146633094
+Idaho,1939,2309,Project Tycho - https://zenodo.org/records/11452259,442.74343698527963
+Idaho,1940,1467,Project Tycho - https://zenodo.org/records/11452259,280.7537290295911
+Idaho,1941,564,Project Tycho - https://zenodo.org/records/11452259,112.46238791148971
+Idaho,1942,2052,Project Tycho - https://zenodo.org/records/11452259,428.8598430857845
+Idaho,1943,3313,Project Tycho - https://zenodo.org/records/11452259,661.9380619380619
+Idaho,1944,1104,Project Tycho - https://zenodo.org/records/11452259,208.48716500890416
+Idaho,1945,1445,Project Tycho - https://zenodo.org/records/11452259,284.72513679614275
+Idaho,1946,2367,Project Tycho - https://zenodo.org/records/11452259,464.5649046434901
+Idaho,1947,255,Project Tycho - https://zenodo.org/records/11452259,48.80177293970397
+Idaho,1948,1517,Project Tycho - https://zenodo.org/records/11452259,275.04256179392297
+Idaho,1949,2913,Project Tycho - https://zenodo.org/records/11452259,510.5420894894579
+Idaho,1950,2004,Project Tycho - https://zenodo.org/records/11452259,339.32169525389867
+Idaho,1951,2119,Project Tycho - https://zenodo.org/records/11452259,359.40290609221
+Idaho,1952,1278,Project Tycho - https://zenodo.org/records/11452259,217.4997064264526
+Idaho,1953,2089,Project Tycho - https://zenodo.org/records/11452259,350.15320250219577
+Idaho,1954,4405,Project Tycho - https://zenodo.org/records/11452259,733.4332334332335
+Idaho,1955,703,Project Tycho - https://zenodo.org/records/11452259,113.64040490254082
+Idaho,1956,1997,Project Tycho - https://zenodo.org/records/11452259,317.6759546186298
+Idaho,1957,3249,Project Tycho - https://zenodo.org/records/11452259,505.5691971579822
+Idaho,1958,3698,Project Tycho - https://zenodo.org/records/11452259,571.8739464869495
+Idaho,1959,1624,Project Tycho - https://zenodo.org/records/11452259,246.9372332386031
+Idaho,1960,2831,Project Tycho - https://zenodo.org/records/11452259,421.48611448164354
+Idaho,1961,1966,Project Tycho - https://zenodo.org/records/11452259,287.13976082397136
+Idaho,1962,1616,Project Tycho - https://zenodo.org/records/11452259,233.2927188418518
+Idaho,1963,3927,Project Tycho - https://zenodo.org/records/11452259,574.3890077711454
+Idaho,1964,2234,Project Tycho - https://zenodo.org/records/11452259,328.2012105541517
+Idaho,1965,3119,Project Tycho - https://zenodo.org/records/11452259,454.21051251955043
+Idaho,1966,1701,Project Tycho - https://zenodo.org/records/11452259,246.63290265612474
+Idaho,1967,417,Project Tycho - https://zenodo.org/records/11452259,60.549915201077994
+Idaho,1968,17,Project Tycho - https://zenodo.org/records/11452259,2.443599565901724
+Idaho,1969,90,Project Tycho - https://zenodo.org/records/11452259,12.717127285727004
+Idaho,1970,98,Project Tycho - https://zenodo.org/records/11452259,13.730720946915351
+Idaho,1971,274,Project Tycho - https://zenodo.org/records/11452259,37.0525131475569
+Idaho,1972,110,Project Tycho - https://zenodo.org/records/11452259,14.397905759162304
+Idaho,1973,255,Project Tycho - https://zenodo.org/records/11452259,32.57304025261351
+Idaho,1974,54,Project Tycho - https://zenodo.org/records/11452259,6.676582628273844
+Idaho,1975,20,Project Tycho - https://zenodo.org/records/11452259,2.4014994962854805
+Idaho,1976,1982,Project Tycho - https://zenodo.org/records/11452259,231.04568572890716
+Idaho,1977,138,Project Tycho - https://zenodo.org/records/11452259,15.604646113764655
+Idaho,1978,1,Project Tycho - https://zenodo.org/records/11452259,0.10969723562966213
+Idaho,1979,20,Project Tycho - https://zenodo.org/records/11452259,2.1423391558541023
+Idaho,1980,0,https://stacks.cdc.gov/view/cdc/1484,0.0
+Idaho,1981,1,Project Tycho - https://zenodo.org/records/11452259,0.10382426289964554
+Idaho,1982,0,https://stacks.cdc.gov/view/cdc/35066,0.0
+Idaho,1983,4,Project Tycho - https://zenodo.org/records/11452259,0.4069797018873684
+Idaho,1984,23,https://stacks.cdc.gov/view/cdc/35267,2.318948125130441
+Idaho,1985,35,Project Tycho - https://zenodo.org/records/11452259,3.517428860001307
+Idaho,1986,1,Project Tycho - https://zenodo.org/records/11452259,0.10088638780323927
+Idaho,1987,0,https://stacks.cdc.gov/view/cdc/35629,0.0
+Idaho,1988,1,Project Tycho - https://zenodo.org/records/11452259,0.10135316612087986
+Idaho,1989,10,Project Tycho - https://zenodo.org/records/11452259,1.0046111652484906
+Idaho,1990,14,Project Tycho - https://zenodo.org/records/11452259,1.3821795589465027
+Idaho,1991,432,Project Tycho - https://zenodo.org/records/11452259,41.54033884223614
+Idaho,1992,0,https://stacks.cdc.gov/view/cdc/36063,0.0
+Idaho,1993,0,https://stacks.cdc.gov/view/cdc/5650,0.0
+Idaho,1994,2,Project Tycho - https://zenodo.org/records/11452259,0.17596432851132418
+Idaho,1995,4,Project Tycho - https://zenodo.org/records/11452259,0.3430046348501284
+Idaho,1996,2,Project Tycho - https://zenodo.org/records/11452259,0.16822371735723904
+Idaho,1997,0,"https://www.cdc.gov/mmwr/preview/mmwrhtml/00056071.htm#:~:text=As%20of%20January%201%2C%201997,and%20control%20of%20the%20disease.",0.0
+Idaho,1998,1,Project Tycho - https://zenodo.org/records/11452259,0.08115875220041667
+Idaho,1999,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.0
+Idaho,2000,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4953a1.htm,0.0
+Idaho,2001,2,Project Tycho - https://zenodo.org/records/11452259,0.15136825550356056
+Idaho,2002,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.0
+Idaho,2003,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.0
+Idaho,2004,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0
+Idaho,2005,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.0
+Idaho,2006,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.0
+Idaho,2007,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.0
+Idaho,2008,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.0
+Idaho,2009,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.0
+Idaho,2010,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.0
+Idaho,2011,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.0
+Idaho,2012,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.0
+Idaho,2013,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.0
+Idaho,2014,0,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.0
+Idaho,2015,0,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.0
+Idaho,2016,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Idaho,2017,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Idaho,2018,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Idaho,2019,2,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.11167887409826288
+Idaho,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Idaho,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Idaho,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Illinois,1888,43,Project Tycho - https://zenodo.org/records/11452259,
+Illinois,1889,128,Project Tycho - https://zenodo.org/records/11452259,
+Illinois,1890,57,Project Tycho - https://zenodo.org/records/11452259,
+Illinois,1891,228,Project Tycho - https://zenodo.org/records/11452259,
+Illinois,1892,125,Project Tycho - https://zenodo.org/records/11452259,
+Illinois,1893,160,Project Tycho - https://zenodo.org/records/11452259,
+Illinois,1894,14,Project Tycho - https://zenodo.org/records/11452259,
+Illinois,1895,11,Project Tycho - https://zenodo.org/records/11452259,
+Illinois,1896,77,Project Tycho - https://zenodo.org/records/11452259,
+Illinois,1897,125,Project Tycho - https://zenodo.org/records/11452259,
+Illinois,1898,43,Project Tycho - https://zenodo.org/records/11452259,
+Illinois,1899,147,Project Tycho - https://zenodo.org/records/11452259,
+Illinois,1900,180,Project Tycho - https://zenodo.org/records/11452259,3.7245273367891425
+Illinois,1901,131,Project Tycho - https://zenodo.org/records/11452259,2.6631894763762896
+Illinois,1902,110,Project Tycho - https://zenodo.org/records/11452259,2.201324316708932
+Illinois,1903,259,Project Tycho - https://zenodo.org/records/11452259,5.102371499531823
+Illinois,1904,54,Project Tycho - https://zenodo.org/records/11452259,1.045263591281805
+Illinois,1905,218,Project Tycho - https://zenodo.org/records/11452259,4.155356187411138
+Illinois,1906,283,Project Tycho - https://zenodo.org/records/11452259,5.325245483467371
+Illinois,1907,3676,Project Tycho - https://zenodo.org/records/11452259,68.20816627651695
+Illinois,1908,7221,Project Tycho - https://zenodo.org/records/11452259,131.78272221019753
+Illinois,1909,9873,Project Tycho - https://zenodo.org/records/11452259,177.1714902665145
+Illinois,1910,11752,Project Tycho - https://zenodo.org/records/11452259,207.13231722406036
+Illinois,1911,7109,Project Tycho - https://zenodo.org/records/11452259,123.36109261591284
+Illinois,1912,6979,Project Tycho - https://zenodo.org/records/11452259,119.62985538826307
+Illinois,1913,15861,Project Tycho - https://zenodo.org/records/11452259,265.8137031564309
+Illinois,1914,4592,Project Tycho - https://zenodo.org/records/11452259,75.09269254235697
+Illinois,1915,21188,Project Tycho - https://zenodo.org/records/11452259,341.73124260305406
+Illinois,1916,10783,Project Tycho - https://zenodo.org/records/11452259,171.69633044672892
+Illinois,1917,22365,Project Tycho - https://zenodo.org/records/11452259,353.9150537408101
+Illinois,1918,6750,Project Tycho - https://zenodo.org/records/11452259,107.46225885668117
+Illinois,1919,18771,Project Tycho - https://zenodo.org/records/11452259,293.3705843593203
+Illinois,1920,13413,Project Tycho - https://zenodo.org/records/11452259,201.1046135314483
+Illinois,1921,13022,Project Tycho - https://zenodo.org/records/11452259,189.69074087184325
+Illinois,1922,13206,Project Tycho - https://zenodo.org/records/11452259,189.60631205529165
+Illinois,1923,25087,Project Tycho - https://zenodo.org/records/11452259,354.58316443036307
+Illinois,1924,6154,Project Tycho - https://zenodo.org/records/11452259,85.20931597854674
+Illinois,1925,13712,Project Tycho - https://zenodo.org/records/11452259,187.49386392419515
+Illinois,1926,8500,Project Tycho - https://zenodo.org/records/11452259,114.82770103459758
+Illinois,1927,20012,Project Tycho - https://zenodo.org/records/11452259,265.8865273574676
+Illinois,1928,9406,Project Tycho - https://zenodo.org/records/11452259,124.03119583689805
+Illinois,1929,55025,Project Tycho - https://zenodo.org/records/11452259,722.7193001581642
+Illinois,1930,17913,Project Tycho - https://zenodo.org/records/11452259,234.10655278787146
+Illinois,1931,53774,Project Tycho - https://zenodo.org/records/11452259,698.8458399932317
+Illinois,1932,26112,Project Tycho - https://zenodo.org/records/11452259,337.2015781529742
+Illinois,1933,20781,Project Tycho - https://zenodo.org/records/11452259,267.25334397836974
+Illinois,1934,57797,Project Tycho - https://zenodo.org/records/11452259,742.9138026152951
+Illinois,1935,80971,Project Tycho - https://zenodo.org/records/11452259,1037.451710787609
+Illinois,1936,1722,Project Tycho - https://zenodo.org/records/11452259,21.9423433709148
+Illinois,1937,18086,Project Tycho - https://zenodo.org/records/11452259,229.95968013150144
+Illinois,1938,127935,Project Tycho - https://zenodo.org/records/11452259,1624.8054005491078
+Illinois,1939,1740,Project Tycho - https://zenodo.org/records/11452259,22.03120073842507
+Illinois,1940,14238,Project Tycho - https://zenodo.org/records/11452259,179.93391807433554
+Illinois,1941,75370,Project Tycho - https://zenodo.org/records/11452259,941.7724239487842
+Illinois,1942,13822,Project Tycho - https://zenodo.org/records/11452259,171.3813057985827
+Illinois,1943,40551,Project Tycho - https://zenodo.org/records/11452259,521.9751257632973
+Illinois,1944,21263,Project Tycho - https://zenodo.org/records/11452259,275.18795493921806
+Illinois,1945,12697,Project Tycho - https://zenodo.org/records/11452259,166.87693309190482
+Illinois,1946,38721,Project Tycho - https://zenodo.org/records/11452259,474.33865950113653
+Illinois,1947,10090,Project Tycho - https://zenodo.org/records/11452259,120.84786092698813
+Illinois,1948,52639,Project Tycho - https://zenodo.org/records/11452259,614.9019362302804
+Illinois,1949,5715,Project Tycho - https://zenodo.org/records/11452259,65.85110391338766
+Illinois,1950,18801,Project Tycho - https://zenodo.org/records/11452259,214.94870430553655
+Illinois,1951,16620,Project Tycho - https://zenodo.org/records/11452259,188.8896086848305
+Illinois,1952,39777,Project Tycho - https://zenodo.org/records/11452259,443.6943137255777
+Illinois,1953,19709,Project Tycho - https://zenodo.org/records/11452259,217.2014416912376
+Illinois,1954,33190,Project Tycho - https://zenodo.org/records/11452259,358.37487199354905
+Illinois,1955,13649,Project Tycho - https://zenodo.org/records/11452259,144.5189680483798
+Illinois,1956,42211,Project Tycho - https://zenodo.org/records/11452259,442.48511194995984
+Illinois,1957,9688,Project Tycho - https://zenodo.org/records/11452259,100.10676125694744
+Illinois,1958,22962,Project Tycho - https://zenodo.org/records/11452259,232.03581771253224
+Illinois,1959,9611,Project Tycho - https://zenodo.org/records/11452259,96.14859404564993
+Illinois,1960,22656,Project Tycho - https://zenodo.org/records/11452259,224.4037937077794
+Illinois,1961,16356,Project Tycho - https://zenodo.org/records/11452259,161.29970720296484
+Illinois,1962,16602,Project Tycho - https://zenodo.org/records/11452259,161.3367177569512
+Illinois,1963,10215,Project Tycho - https://zenodo.org/records/11452259,98.10416462983278
+Illinois,1964,15778,Project Tycho - https://zenodo.org/records/11452259,148.98145332927942
+Illinois,1965,4565,Project Tycho - https://zenodo.org/records/11452259,42.64883157616722
+Illinois,1966,11521,Project Tycho - https://zenodo.org/records/11452259,106.21530555085371
+Illinois,1967,1311,Project Tycho - https://zenodo.org/records/11452259,11.96391988389796
+Illinois,1968,1482,Project Tycho - https://zenodo.org/records/11452259,13.465388635920696
+Illinois,1969,1116,Project Tycho - https://zenodo.org/records/11452259,10.09951186597622
+Illinois,1970,3293,Project Tycho - https://zenodo.org/records/11452259,29.609594839496307
+Illinois,1971,3239,Project Tycho - https://zenodo.org/records/11452259,28.884571313812806
+Illinois,1972,4453,Project Tycho - https://zenodo.org/records/11452259,39.53583702108077
+Illinois,1973,2167,Project Tycho - https://zenodo.org/records/11452259,19.240641918246716
+Illinois,1974,2122,Project Tycho - https://zenodo.org/records/11452259,18.823058548316403
+Illinois,1975,1852,Project Tycho - https://zenodo.org/records/11452259,16.3849812360115
+Illinois,1976,2032,Project Tycho - https://zenodo.org/records/11452259,17.896469102389027
+Illinois,1977,1919,Project Tycho - https://zenodo.org/records/11452259,16.836727263092158
+Illinois,1978,825,Project Tycho - https://zenodo.org/records/11452259,7.221655723451027
+Illinois,1979,1284,Project Tycho - https://zenodo.org/records/11452259,11.255029591348634
+Illinois,1980,339,Project Tycho - https://zenodo.org/records/11452259,2.9616981660885386
+Illinois,1981,28,Project Tycho - https://zenodo.org/records/11452259,0.24443685720199587
+Illinois,1982,14,Project Tycho - https://zenodo.org/records/11452259,0.12243289911922647
+Illinois,1983,182,Project Tycho - https://zenodo.org/records/11452259,1.5936637330995025
+Illinois,1984,149,Project Tycho - https://zenodo.org/records/11452259,1.3043237720273146
+Illinois,1985,193,Project Tycho - https://zenodo.org/records/11452259,1.6913200665486248
+Illinois,1986,380,Project Tycho - https://zenodo.org/records/11452259,3.3337298717286026
+Illinois,1987,182,Project Tycho - https://zenodo.org/records/11452259,1.5961315384278754
+Illinois,1988,46,Project Tycho - https://zenodo.org/records/11452259,0.4034531024798069
+Illinois,1989,238,Project Tycho - https://zenodo.org/records/11452259,2.0838457215188857
+Illinois,1990,5,Project Tycho - https://zenodo.org/records/11452259,0.043636014548247254
+Illinois,1991,28,https://stacks.cdc.gov/view/cdc/36010,0.2424765585786994
+Illinois,1992,18,https://stacks.cdc.gov/view/cdc/36063,0.15454846433777011
+Illinois,1993,9,https://stacks.cdc.gov/view/cdc/5650,0.07667595098839135
+Illinois,1994,44,Project Tycho - https://zenodo.org/records/11452259,0.37235154386258873
+Illinois,1995,2,Project Tycho - https://zenodo.org/records/11452259,0.01681121651090094
+Illinois,1996,3,Project Tycho - https://zenodo.org/records/11452259,0.025073222166466805
+Illinois,1997,5,Project Tycho - https://zenodo.org/records/11452259,0.04158515975354971
+Illinois,1998,1,Project Tycho - https://zenodo.org/records/11452259,0.008276882922580603
+Illinois,1999,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.016473788801744375
+Illinois,2000,3,Project Tycho - https://zenodo.org/records/11452259,0.024102977561333037
+Illinois,2001,3,Project Tycho - https://zenodo.org/records/11452259,0.02399820877369713
+Illinois,2002,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.0079757021828141
+Illinois,2003,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.007956359685380079
+Illinois,2004,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.007935020435058126
+Illinois,2005,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.015844706663776593
+Illinois,2006,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.0
+Illinois,2007,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.007868711492984926
+Illinois,2008,32,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.2507879247181673
+Illinois,2009,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.0
+Illinois,2010,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.0
+Illinois,2011,3,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.023290750078606284
+Illinois,2012,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.0
+Illinois,2013,5,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.03873364829986785
+Illinois,2014,2,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.015506307694609782
+Illinois,2015,17,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.13206505306995314
+Illinois,2016,2,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.01558296252375428
+Illinois,2017,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Illinois,2018,5,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0392544511996121
+Illinois,2019,9,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.07097968687547734
+Illinois,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Illinois,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Illinois,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Indiana,1891,9,Project Tycho - https://zenodo.org/records/11452259,
+Indiana,1892,2,Project Tycho - https://zenodo.org/records/11452259,
+Indiana,1893,4,Project Tycho - https://zenodo.org/records/11452259,
+Indiana,1894,2,Project Tycho - https://zenodo.org/records/11452259,
+Indiana,1895,1,Project Tycho - https://zenodo.org/records/11452259,
+Indiana,1897,1,Project Tycho - https://zenodo.org/records/11452259,
+Indiana,1898,4,Project Tycho - https://zenodo.org/records/11452259,
+Indiana,1899,1,Project Tycho - https://zenodo.org/records/11452259,
+Indiana,1900,9,Project Tycho - https://zenodo.org/records/11452259,0.35706945953173114
+Indiana,1902,2,Project Tycho - https://zenodo.org/records/11452259,0.07783412536042064
+Indiana,1903,4,Project Tycho - https://zenodo.org/records/11452259,0.15404795666939075
+Indiana,1904,1,Project Tycho - https://zenodo.org/records/11452259,0.03821732972459828
+Indiana,1906,37,Project Tycho - https://zenodo.org/records/11452259,1.3880224169371749
+Indiana,1907,10508,Project Tycho - https://zenodo.org/records/11452259,391.8440648563829
+Indiana,1908,1492,Project Tycho - https://zenodo.org/records/11452259,55.67835227902468
+Indiana,1909,2382,Project Tycho - https://zenodo.org/records/11452259,88.85811723750484
+Indiana,1910,9715,Project Tycho - https://zenodo.org/records/11452259,357.7329415884521
+Indiana,1911,1175,Project Tycho - https://zenodo.org/records/11452259,42.66907211291072
+Indiana,1912,257,Project Tycho - https://zenodo.org/records/11452259,9.218788392935611
+Indiana,1913,1483,Project Tycho - https://zenodo.org/records/11452259,52.461702603345664
+Indiana,1914,758,Project Tycho - https://zenodo.org/records/11452259,26.50482174458373
+Indiana,1915,1033,Project Tycho - https://zenodo.org/records/11452259,35.91952773992454
+Indiana,1916,1745,Project Tycho - https://zenodo.org/records/11452259,60.17455102715717
+Indiana,1917,8482,Project Tycho - https://zenodo.org/records/11452259,291.18647675348706
+Indiana,1918,2091,Project Tycho - https://zenodo.org/records/11452259,72.53163503163503
+Indiana,1919,1324,Project Tycho - https://zenodo.org/records/11452259,45.51539307217215
+Indiana,1920,10604,Project Tycho - https://zenodo.org/records/11452259,359.46408528695605
+Indiana,1921,928,Project Tycho - https://zenodo.org/records/11452259,31.151644054869863
+Indiana,1922,1785,Project Tycho - https://zenodo.org/records/11452259,60.142218658238896
+Indiana,1923,11699,Project Tycho - https://zenodo.org/records/11452259,384.19831319239603
+Indiana,1924,1526,Project Tycho - https://zenodo.org/records/11452259,49.39972535565536
+Indiana,1925,1024,Project Tycho - https://zenodo.org/records/11452259,32.79823735097861
+Indiana,1926,12291,Project Tycho - https://zenodo.org/records/11452259,390.0483252452757
+Indiana,1927,1407,Project Tycho - https://zenodo.org/records/11452259,44.04871217782531
+Indiana,1928,10945,Project Tycho - https://zenodo.org/records/11452259,340.4130116458884
+Indiana,1929,13840,Project Tycho - https://zenodo.org/records/11452259,428.58567347098034
+Indiana,1930,4950,Project Tycho - https://zenodo.org/records/11452259,152.530997688308
+Indiana,1931,23864,Project Tycho - https://zenodo.org/records/11452259,731.9668357433171
+Indiana,1932,3541,Project Tycho - https://zenodo.org/records/11452259,107.81659669193958
+Indiana,1933,5940,Project Tycho - https://zenodo.org/records/11452259,179.6024798446106
+Indiana,1934,27830,Project Tycho - https://zenodo.org/records/11452259,837.6679060620007
+Indiana,1935,11487,Project Tycho - https://zenodo.org/records/11452259,344.4034956639998
+Indiana,1936,829,Project Tycho - https://zenodo.org/records/11452259,24.736315058895705
+Indiana,1937,11231,Project Tycho - https://zenodo.org/records/11452259,332.5364617599354
+Indiana,1938,23646,Project Tycho - https://zenodo.org/records/11452259,697.6484826455293
+Indiana,1939,642,Project Tycho - https://zenodo.org/records/11452259,18.846859869486963
+Indiana,1940,737,Project Tycho - https://zenodo.org/records/11452259,21.446657042345944
+Indiana,1941,21394,Project Tycho - https://zenodo.org/records/11452259,613.6269702161176
+Indiana,1942,4551,Project Tycho - https://zenodo.org/records/11452259,129.63939396787987
+Indiana,1943,13612,Project Tycho - https://zenodo.org/records/11452259,394.27084947525657
+Indiana,1944,6125,Project Tycho - https://zenodo.org/records/11452259,177.8744511302651
+Indiana,1945,1138,Project Tycho - https://zenodo.org/records/11452259,33.17371277686422
+Indiana,1946,17365,Project Tycho - https://zenodo.org/records/11452259,468.6021703849905
+Indiana,1947,2563,Project Tycho - https://zenodo.org/records/11452259,67.75442075786083
+Indiana,1948,18681,Project Tycho - https://zenodo.org/records/11452259,481.36026985652984
+Indiana,1949,3964,Project Tycho - https://zenodo.org/records/11452259,100.05154017281353
+Indiana,1950,7639,Project Tycho - https://zenodo.org/records/11452259,192.37127883460124
+Indiana,1951,4238,Project Tycho - https://zenodo.org/records/11452259,103.36343344155844
+Indiana,1952,10063,Project Tycho - https://zenodo.org/records/11452259,242.35648632948536
+Indiana,1953,8025,Project Tycho - https://zenodo.org/records/11452259,191.7021285744385
+Indiana,1954,22049,Project Tycho - https://zenodo.org/records/11452259,516.5800428464594
+Indiana,1955,3769,Project Tycho - https://zenodo.org/records/11452259,86.29921533886696
+Indiana,1956,16529,Project Tycho - https://zenodo.org/records/11452259,370.40124523300835
+Indiana,1957,8094,Project Tycho - https://zenodo.org/records/11452259,178.53641170046558
+Indiana,1958,18132,Project Tycho - https://zenodo.org/records/11452259,395.24080545245727
+Indiana,1959,4595,Project Tycho - https://zenodo.org/records/11452259,99.51028810773013
+Indiana,1960,10427,Project Tycho - https://zenodo.org/records/11452259,222.8622896145361
+Indiana,1961,5898,Project Tycho - https://zenodo.org/records/11452259,124.56887721158336
+Indiana,1962,7696,Project Tycho - https://zenodo.org/records/11452259,162.33766233766235
+Indiana,1963,5956,Project Tycho - https://zenodo.org/records/11452259,123.9852042102511
+Indiana,1964,22161,Project Tycho - https://zenodo.org/records/11452259,455.9073545893974
+Indiana,1965,2366,Project Tycho - https://zenodo.org/records/11452259,48.02186842008053
+Indiana,1966,5817,Project Tycho - https://zenodo.org/records/11452259,116.24702562890201
+Indiana,1967,694,Project Tycho - https://zenodo.org/records/11452259,13.72069450438736
+Indiana,1968,776,Project Tycho - https://zenodo.org/records/11452259,15.221377876001869
+Indiana,1969,537,Project Tycho - https://zenodo.org/records/11452259,10.430945682744245
+Indiana,1970,287,Project Tycho - https://zenodo.org/records/11452259,5.518607803311434
+Indiana,1971,3078,Project Tycho - https://zenodo.org/records/11452259,58.53214390235971
+Indiana,1972,1267,Project Tycho - https://zenodo.org/records/11452259,23.87081349358493
+Indiana,1973,713,Project Tycho - https://zenodo.org/records/11452259,13.343027145481102
+Indiana,1974,262,Project Tycho - https://zenodo.org/records/11452259,4.881456075000033
+Indiana,1975,511,Project Tycho - https://zenodo.org/records/11452259,9.513824928120354
+Indiana,1976,4337,Project Tycho - https://zenodo.org/records/11452259,80.39704312392101
+Indiana,1977,4260,Project Tycho - https://zenodo.org/records/11452259,78.43768337800537
+Indiana,1978,206,Project Tycho - https://zenodo.org/records/11452259,3.762087074418465
+Indiana,1979,187,Project Tycho - https://zenodo.org/records/11452259,3.3958786381981865
+Indiana,1980,112,Project Tycho - https://zenodo.org/records/11452259,2.037767472900877
+Indiana,1981,18,Project Tycho - https://zenodo.org/records/11452259,0.3281129948240175
+Indiana,1982,3,Project Tycho - https://zenodo.org/records/11452259,0.054810648393527305
+Indiana,1983,86,Project Tycho - https://zenodo.org/records/11452259,1.5762911153084445
+Indiana,1984,3,Project Tycho - https://zenodo.org/records/11452259,0.054907042377255307
+Indiana,1985,4,Project Tycho - https://zenodo.org/records/11452259,0.07319746663567975
+Indiana,1986,37,Project Tycho - https://zenodo.org/records/11452259,0.6777100434064124
+Indiana,1987,0,https://stacks.cdc.gov/view/cdc/35629,0.0
+Indiana,1988,56,Project Tycho - https://zenodo.org/records/11452259,1.018695611204633
+Indiana,1989,77,Project Tycho - https://zenodo.org/records/11452259,1.392602495543672
+Indiana,1990,249,Project Tycho - https://zenodo.org/records/11452259,4.4778921608473246
+Indiana,1991,6,Project Tycho - https://zenodo.org/records/11452259,0.10699642489278959
+Indiana,1992,11,Project Tycho - https://zenodo.org/records/11452259,0.1945423100342978
+Indiana,1993,1,Project Tycho - https://zenodo.org/records/11452259,0.017520296387349928
+Indiana,1994,1,Project Tycho - https://zenodo.org/records/11452259,0.01738715864443452
+Indiana,1995,0,https://stacks.cdc.gov/view/cdc/5644,0.0
+Indiana,1996,0,https://stacks.cdc.gov/view/cdc/5642,0.0
+Indiana,1997,0,"https://www.cdc.gov/mmwr/preview/mmwrhtml/00056071.htm#:~:text=As%20of%20January%201%2C%201997,and%20control%20of%20the%20disease.",0.0
+Indiana,1998,1,Project Tycho - https://zenodo.org/records/11452259,0.016910390487972993
+Indiana,1999,1,Project Tycho - https://zenodo.org/records/11452259,0.016809991455481343
+Indiana,2000,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4953a1.htm,0.0
+Indiana,2001,4,Project Tycho - https://zenodo.org/records/11452259,0.06521150454842092
+Indiana,2002,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.032456351886574135
+Indiana,2003,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.0
+Indiana,2004,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0
+Indiana,2005,33,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.5250685214420482
+Indiana,2006,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.015775356400795644
+Indiana,2007,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.0
+Indiana,2008,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.0
+Indiana,2009,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.0
+Indiana,2010,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.0
+Indiana,2011,14,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.21459993896164592
+Indiana,2012,15,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.22916412994706156
+Indiana,2013,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.030408330666269332
+Indiana,2014,1,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.015145514315161491
+Indiana,2015,0,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.0
+Indiana,2016,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.015049962111720385
+Indiana,2017,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Indiana,2018,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.014913844954773018
+Indiana,2019,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.014841769667311343
+Indiana,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Indiana,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Indiana,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Iowa,1889,8,Project Tycho - https://zenodo.org/records/11452259,
+Iowa,1894,2,Project Tycho - https://zenodo.org/records/11452259,
+Iowa,1895,1,Project Tycho - https://zenodo.org/records/11452259,
+Iowa,1897,4,Project Tycho - https://zenodo.org/records/11452259,
+Iowa,1902,3,Project Tycho - https://zenodo.org/records/11452259,0.13487862272740758
+Iowa,1905,1,Project Tycho - https://zenodo.org/records/11452259,0.04518322021714152
+Iowa,1907,476,Project Tycho - https://zenodo.org/records/11452259,21.449006564026863
+Iowa,1908,597,Project Tycho - https://zenodo.org/records/11452259,26.865026865026863
+Iowa,1909,55,Project Tycho - https://zenodo.org/records/11452259,2.4716623906907307
+Iowa,1910,1,Project Tycho - https://zenodo.org/records/11452259,0.044838464946184875
+Iowa,1911,12,Project Tycho - https://zenodo.org/records/11452259,0.5330374383286789
+Iowa,1912,1,Project Tycho - https://zenodo.org/records/11452259,0.04383505919267218
+Iowa,1913,195,Project Tycho - https://zenodo.org/records/11452259,8.451418429726456
+Iowa,1914,9,Project Tycho - https://zenodo.org/records/11452259,0.3845598370833615
+Iowa,1915,30,Project Tycho - https://zenodo.org/records/11452259,1.2666961103140308
+Iowa,1916,176,Project Tycho - https://zenodo.org/records/11452259,7.400007400007399
+Iowa,1917,608,Project Tycho - https://zenodo.org/records/11452259,25.49926983176353
+Iowa,1918,630,Project Tycho - https://zenodo.org/records/11452259,26.770337276504865
+Iowa,1919,201,Project Tycho - https://zenodo.org/records/11452259,8.440487633425843
+Iowa,1920,1085,Project Tycho - https://zenodo.org/records/11452259,45.163170163170165
+Iowa,1921,894,Project Tycho - https://zenodo.org/records/11452259,37.1045655632278
+Iowa,1922,274,Project Tycho - https://zenodo.org/records/11452259,11.27373450272956
+Iowa,1923,3507,Project Tycho - https://zenodo.org/records/11452259,144.47408261841252
+Iowa,1924,217,Project Tycho - https://zenodo.org/records/11452259,8.957984164595734
+Iowa,1925,74,Project Tycho - https://zenodo.org/records/11452259,3.045985740670537
+Iowa,1926,1985,Project Tycho - https://zenodo.org/records/11452259,81.53852726221147
+Iowa,1927,2646,Project Tycho - https://zenodo.org/records/11452259,108.28990755250484
+Iowa,1928,1031,Project Tycho - https://zenodo.org/records/11452259,42.03959306000122
+Iowa,1929,2705,Project Tycho - https://zenodo.org/records/11452259,109.84950009340253
+Iowa,1930,12857,Project Tycho - https://zenodo.org/records/11452259,518.9557916830645
+Iowa,1931,977,Project Tycho - https://zenodo.org/records/11452259,39.32409250700951
+Iowa,1932,192,Project Tycho - https://zenodo.org/records/11452259,7.706235106797581
+Iowa,1933,977,Project Tycho - https://zenodo.org/records/11452259,39.1191974358307
+Iowa,1934,12282,Project Tycho - https://zenodo.org/records/11452259,488.8338752880586
+Iowa,1935,26008,Project Tycho - https://zenodo.org/records/11452259,1029.3984937408075
+Iowa,1936,285,Project Tycho - https://zenodo.org/records/11452259,11.34775945457492
+Iowa,1937,355,Project Tycho - https://zenodo.org/records/11452259,14.197171923352867
+Iowa,1938,7858,Project Tycho - https://zenodo.org/records/11452259,314.76142141739575
+Iowa,1939,5300,Project Tycho - https://zenodo.org/records/11452259,210.10735296449582
+Iowa,1940,6731,Project Tycho - https://zenodo.org/records/11452259,265.04831392493986
+Iowa,1941,5437,Project Tycho - https://zenodo.org/records/11452259,218.04770901519194
+Iowa,1942,6287,Project Tycho - https://zenodo.org/records/11452259,257.5120656301468
+Iowa,1943,5674,Project Tycho - https://zenodo.org/records/11452259,242.8591117537133
+Iowa,1944,4763,Project Tycho - https://zenodo.org/records/11452259,206.79016767673875
+Iowa,1945,1253,Project Tycho - https://zenodo.org/records/11452259,54.235192883373124
+Iowa,1946,4267,Project Tycho - https://zenodo.org/records/11452259,172.79032277005524
+Iowa,1947,4567,Project Tycho - https://zenodo.org/records/11452259,181.842868172083
+Iowa,1948,9013,Project Tycho - https://zenodo.org/records/11452259,354.06983893024005
+Iowa,1949,2243,Project Tycho - https://zenodo.org/records/11452259,86.91851205427622
+Iowa,1950,10871,Project Tycho - https://zenodo.org/records/11452259,413.71961371961373
+Iowa,1951,2743,Project Tycho - https://zenodo.org/records/11452259,104.70996332670003
+Iowa,1952,3827,Project Tycho - https://zenodo.org/records/11452259,145.58936874245327
+Iowa,1953,11606,Project Tycho - https://zenodo.org/records/11452259,441.01961180698345
+Iowa,1954,12530,Project Tycho - https://zenodo.org/records/11452259,476.6748864235536
+Iowa,1955,7679,Project Tycho - https://zenodo.org/records/11452259,286.3504543235786
+Iowa,1956,8380,Project Tycho - https://zenodo.org/records/11452259,309.716180970343
+Iowa,1957,8927,Project Tycho - https://zenodo.org/records/11452259,328.3535315935905
+Iowa,1958,12546,Project Tycho - https://zenodo.org/records/11452259,462.83111275725753
+Iowa,1959,11468,Project Tycho - https://zenodo.org/records/11452259,419.80738206461916
+Iowa,1960,1764,Project Tycho - https://zenodo.org/records/11452259,63.94186365158789
+Iowa,1961,5415,Project Tycho - https://zenodo.org/records/11452259,196.28412226380294
+Iowa,1962,11107,Project Tycho - https://zenodo.org/records/11452259,403.48742166923984
+Iowa,1963,7319,Project Tycho - https://zenodo.org/records/11452259,266.16994218013514
+Iowa,1964,22495,Project Tycho - https://zenodo.org/records/11452259,818.3731781692452
+Iowa,1965,9309,Project Tycho - https://zenodo.org/records/11452259,339.15756016412473
+Iowa,1966,5453,Project Tycho - https://zenodo.org/records/11452259,197.23216681942242
+Iowa,1967,829,Project Tycho - https://zenodo.org/records/11452259,29.651694528171436
+Iowa,1968,167,Project Tycho - https://zenodo.org/records/11452259,5.951950297294571
+Iowa,1969,268,Project Tycho - https://zenodo.org/records/11452259,9.544822379046979
+Iowa,1970,199,Project Tycho - https://zenodo.org/records/11452259,7.036294906323579
+Iowa,1971,2702,Project Tycho - https://zenodo.org/records/11452259,94.6557012719316
+Iowa,1972,916,Project Tycho - https://zenodo.org/records/11452259,31.99276879601362
+Iowa,1973,288,Project Tycho - https://zenodo.org/records/11452259,10.046822378459613
+Iowa,1974,62,Project Tycho - https://zenodo.org/records/11452259,2.159979960960104
+Iowa,1975,700,Project Tycho - https://zenodo.org/records/11452259,24.274142455232415
+Iowa,1976,27,Project Tycho - https://zenodo.org/records/11452259,0.9291169775480603
+Iowa,1977,4129,Project Tycho - https://zenodo.org/records/11452259,141.57448381374024
+Iowa,1978,77,Project Tycho - https://zenodo.org/records/11452259,2.636095265059379
+Iowa,1979,10,Project Tycho - https://zenodo.org/records/11452259,0.34262368886479866
+Iowa,1980,1,Project Tycho - https://zenodo.org/records/11452259,0.034282595549022056
+Iowa,1981,1,Project Tycho - https://zenodo.org/records/11452259,0.03435375435004415
+Iowa,1982,0,https://stacks.cdc.gov/view/cdc/35066,0.0
+Iowa,1983,0,https://stacks.cdc.gov/view/cdc/35188,0.0
+Iowa,1984,0,https://stacks.cdc.gov/view/cdc/35267,0.0
+Iowa,1985,0,https://stacks.cdc.gov/view/cdc/35429,0.0
+Iowa,1986,142,Project Tycho - https://zenodo.org/records/11452259,5.0809353644193544
+Iowa,1987,0,https://stacks.cdc.gov/view/cdc/35629,0.0
+Iowa,1988,1,Project Tycho - https://zenodo.org/records/11452259,0.03608602330579729
+Iowa,1989,22,Project Tycho - https://zenodo.org/records/11452259,0.7932610311960718
+Iowa,1990,16,Project Tycho - https://zenodo.org/records/11452259,0.5750125424610825
+Iowa,1991,16,Project Tycho - https://zenodo.org/records/11452259,0.5726520015261175
+Iowa,1992,2,Project Tycho - https://zenodo.org/records/11452259,0.07118124203437413
+Iowa,1993,0,https://stacks.cdc.gov/view/cdc/5650,0.0
+Iowa,1994,7,Project Tycho - https://zenodo.org/records/11452259,0.2471532360655888
+Iowa,1995,0,https://stacks.cdc.gov/view/cdc/5644,0.0
+Iowa,1996,1,https://stacks.cdc.gov/view/cdc/5642,0.03507146336733044
+Iowa,1997,0,"https://www.cdc.gov/mmwr/preview/mmwrhtml/00056071.htm#:~:text=As%20of%20January%201%2C%201997,and%20control%20of%20the%20disease.",0.0
+Iowa,1998,1,Project Tycho - https://zenodo.org/records/11452259,0.03491759099349625
+Iowa,1999,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.0
+Iowa,2000,2,Project Tycho - https://zenodo.org/records/11452259,0.0682129170708282
+Iowa,2001,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5053a1.htm,0.0
+Iowa,2002,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.0
+Iowa,2003,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.0
+Iowa,2004,3,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.10146831415131226
+Iowa,2005,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.0
+Iowa,2006,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.0
+Iowa,2007,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.0
+Iowa,2008,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.0
+Iowa,2009,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.03293913966919881
+Iowa,2010,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.0
+Iowa,2011,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.0325750088441149
+Iowa,2012,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.0
+Iowa,2013,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.0
+Iowa,2014,0,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.0
+Iowa,2015,0,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.0
+Iowa,2016,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Iowa,2017,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Iowa,2018,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Iowa,2019,2,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.06323600784758858
+Iowa,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Iowa,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Iowa,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Kansas,1896,4,Project Tycho - https://zenodo.org/records/11452259,
+Kansas,1899,1,Project Tycho - https://zenodo.org/records/11452259,
+Kansas,1903,3,Project Tycho - https://zenodo.org/records/11452259,0.20006695574118805
+Kansas,1907,1455,Project Tycho - https://zenodo.org/records/11452259,90.17037553017701
+Kansas,1908,169,Project Tycho - https://zenodo.org/records/11452259,10.364098761888817
+Kansas,1909,838,Project Tycho - https://zenodo.org/records/11452259,50.49233034757763
+Kansas,1910,1175,Project Tycho - https://zenodo.org/records/11452259,69.37506937506937
+Kansas,1911,353,Project Tycho - https://zenodo.org/records/11452259,20.941054195210963
+Kansas,1912,46,Project Tycho - https://zenodo.org/records/11452259,2.750092516699339
+Kansas,1913,813,Project Tycho - https://zenodo.org/records/11452259,48.838713901852806
+Kansas,1914,425,Project Tycho - https://zenodo.org/records/11452259,25.546054426920854
+Kansas,1915,223,Project Tycho - https://zenodo.org/records/11452259,13.205525950042846
+Kansas,1916,897,Project Tycho - https://zenodo.org/records/11452259,51.88789207318449
+Kansas,1917,2955,Project Tycho - https://zenodo.org/records/11452259,168.88146178764026
+Kansas,1918,2522,Project Tycho - https://zenodo.org/records/11452259,145.71894271142392
+Kansas,1919,315,Project Tycho - https://zenodo.org/records/11452259,17.920576007136372
+Kansas,1920,2770,Project Tycho - https://zenodo.org/records/11452259,156.42921239303377
+Kansas,1921,2841,Project Tycho - https://zenodo.org/records/11452259,159.5369217628914
+Kansas,1922,179,Project Tycho - https://zenodo.org/records/11452259,9.940032174606937
+Kansas,1923,4561,Project Tycho - https://zenodo.org/records/11452259,252.01568343161264
+Kansas,1924,5016,Project Tycho - https://zenodo.org/records/11452259,277.3098511892092
+Kansas,1925,53,Project Tycho - https://zenodo.org/records/11452259,2.9012083806604356
+Kansas,1926,1662,Project Tycho - https://zenodo.org/records/11452259,90.43244337361985
+Kansas,1927,2719,Project Tycho - https://zenodo.org/records/11452259,147.9457361810303
+Kansas,1928,2904,Project Tycho - https://zenodo.org/records/11452259,156.81615681615682
+Kansas,1929,12094,Project Tycho - https://zenodo.org/records/11452259,647.1300525933627
+Kansas,1930,15317,Project Tycho - https://zenodo.org/records/11452259,812.6233829898196
+Kansas,1931,1885,Project Tycho - https://zenodo.org/records/11452259,100.11254030392787
+Kansas,1932,8229,Project Tycho - https://zenodo.org/records/11452259,436.5788221337876
+Kansas,1933,7892,Project Tycho - https://zenodo.org/records/11452259,420.0381398037232
+Kansas,1934,11222,Project Tycho - https://zenodo.org/records/11452259,600.1493153527415
+Kansas,1935,31569,Project Tycho - https://zenodo.org/records/11452259,1684.6935116165887
+Kansas,1936,472,Project Tycho - https://zenodo.org/records/11452259,25.228917684776434
+Kansas,1937,1057,Project Tycho - https://zenodo.org/records/11452259,56.89353749698577
+Kansas,1938,12663,Project Tycho - https://zenodo.org/records/11452259,686.7725108767454
+Kansas,1939,2439,Project Tycho - https://zenodo.org/records/11452259,133.5835217414165
+Kansas,1940,13966,Project Tycho - https://zenodo.org/records/11452259,780.315880987022
+Kansas,1941,16091,Project Tycho - https://zenodo.org/records/11452259,910.7606274745085
+Kansas,1942,10958,Project Tycho - https://zenodo.org/records/11452259,621.9916447189174
+Kansas,1943,13470,Project Tycho - https://zenodo.org/records/11452259,749.2507492507493
+Kansas,1944,12802,Project Tycho - https://zenodo.org/records/11452259,718.8988639241591
+Kansas,1945,1326,Project Tycho - https://zenodo.org/records/11452259,76.52659299106439
+Kansas,1946,15429,Project Tycho - https://zenodo.org/records/11452259,853.9383054618512
+Kansas,1947,506,Project Tycho - https://zenodo.org/records/11452259,27.27978982701055
+Kansas,1948,1363,Project Tycho - https://zenodo.org/records/11452259,71.96820093226013
+Kansas,1949,16984,Project Tycho - https://zenodo.org/records/11452259,881.4043099757386
+Kansas,1950,2124,Project Tycho - https://zenodo.org/records/11452259,110.74520469092494
+Kansas,1951,10888,Project Tycho - https://zenodo.org/records/11452259,557.8011731857886
+Kansas,1952,15306,Project Tycho - https://zenodo.org/records/11452259,773.4299084830193
+Kansas,1953,19937,Project Tycho - https://zenodo.org/records/11452259,998.8506979479897
+Kansas,1954,1355,Project Tycho - https://zenodo.org/records/11452259,66.29022299933172
+Kansas,1955,3046,Project Tycho - https://zenodo.org/records/11452259,145.38734080062318
+Kansas,1956,4255,Project Tycho - https://zenodo.org/records/11452259,200.60166355588723
+Kansas,1957,12,Project Tycho - https://zenodo.org/records/11452259,0.5633464280080822
+Kansas,1958,71,Project Tycho - https://zenodo.org/records/11452259,3.3113478491629755
+Kansas,1967,97,Project Tycho - https://zenodo.org/records/11452259,4.410700814888344
+Kansas,1968,21,Project Tycho - https://zenodo.org/records/11452259,0.9467067228800081
+Kansas,1969,9,Project Tycho - https://zenodo.org/records/11452259,0.4021023699020121
+Kansas,1970,76,Project Tycho - https://zenodo.org/records/11452259,3.3757973100225644
+Kansas,1971,1399,Project Tycho - https://zenodo.org/records/11452259,62.20968443370511
+Kansas,1972,39,Project Tycho - https://zenodo.org/records/11452259,1.7267096750199566
+Kansas,1973,27,Project Tycho - https://zenodo.org/records/11452259,1.1905454814830494
+Kansas,1974,168,Project Tycho - https://zenodo.org/records/11452259,7.3951213328121534
+Kansas,1975,2147,Project Tycho - https://zenodo.org/records/11452259,94.04877570133579
+Kansas,1976,745,Project Tycho - https://zenodo.org/records/11452259,32.34486836723973
+Kansas,1977,1196,Project Tycho - https://zenodo.org/records/11452259,51.48587991133753
+Kansas,1978,95,Project Tycho - https://zenodo.org/records/11452259,4.0633158710551625
+Kansas,1979,75,Project Tycho - https://zenodo.org/records/11452259,3.1870735695563934
+Kansas,1980,71,Project Tycho - https://zenodo.org/records/11452259,2.9940018756789213
+Kansas,1981,1,Project Tycho - https://zenodo.org/records/11452259,0.04188950135994266
+Kansas,1982,44,Project Tycho - https://zenodo.org/records/11452259,1.830585167350848
+Kansas,1983,6,Project Tycho - https://zenodo.org/records/11452259,0.2481444995049517
+Kansas,1984,5,https://stacks.cdc.gov/view/cdc/35267,0.20605725919118403
+Kansas,1985,1,Project Tycho - https://zenodo.org/records/11452259,0.041155108665948924
+Kansas,1986,99,Project Tycho - https://zenodo.org/records/11452259,4.065623266206745
+Kansas,1987,1,Project Tycho - https://zenodo.org/records/11452259,0.04085281059166309
+Kansas,1988,1,Project Tycho - https://zenodo.org/records/11452259,0.04057688975705399
+Kansas,1989,106,Project Tycho - https://zenodo.org/records/11452259,4.282272885011682
+Kansas,1990,235,Project Tycho - https://zenodo.org/records/11452259,9.463736371716234
+Kansas,1991,3,Project Tycho - https://zenodo.org/records/11452259,0.12011030930806853
+Kansas,1992,2,Project Tycho - https://zenodo.org/records/11452259,0.07909615244676038
+Kansas,1993,2,Project Tycho - https://zenodo.org/records/11452259,0.07842669770272517
+Kansas,1994,1,Project Tycho - https://zenodo.org/records/11452259,0.03888498094830358
+Kansas,1995,1,Project Tycho - https://zenodo.org/records/11452259,0.038617076162142286
+Kansas,1996,1,Project Tycho - https://zenodo.org/records/11452259,0.03844876164228502
+Kansas,1997,0,"https://www.cdc.gov/mmwr/preview/mmwrhtml/00056071.htm#:~:text=As%20of%20January%201%2C%201997,and%20control%20of%20the%20disease.",0.0
+Kansas,1998,0,https://stacks.cdc.gov/view/cdc/5637,0.0
+Kansas,1999,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.0
+Kansas,2000,2,Project Tycho - https://zenodo.org/records/11452259,0.07417368658798816
+Kansas,2001,1,Project Tycho - https://zenodo.org/records/11452259,0.03697043548215363
+Kansas,2002,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.0
+Kansas,2003,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.0
+Kansas,2004,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0
+Kansas,2005,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.0
+Kansas,2006,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.03615730307015276
+Kansas,2007,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.0
+Kansas,2008,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.0
+Kansas,2009,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.0
+Kansas,2010,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.0
+Kansas,2011,6,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.2088739397036636
+Kansas,2012,6,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.20769078995191959
+Kansas,2013,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.0
+Kansas,2014,14,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.4819671973125509
+Kansas,2015,0,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.0
+Kansas,2016,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Kansas,2017,2,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.06863884368258379
+Kansas,2018,21,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.7202485886557418
+Kansas,2019,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Kansas,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Kansas,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Kansas,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Kentucky,1889,12,Project Tycho - https://zenodo.org/records/11452259,
+Kentucky,1890,2,Project Tycho - https://zenodo.org/records/11452259,
+Kentucky,1891,4,Project Tycho - https://zenodo.org/records/11452259,
+Kentucky,1893,13,Project Tycho - https://zenodo.org/records/11452259,
+Kentucky,1899,6,Project Tycho - https://zenodo.org/records/11452259,
+Kentucky,1900,5,Project Tycho - https://zenodo.org/records/11452259,0.2325421319834728
+Kentucky,1902,7,Project Tycho - https://zenodo.org/records/11452259,0.32122218617395465
+Kentucky,1903,5,Project Tycho - https://zenodo.org/records/11452259,0.22797832017366476
+Kentucky,1904,11,Project Tycho - https://zenodo.org/records/11452259,0.4983678453066208
+Kentucky,1906,8,Project Tycho - https://zenodo.org/records/11452259,0.3577443147720677
+Kentucky,1907,464,Project Tycho - https://zenodo.org/records/11452259,20.610780948708918
+Kentucky,1908,231,Project Tycho - https://zenodo.org/records/11452259,10.19749141711139
+Kentucky,1909,21,Project Tycho - https://zenodo.org/records/11452259,0.9209403414846786
+Kentucky,1910,943,Project Tycho - https://zenodo.org/records/11452259,40.97685698381653
+Kentucky,1911,290,Project Tycho - https://zenodo.org/records/11452259,12.466019350700934
+Kentucky,1912,129,Project Tycho - https://zenodo.org/records/11452259,5.490887467879372
+Kentucky,1913,184,Project Tycho - https://zenodo.org/records/11452259,7.742888956031331
+Kentucky,1914,330,Project Tycho - https://zenodo.org/records/11452259,13.764940696047166
+Kentucky,1915,420,Project Tycho - https://zenodo.org/records/11452259,17.475236134128263
+Kentucky,1916,520,Project Tycho - https://zenodo.org/records/11452259,21.546267917068416
+Kentucky,1917,670,Project Tycho - https://zenodo.org/records/11452259,27.646867795566678
+Kentucky,1918,994,Project Tycho - https://zenodo.org/records/11452259,40.94874197966981
+Kentucky,1919,415,Project Tycho - https://zenodo.org/records/11452259,17.181326754472217
+Kentucky,1920,1226,Project Tycho - https://zenodo.org/records/11452259,50.58964166770858
+Kentucky,1921,958,Project Tycho - https://zenodo.org/records/11452259,39.28747771112303
+Kentucky,1922,2300,Project Tycho - https://zenodo.org/records/11452259,93.783767253155
+Kentucky,1923,1393,Project Tycho - https://zenodo.org/records/11452259,56.11324159711257
+Kentucky,1924,581,Project Tycho - https://zenodo.org/records/11452259,22.93242119397789
+Kentucky,1925,89,Project Tycho - https://zenodo.org/records/11452259,3.5282178139320997
+Kentucky,1926,3772,Project Tycho - https://zenodo.org/records/11452259,148.06411662993196
+Kentucky,1927,109,Project Tycho - https://zenodo.org/records/11452259,4.268565617056406
+Kentucky,1928,7449,Project Tycho - https://zenodo.org/records/11452259,289.8931999048867
+Kentucky,1929,1225,Project Tycho - https://zenodo.org/records/11452259,46.959947190185105
+Kentucky,1930,1802,Project Tycho - https://zenodo.org/records/11452259,68.63133054516966
+Kentucky,1931,5105,Project Tycho - https://zenodo.org/records/11452259,192.30392533559953
+Kentucky,1932,1999,Project Tycho - https://zenodo.org/records/11452259,74.62641991789974
+Kentucky,1933,1954,Project Tycho - https://zenodo.org/records/11452259,72.35166612483144
+Kentucky,1934,14054,Project Tycho - https://zenodo.org/records/11452259,515.7957398956664
+Kentucky,1935,19597,Project Tycho - https://zenodo.org/records/11452259,712.4244023807343
+Kentucky,1936,2703,Project Tycho - https://zenodo.org/records/11452259,97.55417992412212
+Kentucky,1937,8671,Project Tycho - https://zenodo.org/records/11452259,311.1471861471862
+Kentucky,1938,14689,Project Tycho - https://zenodo.org/records/11452259,524.0830597973455
+Kentucky,1939,1343,Project Tycho - https://zenodo.org/records/11452259,47.492330678171385
+Kentucky,1940,4527,Project Tycho - https://zenodo.org/records/11452259,158.18389375577203
+Kentucky,1941,24467,Project Tycho - https://zenodo.org/records/11452259,865.5296544814959
+Kentucky,1942,1881,Project Tycho - https://zenodo.org/records/11452259,67.18344222813296
+Kentucky,1943,10819,Project Tycho - https://zenodo.org/records/11452259,401.34392158157476
+Kentucky,1944,2181,Project Tycho - https://zenodo.org/records/11452259,82.81342374842944
+Kentucky,1945,1639,Project Tycho - https://zenodo.org/records/11452259,63.04823401473383
+Kentucky,1946,7965,Project Tycho - https://zenodo.org/records/11452259,288.1942396610995
+Kentucky,1947,635,Project Tycho - https://zenodo.org/records/11452259,22.631667298096126
+Kentucky,1948,3620,Project Tycho - https://zenodo.org/records/11452259,128.377125182237
+Kentucky,1949,8393,Project Tycho - https://zenodo.org/records/11452259,294.3002943002943
+Kentucky,1950,5372,Project Tycho - https://zenodo.org/records/11452259,182.78724000794847
+Kentucky,1951,8696,Project Tycho - https://zenodo.org/records/11452259,295.38635454990435
+Kentucky,1952,10111,Project Tycho - https://zenodo.org/records/11452259,345.92120208558566
+Kentucky,1953,4047,Project Tycho - https://zenodo.org/records/11452259,139.2682412317273
+Kentucky,1954,29774,Project Tycho - https://zenodo.org/records/11452259,1024.9571241990263
+Kentucky,1955,2213,Project Tycho - https://zenodo.org/records/11452259,75.97213782780793
+Kentucky,1956,18138,Project Tycho - https://zenodo.org/records/11452259,625.2546625217433
+Kentucky,1957,15998,Project Tycho - https://zenodo.org/records/11452259,545.8339474732918
+Kentucky,1958,18230,Project Tycho - https://zenodo.org/records/11452259,615.0553263015269
+Kentucky,1959,6647,Project Tycho - https://zenodo.org/records/11452259,221.41912772122842
+Kentucky,1960,10734,Project Tycho - https://zenodo.org/records/11452259,352.62337136720566
+Kentucky,1961,11442,Project Tycho - https://zenodo.org/records/11452259,374.2819066984096
+Kentucky,1962,6169,Project Tycho - https://zenodo.org/records/11452259,200.15710174852757
+Kentucky,1963,9057,Project Tycho - https://zenodo.org/records/11452259,292.24651317674574
+Kentucky,1964,14715,Project Tycho - https://zenodo.org/records/11452259,469.80823586767974
+Kentucky,1965,3802,Project Tycho - https://zenodo.org/records/11452259,120.96184070706363
+Kentucky,1966,4852,Project Tycho - https://zenodo.org/records/11452259,154.02455821902913
+Kentucky,1967,1488,Project Tycho - https://zenodo.org/records/11452259,46.863602979618115
+Kentucky,1968,139,Project Tycho - https://zenodo.org/records/11452259,4.346201529300121
+Kentucky,1969,71,Project Tycho - https://zenodo.org/records/11452259,2.2179196663249194
+Kentucky,1970,1070,Project Tycho - https://zenodo.org/records/11452259,33.189295924757694
+Kentucky,1971,3717,Project Tycho - https://zenodo.org/records/11452259,112.59026986224731
+Kentucky,1972,484,Project Tycho - https://zenodo.org/records/11452259,14.495084399425828
+Kentucky,1973,403,Project Tycho - https://zenodo.org/records/11452259,11.942881612852082
+Kentucky,1974,188,Project Tycho - https://zenodo.org/records/11452259,5.49750842975661
+Kentucky,1975,158,Project Tycho - https://zenodo.org/records/11452259,4.551692826416873
+Kentucky,1976,762,Project Tycho - https://zenodo.org/records/11452259,21.569378954739967
+Kentucky,1977,1197,Project Tycho - https://zenodo.org/records/11452259,33.461308161036946
+Kentucky,1978,122,Project Tycho - https://zenodo.org/records/11452259,3.3761486169551844
+Kentucky,1979,62,Project Tycho - https://zenodo.org/records/11452259,1.7007525830179855
+Kentucky,1980,61,Project Tycho - https://zenodo.org/records/11452259,1.663083766257666
+Kentucky,1981,1,Project Tycho - https://zenodo.org/records/11452259,0.027217816564980905
+Kentucky,1982,2,Project Tycho - https://zenodo.org/records/11452259,0.0542427602187936
+Kentucky,1983,1,Project Tycho - https://zenodo.org/records/11452259,0.027040342568691932
+Kentucky,1984,1,Project Tycho - https://zenodo.org/records/11452259,0.02703325198126704
+Kentucky,1985,5,Project Tycho - https://zenodo.org/records/11452259,0.13518921081946292
+Kentucky,1986,6,Project Tycho - https://zenodo.org/records/11452259,0.16253573077148126
+Kentucky,1987,0,https://stacks.cdc.gov/view/cdc/35629,0.0
+Kentucky,1988,35,Project Tycho - https://zenodo.org/records/11452259,0.9501373355651608
+Kentucky,1989,44,Project Tycho - https://zenodo.org/records/11452259,1.1953328771146186
+Kentucky,1990,41,Project Tycho - https://zenodo.org/records/11452259,1.1092245276056225
+Kentucky,1991,26,Project Tycho - https://zenodo.org/records/11452259,0.6992254733218589
+Kentucky,1992,262,Project Tycho - https://zenodo.org/records/11452259,6.967873846378063
+Kentucky,1993,0,https://stacks.cdc.gov/view/cdc/5650,0.0
+Kentucky,1994,0,https://stacks.cdc.gov/view/cdc/5648,0.0
+Kentucky,1995,0,https://stacks.cdc.gov/view/cdc/5644,0.0
+Kentucky,1996,0,https://stacks.cdc.gov/view/cdc/5642,0.0
+Kentucky,1997,0,"https://www.cdc.gov/mmwr/preview/mmwrhtml/00056071.htm#:~:text=As%20of%20January%201%2C%201997,and%20control%20of%20the%20disease.",0.0
+Kentucky,1998,0,https://stacks.cdc.gov/view/cdc/5637,0.0
+Kentucky,1999,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.05044409722090857
+Kentucky,2000,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4953a1.htm,0.0
+Kentucky,2001,4,Project Tycho - https://zenodo.org/records/11452259,0.09822700260301556
+Kentucky,2002,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.0
+Kentucky,2003,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.0
+Kentucky,2004,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0
+Kentucky,2005,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.0
+Kentucky,2006,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.0
+Kentucky,2007,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.0
+Kentucky,2008,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.0
+Kentucky,2009,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.0
+Kentucky,2010,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.022973654731699877
+Kentucky,2011,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.022856165919308134
+Kentucky,2012,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.0
+Kentucky,2013,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.0
+Kentucky,2014,0,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.0
+Kentucky,2015,0,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.0
+Kentucky,2016,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Kentucky,2017,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Kentucky,2018,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Kentucky,2019,2,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.04467459804588841
+Kentucky,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Kentucky,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Kentucky,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Louisiana,1888,1,Project Tycho - https://zenodo.org/records/11452259,
+Louisiana,1889,18,Project Tycho - https://zenodo.org/records/11452259,
+Louisiana,1890,27,Project Tycho - https://zenodo.org/records/11452259,
+Louisiana,1891,36,Project Tycho - https://zenodo.org/records/11452259,
+Louisiana,1892,9,Project Tycho - https://zenodo.org/records/11452259,
+Louisiana,1894,7,Project Tycho - https://zenodo.org/records/11452259,
+Louisiana,1895,62,Project Tycho - https://zenodo.org/records/11452259,
+Louisiana,1896,10,Project Tycho - https://zenodo.org/records/11452259,
+Louisiana,1897,1,Project Tycho - https://zenodo.org/records/11452259,
+Louisiana,1899,28,Project Tycho - https://zenodo.org/records/11452259,
+Louisiana,1900,46,Project Tycho - https://zenodo.org/records/11452259,3.3203790429223954
+Louisiana,1901,1,Project Tycho - https://zenodo.org/records/11452259,0.07075077896607641
+Louisiana,1902,1,Project Tycho - https://zenodo.org/records/11452259,0.06937506937506938
+Louisiana,1903,2,Project Tycho - https://zenodo.org/records/11452259,0.13619645521486012
+Louisiana,1904,31,Project Tycho - https://zenodo.org/records/11452259,2.071507088229496
+Louisiana,1906,3,Project Tycho - https://zenodo.org/records/11452259,0.19323036731160523
+Louisiana,1907,84,Project Tycho - https://zenodo.org/records/11452259,5.3145081644131675
+Louisiana,1908,13,Project Tycho - https://zenodo.org/records/11452259,0.8081526438713744
+Louisiana,1909,80,Project Tycho - https://zenodo.org/records/11452259,4.891069762550791
+Louisiana,1910,2531,Project Tycho - https://zenodo.org/records/11452259,151.67795611706828
+Louisiana,1911,2336,Project Tycho - https://zenodo.org/records/11452259,137.67942971482796
+Louisiana,1912,327,Project Tycho - https://zenodo.org/records/11452259,19.11488160756739
+Louisiana,1913,4590,Project Tycho - https://zenodo.org/records/11452259,265.5132938861949
+Louisiana,1914,686,Project Tycho - https://zenodo.org/records/11452259,39.38590145486697
+Louisiana,1915,353,Project Tycho - https://zenodo.org/records/11452259,20.093866247712402
+Louisiana,1916,3936,Project Tycho - https://zenodo.org/records/11452259,218.56964602934588
+Louisiana,1917,4787,Project Tycho - https://zenodo.org/records/11452259,266.41881795085135
+Louisiana,1918,1046,Project Tycho - https://zenodo.org/records/11452259,59.848513456760884
+Louisiana,1919,201,Project Tycho - https://zenodo.org/records/11452259,11.435034214077493
+Louisiana,1920,1067,Project Tycho - https://zenodo.org/records/11452259,58.793936344956755
+Louisiana,1921,949,Project Tycho - https://zenodo.org/records/11452259,51.32928792917964
+Louisiana,1922,19,Project Tycho - https://zenodo.org/records/11452259,1.0144852475157125
+Louisiana,1923,681,Project Tycho - https://zenodo.org/records/11452259,35.74985182972571
+Louisiana,1924,1892,Project Tycho - https://zenodo.org/records/11452259,97.47859154769934
+Louisiana,1925,33,Project Tycho - https://zenodo.org/records/11452259,1.671756235650759
+Louisiana,1926,209,Project Tycho - https://zenodo.org/records/11452259,10.413526623002932
+Louisiana,1927,1937,Project Tycho - https://zenodo.org/records/11452259,94.90264517238523
+Louisiana,1928,6946,Project Tycho - https://zenodo.org/records/11452259,336.194812938999
+Louisiana,1929,2076,Project Tycho - https://zenodo.org/records/11452259,99.4211924221512
+Louisiana,1930,2574,Project Tycho - https://zenodo.org/records/11452259,122.15812690872075
+Louisiana,1931,387,Project Tycho - https://zenodo.org/records/11452259,18.202136846204642
+Louisiana,1932,1952,Project Tycho - https://zenodo.org/records/11452259,90.48955684686543
+Louisiana,1933,1122,Project Tycho - https://zenodo.org/records/11452259,51.46368782732419
+Louisiana,1934,5783,Project Tycho - https://zenodo.org/records/11452259,262.3625239429054
+Louisiana,1935,3448,Project Tycho - https://zenodo.org/records/11452259,154.60302713444543
+Louisiana,1936,1972,Project Tycho - https://zenodo.org/records/11452259,87.71282146170837
+Louisiana,1937,554,Project Tycho - https://zenodo.org/records/11452259,24.521335996745833
+Louisiana,1938,1101,Project Tycho - https://zenodo.org/records/11452259,48.13567176805689
+Louisiana,1939,4887,Project Tycho - https://zenodo.org/records/11452259,209.17385955946366
+Louisiana,1940,401,Project Tycho - https://zenodo.org/records/11452259,16.90292829533336
+Louisiana,1941,1157,Project Tycho - https://zenodo.org/records/11452259,46.531568270698706
+Louisiana,1942,4058,Project Tycho - https://zenodo.org/records/11452259,159.22804610942867
+Louisiana,1943,3350,Project Tycho - https://zenodo.org/records/11452259,130.473814684341
+Louisiana,1944,3212,Project Tycho - https://zenodo.org/records/11452259,127.94223320539109
+Louisiana,1945,1434,Project Tycho - https://zenodo.org/records/11452259,58.97766292990665
+Louisiana,1946,3703,Project Tycho - https://zenodo.org/records/11452259,144.7300743075391
+Louisiana,1947,1976,Project Tycho - https://zenodo.org/records/11452259,76.54230221116612
+Louisiana,1948,1555,Project Tycho - https://zenodo.org/records/11452259,59.84000591088419
+Louisiana,1949,1359,Project Tycho - https://zenodo.org/records/11452259,51.542990039573176
+Louisiana,1950,787,Project Tycho - https://zenodo.org/records/11452259,29.151419585234937
+Louisiana,1951,2177,Project Tycho - https://zenodo.org/records/11452259,78.541898693578
+Louisiana,1952,803,Project Tycho - https://zenodo.org/records/11452259,28.226523652280164
+Louisiana,1953,4684,Project Tycho - https://zenodo.org/records/11452259,163.27008650804882
+Louisiana,1954,3028,Project Tycho - https://zenodo.org/records/11452259,104.9245586186273
+Louisiana,1955,167,Project Tycho - https://zenodo.org/records/11452259,5.663040286258209
+Louisiana,1956,2120,Project Tycho - https://zenodo.org/records/11452259,69.85099333384294
+Louisiana,1957,1085,Project Tycho - https://zenodo.org/records/11452259,34.796664010147154
+Louisiana,1958,272,Project Tycho - https://zenodo.org/records/11452259,8.612623509612416
+Louisiana,1959,68,Project Tycho - https://zenodo.org/records/11452259,2.117583164964711
+Louisiana,1960,244,Project Tycho - https://zenodo.org/records/11452259,7.477185391295821
+Louisiana,1961,41,Project Tycho - https://zenodo.org/records/11452259,1.2460919062683589
+Louisiana,1962,232,Project Tycho - https://zenodo.org/records/11452259,6.928796166464328
+Louisiana,1963,141,Project Tycho - https://zenodo.org/records/11452259,4.171132391446279
+Louisiana,1964,117,Project Tycho - https://zenodo.org/records/11452259,3.3918490099569616
+Louisiana,1965,134,Project Tycho - https://zenodo.org/records/11452259,3.8291228222578337
+Louisiana,1966,107,Project Tycho - https://zenodo.org/records/11452259,3.011073433608645
+Louisiana,1967,159,Project Tycho - https://zenodo.org/records/11452259,4.435664865712338
+Louisiana,1968,7,Project Tycho - https://zenodo.org/records/11452259,0.1940884538719676
+Louisiana,1969,124,Project Tycho - https://zenodo.org/records/11452259,3.42293793523415
+Louisiana,1970,309,Project Tycho - https://zenodo.org/records/11452259,8.46974232522111
+Louisiana,1971,1586,Project Tycho - https://zenodo.org/records/11452259,42.70101989743678
+Louisiana,1972,123,Project Tycho - https://zenodo.org/records/11452259,3.2665791506734863
+Louisiana,1973,90,Project Tycho - https://zenodo.org/records/11452259,2.3733157039926818
+Louisiana,1974,13,Project Tycho - https://zenodo.org/records/11452259,0.339964471097659
+Louisiana,1975,2,Project Tycho - https://zenodo.org/records/11452259,0.05141401391777357
+Louisiana,1976,314,Project Tycho - https://zenodo.org/records/11452259,7.940210719031597
+Louisiana,1977,112,Project Tycho - https://zenodo.org/records/11452259,2.787128344522907
+Louisiana,1978,472,Project Tycho - https://zenodo.org/records/11452259,11.589514141539889
+Louisiana,1979,257,Project Tycho - https://zenodo.org/records/11452259,6.205028632464806
+Louisiana,1980,19,Project Tycho - https://zenodo.org/records/11452259,0.44945691411398797
+Louisiana,1981,4,Project Tycho - https://zenodo.org/records/11452259,0.09329258934981129
+Louisiana,1982,15,Project Tycho - https://zenodo.org/records/11452259,0.34427674341742864
+Louisiana,1983,26,Project Tycho - https://zenodo.org/records/11452259,0.5909479054419711
+Louisiana,1984,8,Project Tycho - https://zenodo.org/records/11452259,0.18161687602173682
+Louisiana,1985,42,Project Tycho - https://zenodo.org/records/11452259,0.951835751222769
+Louisiana,1986,4,Project Tycho - https://zenodo.org/records/11452259,0.09067570401183318
+Louisiana,1987,0,https://stacks.cdc.gov/view/cdc/35629,0.0
+Louisiana,1988,1,https://stacks.cdc.gov/view/cdc/35958,0.023292914691330446
+Louisiana,1989,118,Project Tycho - https://zenodo.org/records/11452259,2.771810034234203
+Louisiana,1990,10,https://stacks.cdc.gov/view/cdc/35905,0.23677616933095103
+Louisiana,1991,0,https://stacks.cdc.gov/view/cdc/36010,0.0
+Louisiana,1992,3,https://stacks.cdc.gov/view/cdc/36063,0.07017348522930006
+Louisiana,1993,1,Project Tycho - https://zenodo.org/records/11452259,0.0233152787586386
+Louisiana,1994,1,Project Tycho - https://zenodo.org/records/11452259,0.023197518051148672
+Louisiana,1995,17,Project Tycho - https://zenodo.org/records/11452259,0.39240081203885696
+Louisiana,1996,1,https://stacks.cdc.gov/view/cdc/5642,0.02302502290414153
+Louisiana,1997,0,"https://www.cdc.gov/mmwr/preview/mmwrhtml/00056071.htm#:~:text=As%20of%20January%201%2C%201997,and%20control%20of%20the%20disease.",0.0
+Louisiana,1998,1,Project Tycho - https://zenodo.org/records/11452259,0.02289838612174614
+Louisiana,1999,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.0
+Louisiana,2000,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4953a1.htm,0.0
+Louisiana,2001,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5053a1.htm,0.0
+Louisiana,2002,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.0
+Louisiana,2003,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.0
+Louisiana,2004,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0
+Louisiana,2005,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.0
+Louisiana,2006,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.0
+Louisiana,2007,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.0
+Louisiana,2008,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.022522415997581993
+Louisiana,2009,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.0
+Louisiana,2010,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.0
+Louisiana,2011,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.0
+Louisiana,2012,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.0
+Louisiana,2013,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.0
+Louisiana,2014,0,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.0
+Louisiana,2015,0,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.0
+Louisiana,2016,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Louisiana,2017,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Louisiana,2018,2,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.042834679127560386
+Louisiana,2019,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Louisiana,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Louisiana,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Louisiana,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Maine,1889,2,Project Tycho - https://zenodo.org/records/11452259,
+Maine,1890,1,Project Tycho - https://zenodo.org/records/11452259,
+Maine,1891,6,Project Tycho - https://zenodo.org/records/11452259,
+Maine,1892,2,Project Tycho - https://zenodo.org/records/11452259,
+Maine,1893,1,Project Tycho - https://zenodo.org/records/11452259,
+Maine,1894,1,Project Tycho - https://zenodo.org/records/11452259,
+Maine,1897,4,Project Tycho - https://zenodo.org/records/11452259,
+Maine,1899,5,Project Tycho - https://zenodo.org/records/11452259,
+Maine,1901,1,Project Tycho - https://zenodo.org/records/11452259,0.14291859785422018
+Maine,1903,1,Project Tycho - https://zenodo.org/records/11452259,0.14090282073356827
+Maine,1904,5,Project Tycho - https://zenodo.org/records/11452259,0.6947155764958268
+Maine,1906,27,Project Tycho - https://zenodo.org/records/11452259,3.7000037000036996
+Maine,1907,140,Project Tycho - https://zenodo.org/records/11452259,19.132714071154563
+Maine,1908,28,Project Tycho - https://zenodo.org/records/11452259,3.805718091432377
+Maine,1909,150,Project Tycho - https://zenodo.org/records/11452259,20.25002025002025
+Maine,1910,90,Project Tycho - https://zenodo.org/records/11452259,12.06846844430737
+Maine,1911,36,Project Tycho - https://zenodo.org/records/11452259,4.788819702268437
+Maine,1912,8,Project Tycho - https://zenodo.org/records/11452259,1.0613556430289497
+Maine,1913,8,Project Tycho - https://zenodo.org/records/11452259,1.047445346265792
+Maine,1914,4,Project Tycho - https://zenodo.org/records/11452259,0.5176170979279787
+Maine,1915,8,Project Tycho - https://zenodo.org/records/11452259,1.032559172094056
+Maine,1916,20,Project Tycho - https://zenodo.org/records/11452259,2.5780670941961263
+Maine,1917,1062,Project Tycho - https://zenodo.org/records/11452259,136.54299368585083
+Maine,1918,631,Project Tycho - https://zenodo.org/records/11452259,82.94337241705662
+Maine,1919,55,Project Tycho - https://zenodo.org/records/11452259,7.210637131896974
+Maine,1920,787,Project Tycho - https://zenodo.org/records/11452259,101.9732537242265
+Maine,1921,932,Project Tycho - https://zenodo.org/records/11452259,120.13792658953949
+Maine,1922,146,Project Tycho - https://zenodo.org/records/11452259,18.747319518527746
+Maine,1923,1781,Project Tycho - https://zenodo.org/records/11452259,227.81315995144422
+Maine,1924,314,Project Tycho - https://zenodo.org/records/11452259,39.8079078282124
+Maine,1925,26,Project Tycho - https://zenodo.org/records/11452259,3.2795487340941887
+Maine,1926,1883,Project Tycho - https://zenodo.org/records/11452259,237.21549572747557
+Maine,1927,368,Project Tycho - https://zenodo.org/records/11452259,46.18497080808638
+Maine,1928,4292,Project Tycho - https://zenodo.org/records/11452259,537.9814664632733
+Maine,1929,5890,Project Tycho - https://zenodo.org/records/11452259,738.2830469405125
+Maine,1930,1646,Project Tycho - https://zenodo.org/records/11452259,205.54445554445553
+Maine,1931,3651,Project Tycho - https://zenodo.org/records/11452259,451.9643924848386
+Maine,1932,11108,Project Tycho - https://zenodo.org/records/11452259,1361.5832020739997
+Maine,1933,139,Project Tycho - https://zenodo.org/records/11452259,16.913658813780614
+Maine,1934,706,Project Tycho - https://zenodo.org/records/11452259,85.07776903434322
+Maine,1935,7357,Project Tycho - https://zenodo.org/records/11452259,879.1447786663099
+Maine,1936,8919,Project Tycho - https://zenodo.org/records/11452259,1060.724989296418
+Maine,1937,1162,Project Tycho - https://zenodo.org/records/11452259,137.8668837101141
+Maine,1938,4012,Project Tycho - https://zenodo.org/records/11452259,475.44389181399856
+Maine,1939,1805,Project Tycho - https://zenodo.org/records/11452259,213.14383016510678
+Maine,1940,11162,Project Tycho - https://zenodo.org/records/11452259,1313.409793975165
+Maine,1941,4428,Project Tycho - https://zenodo.org/records/11452259,519.1991107484065
+Maine,1942,4860,Project Tycho - https://zenodo.org/records/11452259,578.6823426871102
+Maine,1943,2788,Project Tycho - https://zenodo.org/records/11452259,345.5601470489808
+Maine,1944,5717,Project Tycho - https://zenodo.org/records/11452259,713.0198141434096
+Maine,1945,162,Project Tycho - https://zenodo.org/records/11452259,20.229770229770228
+Maine,1946,5217,Project Tycho - https://zenodo.org/records/11452259,626.4168523783908
+Maine,1947,5160,Project Tycho - https://zenodo.org/records/11452259,603.6118448296434
+Maine,1948,2960,Project Tycho - https://zenodo.org/records/11452259,336.7930474991978
+Maine,1949,10013,Project Tycho - https://zenodo.org/records/11452259,1107.7516060904766
+Maine,1950,1011,Project Tycho - https://zenodo.org/records/11452259,110.14067720719848
+Maine,1951,2071,Project Tycho - https://zenodo.org/records/11452259,225.86583721954898
+Maine,1952,11560,Project Tycho - https://zenodo.org/records/11452259,1262.1258522897867
+Maine,1953,1546,Project Tycho - https://zenodo.org/records/11452259,169.16271023609468
+Maine,1954,5810,Project Tycho - https://zenodo.org/records/11452259,626.1268397190727
+Maine,1955,6636,Project Tycho - https://zenodo.org/records/11452259,709.7827226306883
+Maine,1956,1121,Project Tycho - https://zenodo.org/records/11452259,119.39020467805118
+Maine,1957,4549,Project Tycho - https://zenodo.org/records/11452259,481.91469188287857
+Maine,1958,4295,Project Tycho - https://zenodo.org/records/11452259,454.524289270052
+Maine,1959,2588,Project Tycho - https://zenodo.org/records/11452259,270.1582638886714
+Maine,1960,4027,Project Tycho - https://zenodo.org/records/11452259,412.61302799764337
+Maine,1961,3076,Project Tycho - https://zenodo.org/records/11452259,308.8368917514646
+Maine,1962,6867,Project Tycho - https://zenodo.org/records/11452259,690.1549155070282
+Maine,1963,459,Project Tycho - https://zenodo.org/records/11452259,46.177387567115666
+Maine,1964,3707,Project Tycho - https://zenodo.org/records/11452259,372.9402520943306
+Maine,1965,2949,Project Tycho - https://zenodo.org/records/11452259,295.49187021604274
+Maine,1966,297,Project Tycho - https://zenodo.org/records/11452259,29.7000297000297
+Maine,1967,212,Project Tycho - https://zenodo.org/records/11452259,21.094443405200376
+Maine,1968,7,Project Tycho - https://zenodo.org/records/11452259,0.7035218302823937
+Maine,1969,1,Project Tycho - https://zenodo.org/records/11452259,0.10070574586703619
+Maine,1970,419,Project Tycho - https://zenodo.org/records/11452259,42.12261803632196
+Maine,1971,1240,Project Tycho - https://zenodo.org/records/11452259,121.99861275770976
+Maine,1972,211,Project Tycho - https://zenodo.org/records/11452259,20.38005420514891
+Maine,1973,12,Project Tycho - https://zenodo.org/records/11452259,1.1464603038119805
+Maine,1974,30,Project Tycho - https://zenodo.org/records/11452259,2.829924374987619
+Maine,1975,4,Project Tycho - https://zenodo.org/records/11452259,0.3727636510708568
+Maine,1976,10,Project Tycho - https://zenodo.org/records/11452259,0.9178522257916476
+Maine,1977,179,Project Tycho - https://zenodo.org/records/11452259,16.203772853882704
+Maine,1978,1322,Project Tycho - https://zenodo.org/records/11452259,118.59916621735944
+Maine,1979,19,Project Tycho - https://zenodo.org/records/11452259,1.690865322577057
+Maine,1980,48,Project Tycho - https://zenodo.org/records/11452259,4.2553719638364305
+Maine,1981,5,Project Tycho - https://zenodo.org/records/11452259,0.4408525736091542
+Maine,1982,0,https://stacks.cdc.gov/view/cdc/35066,0.0
+Maine,1983,0,https://stacks.cdc.gov/view/cdc/35188,0.0
+Maine,1984,0,https://stacks.cdc.gov/view/cdc/35267,0.0
+Maine,1985,1,Project Tycho - https://zenodo.org/records/11452259,0.08590342050239756
+Maine,1986,15,Project Tycho - https://zenodo.org/records/11452259,1.2806327350217195
+Maine,1987,3,Project Tycho - https://zenodo.org/records/11452259,0.2530027206225891
+Maine,1988,8,Project Tycho - https://zenodo.org/records/11452259,0.6638767247309847
+Maine,1989,1,Project Tycho - https://zenodo.org/records/11452259,0.08188800995758201
+Maine,1990,3,Project Tycho - https://zenodo.org/records/11452259,0.24340237576945578
+Maine,1991,7,Project Tycho - https://zenodo.org/records/11452259,0.5660343793109583
+Maine,1992,4,Project Tycho - https://zenodo.org/records/11452259,0.32336741895401955
+Maine,1993,2,Project Tycho - https://zenodo.org/records/11452259,0.16135616630657348
+Maine,1994,5,Project Tycho - https://zenodo.org/records/11452259,0.40357600627641405
+Maine,1995,0,https://stacks.cdc.gov/view/cdc/5644,0.0
+Maine,1996,0,https://stacks.cdc.gov/view/cdc/5642,0.0
+Maine,1997,1,"https://www.cdc.gov/mmwr/preview/mmwrhtml/00056071.htm#:~:text=As%20of%20January%201%2C%201997,and%20control%20of%20the%20disease.",0.08022720344014247
+Maine,1998,0,https://stacks.cdc.gov/view/cdc/5637,0.0
+Maine,1999,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.0
+Maine,2000,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4953a1.htm,0.0
+Maine,2001,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5053a1.htm,0.0
+Maine,2002,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.0
+Maine,2003,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.0
+Maine,2004,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0
+Maine,2005,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.0
+Maine,2006,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.0
+Maine,2007,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.0
+Maine,2008,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.0
+Maine,2009,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.0
+Maine,2010,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.0
+Maine,2011,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.0
+Maine,2012,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.0
+Maine,2013,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.0
+Maine,2014,0,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.0
+Maine,2015,0,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.0
+Maine,2016,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Maine,2017,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.07478995241863227
+Maine,2018,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Maine,2019,2,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.148465424258508
+Maine,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Maine,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Maine,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Maryland,1909,13,Project Tycho - https://zenodo.org/records/11452259,1.007526220869898
+Maryland,1910,1,Project Tycho - https://zenodo.org/records/11452259,0.07672818732726566
+Maryland,1911,6,Project Tycho - https://zenodo.org/records/11452259,0.45271948595211436
+Maryland,1912,479,Project Tycho - https://zenodo.org/records/11452259,35.57780509453372
+Maryland,1913,294,Project Tycho - https://zenodo.org/records/11452259,21.469758311863576
+Maryland,1914,67,Project Tycho - https://zenodo.org/records/11452259,4.818795315555575
+Maryland,1915,20,Project Tycho - https://zenodo.org/records/11452259,1.4261256231277646
+Maryland,1916,954,Project Tycho - https://zenodo.org/records/11452259,67.35314155808855
+Maryland,1917,167,Project Tycho - https://zenodo.org/records/11452259,11.682994876272188
+Maryland,1918,248,Project Tycho - https://zenodo.org/records/11452259,16.888360446642654
+Maryland,1919,511,Project Tycho - https://zenodo.org/records/11452259,35.32799380550246
+Maryland,1920,14,Project Tycho - https://zenodo.org/records/11452259,0.9553288241812832
+Maryland,1921,9,Project Tycho - https://zenodo.org/records/11452259,0.6026145436333104
+Maryland,1922,36,Project Tycho - https://zenodo.org/records/11452259,2.383302582109739
+Maryland,1923,845,Project Tycho - https://zenodo.org/records/11452259,55.5000555000555
+Maryland,1924,304,Project Tycho - https://zenodo.org/records/11452259,19.759030819538303
+Maryland,1925,13,Project Tycho - https://zenodo.org/records/11452259,0.8346409374687009
+Maryland,1926,532,Project Tycho - https://zenodo.org/records/11452259,33.722622555109865
+Maryland,1927,392,Project Tycho - https://zenodo.org/records/11452259,24.490831245052636
+Maryland,1928,17974,Project Tycho - https://zenodo.org/records/11452259,1115.2822332946557
+Maryland,1929,2065,Project Tycho - https://zenodo.org/records/11452259,127.26323645509333
+Maryland,1930,1276,Project Tycho - https://zenodo.org/records/11452259,77.91719283161825
+Maryland,1931,21107,Project Tycho - https://zenodo.org/records/11452259,1272.5355513526908
+Maryland,1932,1343,Project Tycho - https://zenodo.org/records/11452259,79.95580105234455
+Maryland,1933,762,Project Tycho - https://zenodo.org/records/11452259,44.937353083752136
+Maryland,1934,27103,Project Tycho - https://zenodo.org/records/11452259,1583.387372861057
+Maryland,1935,2520,Project Tycho - https://zenodo.org/records/11452259,145.60338446978125
+Maryland,1936,7185,Project Tycho - https://zenodo.org/records/11452259,411.33651448837696
+Maryland,1937,12353,Project Tycho - https://zenodo.org/records/11452259,703.5723683386169
+Maryland,1938,2329,Project Tycho - https://zenodo.org/records/11452259,131.74820649339335
+Maryland,1939,13561,Project Tycho - https://zenodo.org/records/11452259,755.5745982962937
+Maryland,1940,261,Project Tycho - https://zenodo.org/records/11452259,14.178317604092483
+Maryland,1941,7499,Project Tycho - https://zenodo.org/records/11452259,391.6104804761365
+Maryland,1942,10809,Project Tycho - https://zenodo.org/records/11452259,540.4505404505404
+Maryland,1943,3545,Project Tycho - https://zenodo.org/records/11452259,169.52889140538733
+Maryland,1944,13417,Project Tycho - https://zenodo.org/records/11452259,632.8421342585649
+Maryland,1945,1104,Project Tycho - https://zenodo.org/records/11452259,52.61913658860224
+Maryland,1946,11720,Project Tycho - https://zenodo.org/records/11452259,528.82979712248
+Maryland,1947,1130,Project Tycho - https://zenodo.org/records/11452259,50.21668722736338
+Maryland,1948,9899,Project Tycho - https://zenodo.org/records/11452259,435.4518225059837
+Maryland,1949,17240,Project Tycho - https://zenodo.org/records/11452259,739.4923668002242
+Maryland,1950,1550,Project Tycho - https://zenodo.org/records/11452259,65.751658108346
+Maryland,1951,6904,Project Tycho - https://zenodo.org/records/11452259,282.5523513766037
+Maryland,1952,7971,Project Tycho - https://zenodo.org/records/11452259,318.5214785214785
+Maryland,1953,1841,Project Tycho - https://zenodo.org/records/11452259,71.64631239426721
+Maryland,1954,11648,Project Tycho - https://zenodo.org/records/11452259,433.3841205349585
+Maryland,1955,2290,Project Tycho - https://zenodo.org/records/11452259,83.4322497342191
+Maryland,1956,8741,Project Tycho - https://zenodo.org/records/11452259,310.6463085118368
+Maryland,1957,2556,Project Tycho - https://zenodo.org/records/11452259,88.87736002250448
+Maryland,1958,6015,Project Tycho - https://zenodo.org/records/11452259,201.5087528165999
+Maryland,1959,2333,Project Tycho - https://zenodo.org/records/11452259,76.01661222013473
+Maryland,1960,3251,Project Tycho - https://zenodo.org/records/11452259,104.32869411346765
+Maryland,1961,4175,Project Tycho - https://zenodo.org/records/11452259,131.32333661300916
+Maryland,1962,3121,Project Tycho - https://zenodo.org/records/11452259,95.55262390076977
+Maryland,1963,2100,Project Tycho - https://zenodo.org/records/11452259,61.958124568874716
+Maryland,1964,3054,Project Tycho - https://zenodo.org/records/11452259,87.36967499854099
+Maryland,1965,1279,Project Tycho - https://zenodo.org/records/11452259,35.49228549228549
+Maryland,1966,2133,Project Tycho - https://zenodo.org/records/11452259,57.66898865681004
+Maryland,1967,183,Project Tycho - https://zenodo.org/records/11452259,4.8660415974762525
+Maryland,1968,103,Project Tycho - https://zenodo.org/records/11452259,2.697171766634414
+Maryland,1969,96,Project Tycho - https://zenodo.org/records/11452259,2.479423368771869
+Maryland,1970,1392,Project Tycho - https://zenodo.org/records/11452259,35.43950588367084
+Maryland,1971,556,Project Tycho - https://zenodo.org/records/11452259,13.822792790866615
+Maryland,1972,12,Project Tycho - https://zenodo.org/records/11452259,0.2942927801152254
+Maryland,1973,14,Project Tycho - https://zenodo.org/records/11452259,0.34129102104766107
+Maryland,1974,24,Project Tycho - https://zenodo.org/records/11452259,0.5821098717830243
+Maryland,1975,64,Project Tycho - https://zenodo.org/records/11452259,1.5446867001268332
+Maryland,1976,829,Project Tycho - https://zenodo.org/records/11452259,19.95335872311983
+Maryland,1977,372,Project Tycho - https://zenodo.org/records/11452259,8.912818261885434
+Maryland,1978,52,Project Tycho - https://zenodo.org/records/11452259,1.2417062380933503
+Maryland,1979,16,Project Tycho - https://zenodo.org/records/11452259,0.3813745262315358
+Maryland,1980,85,Project Tycho - https://zenodo.org/records/11452259,2.0085683161344745
+Maryland,1981,5,Project Tycho - https://zenodo.org/records/11452259,0.1172012528345123
+Maryland,1982,5,Project Tycho - https://zenodo.org/records/11452259,0.11662610022147296
+Maryland,1983,10,Project Tycho - https://zenodo.org/records/11452259,0.23160800807848733
+Maryland,1984,23,Project Tycho - https://zenodo.org/records/11452259,0.5263630055602242
+Maryland,1985,116,Project Tycho - https://zenodo.org/records/11452259,2.6259291488095937
+Maryland,1986,35,Project Tycho - https://zenodo.org/records/11452259,0.7792595831673695
+Maryland,1987,11,Project Tycho - https://zenodo.org/records/11452259,0.2406937932947961
+Maryland,1988,16,Project Tycho - https://zenodo.org/records/11452259,0.3431590492864329
+Maryland,1989,120,Project Tycho - https://zenodo.org/records/11452259,2.53591060746048
+Maryland,1990,205,Project Tycho - https://zenodo.org/records/11452259,4.268851874588212
+Maryland,1991,180,Project Tycho - https://zenodo.org/records/11452259,3.702917405192972
+Maryland,1992,13,Project Tycho - https://zenodo.org/records/11452259,0.2649035231557264
+Maryland,1993,2,Project Tycho - https://zenodo.org/records/11452259,0.040424898018088525
+Maryland,1994,2,Project Tycho - https://zenodo.org/records/11452259,0.0400769798629207
+Maryland,1995,1,Project Tycho - https://zenodo.org/records/11452259,0.019885961962529678
+Maryland,1996,3,Project Tycho - https://zenodo.org/records/11452259,0.05926278283410036
+Maryland,1997,2,Project Tycho - https://zenodo.org/records/11452259,0.03923102483598489
+Maryland,1998,1,Project Tycho - https://zenodo.org/records/11452259,0.019473430645960958
+Maryland,1999,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.0
+Maryland,2000,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4953a1.htm,0.0
+Maryland,2001,4,Project Tycho - https://zenodo.org/records/11452259,0.07434854411610269
+Maryland,2002,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.0
+Maryland,2003,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.01817598534288542
+Maryland,2004,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.01800996707597919
+Maryland,2005,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.0
+Maryland,2006,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.03550509728929234
+Maryland,2007,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.0
+Maryland,2008,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.0
+Maryland,2009,4,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.06973357242650866
+Maryland,2010,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.0
+Maryland,2011,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.03421095260226466
+Maryland,2012,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.0
+Maryland,2013,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.01686021633006369
+Maryland,2014,0,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.0
+Maryland,2015,0,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.0
+Maryland,2016,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.01663057554596932
+Maryland,2017,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.016572166648382045
+Maryland,2018,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.016533858448677663
+Maryland,2019,5,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.08249452896283918
+Maryland,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Maryland,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Maryland,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Massachusetts,1888,10,Project Tycho - https://zenodo.org/records/11452259,
+Massachusetts,1889,16,Project Tycho - https://zenodo.org/records/11452259,
+Massachusetts,1890,26,Project Tycho - https://zenodo.org/records/11452259,
+Massachusetts,1891,34,Project Tycho - https://zenodo.org/records/11452259,
+Massachusetts,1892,24,Project Tycho - https://zenodo.org/records/11452259,
+Massachusetts,1893,32,Project Tycho - https://zenodo.org/records/11452259,
+Massachusetts,1894,35,Project Tycho - https://zenodo.org/records/11452259,
+Massachusetts,1895,55,Project Tycho - https://zenodo.org/records/11452259,
+Massachusetts,1896,64,Project Tycho - https://zenodo.org/records/11452259,
+Massachusetts,1897,71,Project Tycho - https://zenodo.org/records/11452259,
+Massachusetts,1898,40,Project Tycho - https://zenodo.org/records/11452259,
+Massachusetts,1899,123,Project Tycho - https://zenodo.org/records/11452259,
+Massachusetts,1900,208,Project Tycho - https://zenodo.org/records/11452259,7.4530921015856455
+Massachusetts,1901,158,Project Tycho - https://zenodo.org/records/11452259,5.649325620692836
+Massachusetts,1902,172,Project Tycho - https://zenodo.org/records/11452259,6.01639257101442
+Massachusetts,1903,119,Project Tycho - https://zenodo.org/records/11452259,4.065701740120345
+Massachusetts,1904,148,Project Tycho - https://zenodo.org/records/11452259,4.979863518091878
+Massachusetts,1905,123,Project Tycho - https://zenodo.org/records/11452259,4.071475244437471
+Massachusetts,1906,426,Project Tycho - https://zenodo.org/records/11452259,13.697277939312055
+Massachusetts,1907,4624,Project Tycho - https://zenodo.org/records/11452259,145.12662957526294
+Massachusetts,1908,15493,Project Tycho - https://zenodo.org/records/11452259,476.0849731627954
+Massachusetts,1909,9420,Project Tycho - https://zenodo.org/records/11452259,283.79340803948764
+Massachusetts,1910,12358,Project Tycho - https://zenodo.org/records/11452259,366.8842301828929
+Massachusetts,1911,9940,Project Tycho - https://zenodo.org/records/11452259,293.52852291072804
+Massachusetts,1912,15603,Project Tycho - https://zenodo.org/records/11452259,453.1224589364124
+Massachusetts,1913,17694,Project Tycho - https://zenodo.org/records/11452259,500.1789382094984
+Massachusetts,1914,7748,Project Tycho - https://zenodo.org/records/11452259,212.8784307002129
+Massachusetts,1915,15072,Project Tycho - https://zenodo.org/records/11452259,406.3952242089894
+Massachusetts,1916,16759,Project Tycho - https://zenodo.org/records/11452259,449.3359565823334
+Massachusetts,1917,16408,Project Tycho - https://zenodo.org/records/11452259,438.51279806335987
+Massachusetts,1918,20443,Project Tycho - https://zenodo.org/records/11452259,552.7084552794972
+Massachusetts,1919,8013,Project Tycho - https://zenodo.org/records/11452259,211.49260250977557
+Massachusetts,1920,23061,Project Tycho - https://zenodo.org/records/11452259,593.4560030386924
+Massachusetts,1921,10963,Project Tycho - https://zenodo.org/records/11452259,277.1968603403683
+Massachusetts,1922,19022,Project Tycho - https://zenodo.org/records/11452259,473.89019957598515
+Massachusetts,1923,19128,Project Tycho - https://zenodo.org/records/11452259,471.01037980998547
+Massachusetts,1924,6815,Project Tycho - https://zenodo.org/records/11452259,165.97249654294998
+Massachusetts,1925,11086,Project Tycho - https://zenodo.org/records/11452259,266.6086922225584
+Massachusetts,1926,8182,Project Tycho - https://zenodo.org/records/11452259,194.89332794053826
+Massachusetts,1927,7192,Project Tycho - https://zenodo.org/records/11452259,170.13533471028143
+Massachusetts,1928,53844,Project Tycho - https://zenodo.org/records/11452259,1275.5563146836564
+Massachusetts,1929,17394,Project Tycho - https://zenodo.org/records/11452259,410.89201647253196
+Massachusetts,1930,38809,Project Tycho - https://zenodo.org/records/11452259,912.2407004759947
+Massachusetts,1931,19552,Project Tycho - https://zenodo.org/records/11452259,459.80384963435813
+Massachusetts,1932,25811,Project Tycho - https://zenodo.org/records/11452259,605.4288514960034
+Massachusetts,1933,24571,Project Tycho - https://zenodo.org/records/11452259,573.247397161456
+Massachusetts,1934,52836,Project Tycho - https://zenodo.org/records/11452259,1226.0909821885432
+Massachusetts,1935,18210,Project Tycho - https://zenodo.org/records/11452259,418.8765413725119
+Massachusetts,1936,36189,Project Tycho - https://zenodo.org/records/11452259,830.1457440378222
+Massachusetts,1937,25380,Project Tycho - https://zenodo.org/records/11452259,581.7954418229774
+Massachusetts,1938,15088,Project Tycho - https://zenodo.org/records/11452259,345.3133350040567
+Massachusetts,1939,30812,Project Tycho - https://zenodo.org/records/11452259,708.1025714566088
+Massachusetts,1940,28436,Project Tycho - https://zenodo.org/records/11452259,657.8877352383605
+Massachusetts,1941,27918,Project Tycho - https://zenodo.org/records/11452259,635.4547707931166
+Massachusetts,1942,31513,Project Tycho - https://zenodo.org/records/11452259,720.4008805839469
+Massachusetts,1943,44219,Project Tycho - https://zenodo.org/records/11452259,1037.6985007006149
+Massachusetts,1944,23394,Project Tycho - https://zenodo.org/records/11452259,557.505471627609
+Massachusetts,1945,9885,Project Tycho - https://zenodo.org/records/11452259,235.06605272851405
+Massachusetts,1946,50813,Project Tycho - https://zenodo.org/records/11452259,1129.5558024529987
+Massachusetts,1947,14275,Project Tycho - https://zenodo.org/records/11452259,311.369852854569
+Massachusetts,1948,40523,Project Tycho - https://zenodo.org/records/11452259,866.1214694590817
+Massachusetts,1949,26401,Project Tycho - https://zenodo.org/records/11452259,556.3093308294743
+Massachusetts,1950,12962,Project Tycho - https://zenodo.org/records/11452259,276.33484739758745
+Massachusetts,1951,16225,Project Tycho - https://zenodo.org/records/11452259,348.2765622860165
+Massachusetts,1952,58519,Project Tycho - https://zenodo.org/records/11452259,1257.2159023771926
+Massachusetts,1953,2626,Project Tycho - https://zenodo.org/records/11452259,54.5854478438748
+Massachusetts,1954,23325,Project Tycho - https://zenodo.org/records/11452259,474.5763401567882
+Massachusetts,1955,46745,Project Tycho - https://zenodo.org/records/11452259,956.5403871016325
+Massachusetts,1956,3551,Project Tycho - https://zenodo.org/records/11452259,72.5302095165109
+Massachusetts,1957,11166,Project Tycho - https://zenodo.org/records/11452259,226.31051237259393
+Massachusetts,1958,35569,Project Tycho - https://zenodo.org/records/11452259,709.250829011308
+Massachusetts,1959,6305,Project Tycho - https://zenodo.org/records/11452259,123.0936349169689
+Massachusetts,1960,21703,Project Tycho - https://zenodo.org/records/11452259,420.18059459919925
+Massachusetts,1961,22131,Project Tycho - https://zenodo.org/records/11452259,423.6231291222669
+Massachusetts,1962,26562,Project Tycho - https://zenodo.org/records/11452259,504.1889518423814
+Massachusetts,1963,4504,Project Tycho - https://zenodo.org/records/11452259,84.19723988586264
+Massachusetts,1964,7350,Project Tycho - https://zenodo.org/records/11452259,134.77711715597178
+Massachusetts,1965,19505,Project Tycho - https://zenodo.org/records/11452259,354.15329853715895
+Massachusetts,1966,831,Project Tycho - https://zenodo.org/records/11452259,14.998551583917438
+Massachusetts,1967,422,Project Tycho - https://zenodo.org/records/11452259,7.53626066461247
+Massachusetts,1968,549,Project Tycho - https://zenodo.org/records/11452259,9.762398512843511
+Massachusetts,1969,368,Project Tycho - https://zenodo.org/records/11452259,6.506767568714471
+Massachusetts,1970,905,Project Tycho - https://zenodo.org/records/11452259,15.891526023734741
+Massachusetts,1971,466,Project Tycho - https://zenodo.org/records/11452259,8.11377815293845
+Massachusetts,1972,1316,Project Tycho - https://zenodo.org/records/11452259,22.823202386654877
+Massachusetts,1973,3927,Project Tycho - https://zenodo.org/records/11452259,67.8595454291749
+Massachusetts,1974,405,Project Tycho - https://zenodo.org/records/11452259,7.0077436432411355
+Massachusetts,1975,156,Project Tycho - https://zenodo.org/records/11452259,2.7066825389306834
+Massachusetts,1976,43,Project Tycho - https://zenodo.org/records/11452259,0.7479021778737489
+Massachusetts,1977,765,Project Tycho - https://zenodo.org/records/11452259,13.3183912010177
+Massachusetts,1978,315,Project Tycho - https://zenodo.org/records/11452259,5.48569756739789
+Massachusetts,1979,24,Project Tycho - https://zenodo.org/records/11452259,0.41781696900947085
+Massachusetts,1980,58,Project Tycho - https://zenodo.org/records/11452259,1.00837630378275
+Massachusetts,1981,61,Project Tycho - https://zenodo.org/records/11452259,1.0563771148539958
+Massachusetts,1982,5,Project Tycho - https://zenodo.org/records/11452259,0.08655021738818101
+Massachusetts,1983,9,Project Tycho - https://zenodo.org/records/11452259,0.15503325807904147
+Massachusetts,1984,84,Project Tycho - https://zenodo.org/records/11452259,1.4367292653028343
+Massachusetts,1985,118,Project Tycho - https://zenodo.org/records/11452259,2.004548286085734
+Massachusetts,1986,37,Project Tycho - https://zenodo.org/records/11452259,0.6262079890599772
+Massachusetts,1987,68,Project Tycho - https://zenodo.org/records/11452259,1.144561674116697
+Massachusetts,1988,5,Project Tycho - https://zenodo.org/records/11452259,0.08352877674946428
+Massachusetts,1989,107,Project Tycho - https://zenodo.org/records/11452259,1.7769679380180299
+Massachusetts,1990,32,Project Tycho - https://zenodo.org/records/11452259,0.5311483660050439
+Massachusetts,1991,38,Project Tycho - https://zenodo.org/records/11452259,0.6328428801012549
+Massachusetts,1992,21,Project Tycho - https://zenodo.org/records/11452259,0.35003109442888847
+Massachusetts,1993,10,Project Tycho - https://zenodo.org/records/11452259,0.166198706508707
+Massachusetts,1994,5,Project Tycho - https://zenodo.org/records/11452259,0.08281733989710442
+Massachusetts,1995,3,Project Tycho - https://zenodo.org/records/11452259,0.04943644919737453
+Massachusetts,1996,4,Project Tycho - https://zenodo.org/records/11452259,0.06566550843654036
+Massachusetts,1997,16,"https://www.cdc.gov/mmwr/preview/mmwrhtml/00056071.htm#:~:text=As%20of%20January%201%2C%201997,and%20control%20of%20the%20disease.",0.2613699608484134
+Massachusetts,1998,2,https://stacks.cdc.gov/view/cdc/5637,0.03251741185464522
+Massachusetts,1999,8,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.12942169211097132
+Massachusetts,2000,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4953a1.htm,0.0
+Massachusetts,2001,2,Project Tycho - https://zenodo.org/records/11452259,0.031230329771982677
+Massachusetts,2002,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.0
+Massachusetts,2003,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.0
+Massachusetts,2004,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.031158991402143708
+Massachusetts,2005,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.0
+Massachusetts,2006,19,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.29611186420496927
+Massachusetts,2007,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.015532798280208574
+Massachusetts,2008,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.030885955924196597
+Massachusetts,2009,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.030655428386620134
+Massachusetts,2010,3,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.04564121803631398
+Massachusetts,2011,24,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.362492206417562
+Massachusetts,2012,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.0
+Massachusetts,2013,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.014876805914065917
+Massachusetts,2014,8,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.11813998051871721
+Massachusetts,2015,0,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.0
+Massachusetts,2016,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.014632489658122123
+Massachusetts,2017,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Massachusetts,2018,2,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.029016605477899866
+Massachusetts,2019,3,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.04346706652504131
+Massachusetts,2020,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.014282466044865225
+Massachusetts,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Massachusetts,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Michigan,1888,1,Project Tycho - https://zenodo.org/records/11452259,
+Michigan,1889,3,Project Tycho - https://zenodo.org/records/11452259,
+Michigan,1890,36,Project Tycho - https://zenodo.org/records/11452259,
+Michigan,1891,11,Project Tycho - https://zenodo.org/records/11452259,
+Michigan,1892,6,Project Tycho - https://zenodo.org/records/11452259,
+Michigan,1893,3,Project Tycho - https://zenodo.org/records/11452259,
+Michigan,1894,2,Project Tycho - https://zenodo.org/records/11452259,
+Michigan,1895,3,Project Tycho - https://zenodo.org/records/11452259,
+Michigan,1896,5,Project Tycho - https://zenodo.org/records/11452259,
+Michigan,1897,17,Project Tycho - https://zenodo.org/records/11452259,
+Michigan,1898,18,Project Tycho - https://zenodo.org/records/11452259,
+Michigan,1899,34,Project Tycho - https://zenodo.org/records/11452259,
+Michigan,1900,35,Project Tycho - https://zenodo.org/records/11452259,1.4430472540253803
+Michigan,1901,1,Project Tycho - https://zenodo.org/records/11452259,0.04077555097963261
+Michigan,1902,3,Project Tycho - https://zenodo.org/records/11452259,0.12099325785236162
+Michigan,1903,4,Project Tycho - https://zenodo.org/records/11452259,0.15952111760494994
+Michigan,1904,1,Project Tycho - https://zenodo.org/records/11452259,0.03942387525655087
+Michigan,1905,2,Project Tycho - https://zenodo.org/records/11452259,0.07747196580077542
+Michigan,1906,325,Project Tycho - https://zenodo.org/records/11452259,12.363873750012363
+Michigan,1907,1242,Project Tycho - https://zenodo.org/records/11452259,46.07349575786263
+Michigan,1908,1975,Project Tycho - https://zenodo.org/records/11452259,72.484458964988
+Michigan,1909,722,Project Tycho - https://zenodo.org/records/11452259,26.0295460584165
+Michigan,1910,2095,Project Tycho - https://zenodo.org/records/11452259,73.90208661395103
+Michigan,1911,2535,Project Tycho - https://zenodo.org/records/11452259,86.84730906953129
+Michigan,1912,379,Project Tycho - https://zenodo.org/records/11452259,12.6333459666793
+Michigan,1913,2717,Project Tycho - https://zenodo.org/records/11452259,87.52936840650482
+Michigan,1914,1590,Project Tycho - https://zenodo.org/records/11452259,49.90297167488496
+Michigan,1915,1077,Project Tycho - https://zenodo.org/records/11452259,32.97346233294747
+Michigan,1916,4069,Project Tycho - https://zenodo.org/records/11452259,121.23277855457992
+Michigan,1917,7401,Project Tycho - https://zenodo.org/records/11452259,214.24533160261933
+Michigan,1918,4393,Project Tycho - https://zenodo.org/records/11452259,125.42473245531261
+Michigan,1919,4934,Project Tycho - https://zenodo.org/records/11452259,137.26179139712974
+Michigan,1920,9874,Project Tycho - https://zenodo.org/records/11452259,264.95127220348814
+Michigan,1921,1931,Project Tycho - https://zenodo.org/records/11452259,49.821046721873174
+Michigan,1922,8430,Project Tycho - https://zenodo.org/records/11452259,213.6371999385698
+Michigan,1923,13268,Project Tycho - https://zenodo.org/records/11452259,326.2305009782243
+Michigan,1924,4695,Project Tycho - https://zenodo.org/records/11452259,111.30303014498554
+Michigan,1925,3645,Project Tycho - https://zenodo.org/records/11452259,84.07662529112541
+Michigan,1926,17856,Project Tycho - https://zenodo.org/records/11452259,400.7675092824498
+Michigan,1927,3195,Project Tycho - https://zenodo.org/records/11452259,69.5534580912659
+Michigan,1928,42825,Project Tycho - https://zenodo.org/records/11452259,917.0893415266406
+Michigan,1929,23785,Project Tycho - https://zenodo.org/records/11452259,495.5419971061264
+Michigan,1930,44587,Project Tycho - https://zenodo.org/records/11452259,921.4409917761179
+Michigan,1931,7865,Project Tycho - https://zenodo.org/records/11452259,163.75870898588698
+Michigan,1932,60439,Project Tycho - https://zenodo.org/records/11452259,1263.151074866556
+Michigan,1933,32800,Project Tycho - https://zenodo.org/records/11452259,685.5069616575893
+Michigan,1934,9162,Project Tycho - https://zenodo.org/records/11452259,190.76380060123284
+Michigan,1935,111413,Project Tycho - https://zenodo.org/records/11452259,2300.572515537377
+Michigan,1936,3321,Project Tycho - https://zenodo.org/records/11452259,67.86014149483162
+Michigan,1937,9185,Project Tycho - https://zenodo.org/records/11452259,184.69855426377165
+Michigan,1938,109041,Project Tycho - https://zenodo.org/records/11452259,2154.510837264002
+Michigan,1939,14078,Project Tycho - https://zenodo.org/records/11452259,272.7683487962774
+Michigan,1940,25333,Project Tycho - https://zenodo.org/records/11452259,476.15601707793616
+Michigan,1941,86581,Project Tycho - https://zenodo.org/records/11452259,1580.6744425165477
+Michigan,1942,9467,Project Tycho - https://zenodo.org/records/11452259,170.43687975387382
+Michigan,1943,66298,Project Tycho - https://zenodo.org/records/11452259,1225.3796157588943
+Michigan,1944,28900,Project Tycho - https://zenodo.org/records/11452259,528.0982050691215
+Michigan,1945,8528,Project Tycho - https://zenodo.org/records/11452259,155.60695012749807
+Michigan,1946,59563,Project Tycho - https://zenodo.org/records/11452259,1012.9978975739957
+Michigan,1947,9394,Project Tycho - https://zenodo.org/records/11452259,154.45384108978578
+Michigan,1948,48681,Project Tycho - https://zenodo.org/records/11452259,782.7517726117436
+Michigan,1949,19761,Project Tycho - https://zenodo.org/records/11452259,311.7697211190578
+Michigan,1950,38433,Project Tycho - https://zenodo.org/records/11452259,599.2602683721773
+Michigan,1951,14522,Project Tycho - https://zenodo.org/records/11452259,223.29525176993238
+Michigan,1952,39247,Project Tycho - https://zenodo.org/records/11452259,589.590860267552
+Michigan,1953,25401,Project Tycho - https://zenodo.org/records/11452259,371.96752236330076
+Michigan,1954,40177,Project Tycho - https://zenodo.org/records/11452259,568.0280659052241
+Michigan,1955,22520,Project Tycho - https://zenodo.org/records/11452259,308.8195263898764
+Michigan,1956,40655,Project Tycho - https://zenodo.org/records/11452259,543.9183824077356
+Michigan,1957,17553,Project Tycho - https://zenodo.org/records/11452259,231.67478577704497
+Michigan,1958,40569,Project Tycho - https://zenodo.org/records/11452259,528.6092543168323
+Michigan,1959,11469,Project Tycho - https://zenodo.org/records/11452259,147.51567474626572
+Michigan,1960,35379,Project Tycho - https://zenodo.org/records/11452259,451.1572165388862
+Michigan,1961,27653,Project Tycho - https://zenodo.org/records/11452259,349.9984115719577
+Michigan,1962,25666,Project Tycho - https://zenodo.org/records/11452259,323.21139090331076
+Michigan,1963,41217,Project Tycho - https://zenodo.org/records/11452259,510.99310220680286
+Michigan,1964,29002,Project Tycho - https://zenodo.org/records/11452259,353.8906433739706
+Michigan,1965,28161,Project Tycho - https://zenodo.org/records/11452259,336.63835267281485
+Michigan,1966,14984,Project Tycho - https://zenodo.org/records/11452259,175.8579766098563
+Michigan,1967,1153,Project Tycho - https://zenodo.org/records/11452259,13.34702377576074
+Michigan,1968,350,Project Tycho - https://zenodo.org/records/11452259,4.020818188251491
+Michigan,1969,388,Project Tycho - https://zenodo.org/records/11452259,4.414216918487503
+Michigan,1970,1819,Project Tycho - https://zenodo.org/records/11452259,20.459565251672338
+Michigan,1971,2590,Project Tycho - https://zenodo.org/records/11452259,28.831725139037932
+Michigan,1972,2328,Project Tycho - https://zenodo.org/records/11452259,25.757990841308203
+Michigan,1973,4250,Project Tycho - https://zenodo.org/records/11452259,46.76994129987202
+Michigan,1974,2303,Project Tycho - https://zenodo.org/records/11452259,25.233865227711803
+Michigan,1975,3173,Project Tycho - https://zenodo.org/records/11452259,34.76580197736662
+Michigan,1976,6021,Project Tycho - https://zenodo.org/records/11452259,65.88728317437293
+Michigan,1977,1305,Project Tycho - https://zenodo.org/records/11452259,14.215251145362542
+Michigan,1978,7625,Project Tycho - https://zenodo.org/records/11452259,82.63810751472475
+Michigan,1979,870,Project Tycho - https://zenodo.org/records/11452259,9.379513891060071
+Michigan,1980,278,Project Tycho - https://zenodo.org/records/11452259,3.000601847334559
+Michigan,1981,35,Project Tycho - https://zenodo.org/records/11452259,0.37967147786363414
+Michigan,1982,55,Project Tycho - https://zenodo.org/records/11452259,0.6027851083144562
+Michigan,1983,9,Project Tycho - https://zenodo.org/records/11452259,0.09937283594947047
+Michigan,1984,296,Project Tycho - https://zenodo.org/records/11452259,3.2676488085611517
+Michigan,1985,57,Project Tycho - https://zenodo.org/records/11452259,0.6273823330675947
+Michigan,1986,107,Project Tycho - https://zenodo.org/records/11452259,1.1710752725595612
+Michigan,1987,25,Project Tycho - https://zenodo.org/records/11452259,0.27183758291589954
+Michigan,1988,27,Project Tycho - https://zenodo.org/records/11452259,0.2926126680694012
+Michigan,1989,387,Project Tycho - https://zenodo.org/records/11452259,4.178116000046639
+Michigan,1990,453,Project Tycho - https://zenodo.org/records/11452259,4.860633929671241
+Michigan,1991,30,Project Tycho - https://zenodo.org/records/11452259,0.318999040557219
+Michigan,1992,5,Project Tycho - https://zenodo.org/records/11452259,0.052743767717290876
+Michigan,1993,7,Project Tycho - https://zenodo.org/records/11452259,0.0733847313002338
+Michigan,1994,7,Project Tycho - https://zenodo.org/records/11452259,0.07296177376325885
+Michigan,1995,5,https://stacks.cdc.gov/view/cdc/5644,0.05170882142151687
+Michigan,1996,3,Project Tycho - https://zenodo.org/records/11452259,0.0307726299612788
+Michigan,1997,2,"https://www.cdc.gov/mmwr/preview/mmwrhtml/00056071.htm#:~:text=As%20of%20January%201%2C%201997,and%20control%20of%20the%20disease.",0.02041809104120524
+Michigan,1998,3,Project Tycho - https://zenodo.org/records/11452259,0.030518661602060862
+Michigan,1999,6,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.06076787502235751
+Michigan,2000,1,Project Tycho - https://zenodo.org/records/11452259,0.010037739894455174
+Michigan,2001,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5053a1.htm,0.0
+Michigan,2002,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.0
+Michigan,2003,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.01989813547506251
+Michigan,2004,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0
+Michigan,2005,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.009939184120205289
+Michigan,2006,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.009954094701465252
+Michigan,2007,3,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.029966183162301343
+Michigan,2008,4,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.040173408517867375
+Michigan,2009,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.0
+Michigan,2010,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.0
+Michigan,2011,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.0202164453505006
+Michigan,2012,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.010092663773907376
+Michigan,2013,5,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.050379275336442875
+Michigan,2014,5,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.05029186886093443
+Michigan,2015,1,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.010055893673807123
+Michigan,2016,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.010036058554781475
+Michigan,2017,2,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.020026579276015127
+Michigan,2018,19,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.19005182713325924
+Michigan,2019,46,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.46024029145616924
+Michigan,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Michigan,2021,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.009948870763372874
+Michigan,2022,3,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.029818325885875126
+Minnesota,1888,1,Project Tycho - https://zenodo.org/records/11452259,
+Minnesota,1889,3,Project Tycho - https://zenodo.org/records/11452259,
+Minnesota,1890,22,Project Tycho - https://zenodo.org/records/11452259,
+Minnesota,1891,10,Project Tycho - https://zenodo.org/records/11452259,
+Minnesota,1892,12,Project Tycho - https://zenodo.org/records/11452259,
+Minnesota,1893,6,Project Tycho - https://zenodo.org/records/11452259,
+Minnesota,1894,4,Project Tycho - https://zenodo.org/records/11452259,
+Minnesota,1895,30,Project Tycho - https://zenodo.org/records/11452259,
+Minnesota,1896,12,Project Tycho - https://zenodo.org/records/11452259,
+Minnesota,1897,3,Project Tycho - https://zenodo.org/records/11452259,
+Minnesota,1898,64,Project Tycho - https://zenodo.org/records/11452259,
+Minnesota,1899,3,Project Tycho - https://zenodo.org/records/11452259,
+Minnesota,1900,3,Project Tycho - https://zenodo.org/records/11452259,0.17086676151670452
+Minnesota,1901,10,Project Tycho - https://zenodo.org/records/11452259,0.5534631573412737
+Minnesota,1902,2,Project Tycho - https://zenodo.org/records/11452259,0.10730408152534897
+Minnesota,1903,1,Project Tycho - https://zenodo.org/records/11452259,0.05255134134671221
+Minnesota,1907,63,Project Tycho - https://zenodo.org/records/11452259,3.15473999684526
+Minnesota,1908,42,Project Tycho - https://zenodo.org/records/11452259,2.077130790002077
+Minnesota,1913,42,Project Tycho - https://zenodo.org/records/11452259,1.9158923268512311
+Minnesota,1916,42,Project Tycho - https://zenodo.org/records/11452259,1.8179394262583168
+Minnesota,1917,748,Project Tycho - https://zenodo.org/records/11452259,32.08470361755033
+Minnesota,1918,1358,Project Tycho - https://zenodo.org/records/11452259,59.21620936898108
+Minnesota,1919,810,Project Tycho - https://zenodo.org/records/11452259,34.49236185809076
+Minnesota,1920,2231,Project Tycho - https://zenodo.org/records/11452259,92.74953095177814
+Minnesota,1921,575,Project Tycho - https://zenodo.org/records/11452259,23.60006468469903
+Minnesota,1922,1066,Project Tycho - https://zenodo.org/records/11452259,43.44900305732619
+Minnesota,1923,3618,Project Tycho - https://zenodo.org/records/11452259,145.33114653741916
+Minnesota,1924,723,Project Tycho - https://zenodo.org/records/11452259,28.65044515183349
+Minnesota,1925,286,Project Tycho - https://zenodo.org/records/11452259,11.24859392575928
+Minnesota,1926,3582,Project Tycho - https://zenodo.org/records/11452259,139.7820929070929
+Minnesota,1927,241,Project Tycho - https://zenodo.org/records/11452259,9.302907293633723
+Minnesota,1928,3732,Project Tycho - https://zenodo.org/records/11452259,143.83764383764384
+Minnesota,1929,17375,Project Tycho - https://zenodo.org/records/11452259,674.8694540296407
+Minnesota,1930,6415,Project Tycho - https://zenodo.org/records/11452259,248.78072238320686
+Minnesota,1931,5212,Project Tycho - https://zenodo.org/records/11452259,199.18872252460622
+Minnesota,1932,2966,Project Tycho - https://zenodo.org/records/11452259,111.98174463480585
+Minnesota,1933,27992,Project Tycho - https://zenodo.org/records/11452259,1046.1667027323592
+Minnesota,1934,10671,Project Tycho - https://zenodo.org/records/11452259,395.55991318514515
+Minnesota,1935,45114,Project Tycho - https://zenodo.org/records/11452259,1658.7755270125533
+Minnesota,1936,11029,Project Tycho - https://zenodo.org/records/11452259,402.99861075281706
+Minnesota,1937,800,Project Tycho - https://zenodo.org/records/11452259,29.10418059726144
+Minnesota,1938,9872,Project Tycho - https://zenodo.org/records/11452259,358.2323960093666
+Minnesota,1939,20612,Project Tycho - https://zenodo.org/records/11452259,743.103882764655
+Minnesota,1940,4986,Project Tycho - https://zenodo.org/records/11452259,178.53114627308176
+Minnesota,1941,2037,Project Tycho - https://zenodo.org/records/11452259,74.86994241961129
+Minnesota,1942,20013,Project Tycho - https://zenodo.org/records/11452259,751.0521034187451
+Minnesota,1943,12240,Project Tycho - https://zenodo.org/records/11452259,474.4963999911613
+Minnesota,1944,27073,Project Tycho - https://zenodo.org/records/11452259,1070.7028521755362
+Minnesota,1945,533,Project Tycho - https://zenodo.org/records/11452259,20.98807774803045
+Minnesota,1946,1675,Project Tycho - https://zenodo.org/records/11452259,61.20434064837869
+Minnesota,1947,11052,Project Tycho - https://zenodo.org/records/11452259,394.88408587121035
+Minnesota,1948,10224,Project Tycho - https://zenodo.org/records/11452259,356.12922642211345
+Minnesota,1949,3359,Project Tycho - https://zenodo.org/records/11452259,114.33200530304448
+Minnesota,1950,4133,Project Tycho - https://zenodo.org/records/11452259,137.7668044334711
+Minnesota,1951,2748,Project Tycho - https://zenodo.org/records/11452259,91.20447658653639
+Minnesota,1952,5855,Project Tycho - https://zenodo.org/records/11452259,193.04128215019304
+Minnesota,1953,6983,Project Tycho - https://zenodo.org/records/11452259,228.72209757455659
+Minnesota,1954,2893,Project Tycho - https://zenodo.org/records/11452259,92.84002216864408
+Minnesota,1955,7146,Project Tycho - https://zenodo.org/records/11452259,225.05867398679504
+Minnesota,1956,1361,Project Tycho - https://zenodo.org/records/11452259,41.9642086308753
+Minnesota,1957,7467,Project Tycho - https://zenodo.org/records/11452259,227.84179778681917
+Minnesota,1958,1254,Project Tycho - https://zenodo.org/records/11452259,37.81307735427868
+Minnesota,1959,2694,Project Tycho - https://zenodo.org/records/11452259,79.95569492895696
+Minnesota,1960,4325,Project Tycho - https://zenodo.org/records/11452259,126.15122104173199
+Minnesota,1961,723,Project Tycho - https://zenodo.org/records/11452259,20.814919950366637
+Minnesota,1962,1699,Project Tycho - https://zenodo.org/records/11452259,48.314907409698186
+Minnesota,1963,2669,Project Tycho - https://zenodo.org/records/11452259,75.51214008308317
+Minnesota,1964,345,Project Tycho - https://zenodo.org/records/11452259,9.686771912741557
+Minnesota,1965,950,Project Tycho - https://zenodo.org/records/11452259,26.421240229703482
+Minnesota,1966,1683,Project Tycho - https://zenodo.org/records/11452259,46.483789917574825
+Minnesota,1967,137,Project Tycho - https://zenodo.org/records/11452259,3.740451950345364
+Minnesota,1968,26,Project Tycho - https://zenodo.org/records/11452259,0.7014319733736423
+Minnesota,1969,18,Project Tycho - https://zenodo.org/records/11452259,0.4784996802027137
+Minnesota,1970,49,Project Tycho - https://zenodo.org/records/11452259,1.286119957195828
+Minnesota,1971,71,Project Tycho - https://zenodo.org/records/11452259,1.8406471404250444
+Minnesota,1972,26,Project Tycho - https://zenodo.org/records/11452259,0.671207471261994
+Minnesota,1973,24,Project Tycho - https://zenodo.org/records/11452259,0.6164561426130188
+Minnesota,1974,53,Project Tycho - https://zenodo.org/records/11452259,1.3562521175445796
+Minnesota,1975,53,Project Tycho - https://zenodo.org/records/11452259,1.3463918096699892
+Minnesota,1976,407,Project Tycho - https://zenodo.org/records/11452259,10.255392018029333
+Minnesota,1977,2574,Project Tycho - https://zenodo.org/records/11452259,64.45711160520996
+Minnesota,1978,43,Project Tycho - https://zenodo.org/records/11452259,1.0698231258938
+Minnesota,1979,1218,Project Tycho - https://zenodo.org/records/11452259,30.041688392217182
+Minnesota,1980,1106,Project Tycho - https://zenodo.org/records/11452259,27.047503339363995
+Minnesota,1981,7,Project Tycho - https://zenodo.org/records/11452259,0.17007467979189664
+Minnesota,1982,0,https://stacks.cdc.gov/view/cdc/35066,0.0
+Minnesota,1983,1,https://stacks.cdc.gov/view/cdc/35188,0.02412197808904242
+Minnesota,1984,48,Project Tycho - https://zenodo.org/records/11452259,1.1533296506876847
+Minnesota,1985,4,Project Tycho - https://zenodo.org/records/11452259,0.09549990139635181
+Minnesota,1986,32,Project Tycho - https://zenodo.org/records/11452259,0.7602002842673937
+Minnesota,1987,40,Project Tycho - https://zenodo.org/records/11452259,0.9435361991201052
+Minnesota,1988,21,Project Tycho - https://zenodo.org/records/11452259,0.48831962705402343
+Minnesota,1989,2,Project Tycho - https://zenodo.org/records/11452259,0.046057532767055966
+Minnesota,1990,367,Project Tycho - https://zenodo.org/records/11452259,8.356729900015257
+Minnesota,1991,27,Project Tycho - https://zenodo.org/records/11452259,0.6092255705059009
+Minnesota,1992,10,Project Tycho - https://zenodo.org/records/11452259,0.22341506005173398
+Minnesota,1993,0,https://stacks.cdc.gov/view/cdc/5650,0.0
+Minnesota,1994,0,https://stacks.cdc.gov/view/cdc/5648,0.0
+Minnesota,1995,9,https://stacks.cdc.gov/view/cdc/5644,0.19522564831184044
+Minnesota,1996,18,Project Tycho - https://zenodo.org/records/11452259,0.3868995802139555
+Minnesota,1997,8,Project Tycho - https://zenodo.org/records/11452259,0.17048797708130123
+Minnesota,1998,0,https://stacks.cdc.gov/view/cdc/5637,0.0
+Minnesota,1999,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.020919263566613108
+Minnesota,2000,1,Project Tycho - https://zenodo.org/records/11452259,0.020248550963071706
+Minnesota,2001,4,Project Tycho - https://zenodo.org/records/11452259,0.080196031178613
+Minnesota,2002,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.03980928961716003
+Minnesota,2003,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.0
+Minnesota,2004,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0
+Minnesota,2005,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.0
+Minnesota,2006,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.01934715726414171
+Minnesota,2007,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.019184983529691637
+Minnesota,2008,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.0
+Minnesota,2009,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.018916164316396304
+Minnesota,2010,3,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.05643081845001847
+Minnesota,2011,26,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.4858027872374376
+Minnesota,2012,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.0
+Minnesota,2013,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.03689944311360453
+Minnesota,2014,2,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.03664267365466882
+Minnesota,2015,2,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.03643328355332357
+Minnesota,2016,2,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.03616057827996785
+Minnesota,2017,75,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,1.3453271943362801
+Minnesota,2018,3,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.053434312309306294
+Minnesota,2019,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Minnesota,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Minnesota,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Minnesota,2022,22,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.38412233807584745
+Mississippi,1901,1,Project Tycho - https://zenodo.org/records/11452259,0.06330804809892263
+Mississippi,1903,1,Project Tycho - https://zenodo.org/records/11452259,0.0613636977273341
+Mississippi,1907,9,Project Tycho - https://zenodo.org/records/11452259,0.5203130203130203
+Mississippi,1909,1,Project Tycho - https://zenodo.org/records/11452259,0.05621840174456945
+Mississippi,1914,52,Project Tycho - https://zenodo.org/records/11452259,2.8355923552430102
+Mississippi,1917,36,Project Tycho - https://zenodo.org/records/11452259,1.9760459320898882
+Mississippi,1918,106,Project Tycho - https://zenodo.org/records/11452259,5.84082216735278
+Mississippi,1919,3215,https://www.jstor.org/stable/4575902,179.4295090384476
+Mississippi,1920,7,Project Tycho - https://zenodo.org/records/11452259,0.3885003885003885
+Mississippi,1921,13,Project Tycho - https://zenodo.org/records/11452259,0.7123978599568287
+Mississippi,1923,1,Project Tycho - https://zenodo.org/records/11452259,0.05376754569434871
+Mississippi,1924,25697,https://www.jstor.org/stable/4577735?seq=13,1361.1521034638745
+Mississippi,1925,5077,https://www.jstor.org/stable/4578131,265.5459723522551
+Mississippi,1937,0,Project Tycho - https://zenodo.org/records/11452259,0.0
+Mississippi,1938,0,Project Tycho - https://zenodo.org/records/11452259,0.0
+Mississippi,1939,0,Project Tycho - https://zenodo.org/records/11452259,0.0
+Mississippi,1940,0,Project Tycho - https://zenodo.org/records/11452259,0.0
+Mississippi,1941,0,Project Tycho - https://zenodo.org/records/11452259,0.0
+Mississippi,1944,0,Project Tycho - https://zenodo.org/records/11452259,0.0
+Mississippi,1945,0,Project Tycho - https://zenodo.org/records/11452259,0.0
+Mississippi,1947,324,Project Tycho - https://zenodo.org/records/11452259,15.361951764419727
+Mississippi,1948,1228,Project Tycho - https://zenodo.org/records/11452259,59.09312267693771
+Mississippi,1949,2226,Project Tycho - https://zenodo.org/records/11452259,106.6559339940635
+Mississippi,1950,2268,Project Tycho - https://zenodo.org/records/11452259,104.12381735911147
+Mississippi,1951,1940,Project Tycho - https://zenodo.org/records/11452259,89.60064438566519
+Mississippi,1952,1305,Project Tycho - https://zenodo.org/records/11452259,60.58068325726318
+Mississippi,1953,2414,Project Tycho - https://zenodo.org/records/11452259,114.56477014671789
+Mississippi,1954,3012,Project Tycho - https://zenodo.org/records/11452259,145.7844481100295
+Mississippi,1955,1499,Project Tycho - https://zenodo.org/records/11452259,72.69429599526687
+Mississippi,1956,2277,Project Tycho - https://zenodo.org/records/11452259,109.04723272892016
+Mississippi,1957,1258,Project Tycho - https://zenodo.org/records/11452259,60.188853292301566
+Mississippi,1958,1404,Project Tycho - https://zenodo.org/records/11452259,67.2386099039982
+Mississippi,1959,1421,Project Tycho - https://zenodo.org/records/11452259,66.39758744529558
+Mississippi,1960,1665,Project Tycho - https://zenodo.org/records/11452259,76.2299112436601
+Mississippi,1961,1527,Project Tycho - https://zenodo.org/records/11452259,69.15115709313352
+Mississippi,1962,2668,Project Tycho - https://zenodo.org/records/11452259,118.8290087086342
+Mississippi,1963,673,Project Tycho - https://zenodo.org/records/11452259,29.961126217810712
+Mississippi,1964,5852,Project Tycho - https://zenodo.org/records/11452259,260.8725500291765
+Mississippi,1965,1150,Project Tycho - https://zenodo.org/records/11452259,51.15098614653379
+Mississippi,1966,1280,Project Tycho - https://zenodo.org/records/11452259,56.958631568876555
+Mississippi,1967,678,Project Tycho - https://zenodo.org/records/11452259,30.400479233513344
+Mississippi,1968,241,Project Tycho - https://zenodo.org/records/11452259,10.849898186536311
+Mississippi,1969,23,Project Tycho - https://zenodo.org/records/11452259,1.035001035001035
+Mississippi,1970,138,Project Tycho - https://zenodo.org/records/11452259,6.218429080618779
+Mississippi,1971,1476,Project Tycho - https://zenodo.org/records/11452259,65.08806070652297
+Mississippi,1972,219,Project Tycho - https://zenodo.org/records/11452259,9.482884043813522
+Mississippi,1973,56,Project Tycho - https://zenodo.org/records/11452259,2.381058678214801
+Mississippi,1974,15,Project Tycho - https://zenodo.org/records/11452259,0.6300810788332243
+Mississippi,1975,36,Project Tycho - https://zenodo.org/records/11452259,1.4988458886657274
+Mississippi,1976,17,Project Tycho - https://zenodo.org/records/11452259,0.698959988652179
+Mississippi,1977,58,Project Tycho - https://zenodo.org/records/11452259,2.356133665900246
+Mississippi,1978,232,Project Tycho - https://zenodo.org/records/11452259,9.316135426090721
+Mississippi,1979,27,Project Tycho - https://zenodo.org/records/11452259,1.0758789532574426
+Mississippi,1980,31,Project Tycho - https://zenodo.org/records/11452259,1.2263303409554378
+Mississippi,1981,0,https://stacks.cdc.gov/view/cdc/1307,0.0
+Mississippi,1982,4,Project Tycho - https://zenodo.org/records/11452259,0.1562907210589634
+Mississippi,1983,2,Project Tycho - https://zenodo.org/records/11452259,0.07781241294736302
+Mississippi,1984,0,https://stacks.cdc.gov/view/cdc/35267,0.0
+Mississippi,1985,1,Project Tycho - https://zenodo.org/records/11452259,0.038599755277551544
+Mississippi,1986,7,Project Tycho - https://zenodo.org/records/11452259,0.2696258748396689
+Mississippi,1987,4,Project Tycho - https://zenodo.org/records/11452259,0.15437262386762857
+Mississippi,1988,10,Project Tycho - https://zenodo.org/records/11452259,0.38715692089454934
+Mississippi,1989,1,Project Tycho - https://zenodo.org/records/11452259,0.03880717606776975
+Mississippi,1990,28,https://stacks.cdc.gov/view/cdc/35905,1.085270055887532
+Mississippi,1991,0,https://stacks.cdc.gov/view/cdc/36010,0.0
+Mississippi,1992,17,https://stacks.cdc.gov/view/cdc/36063,0.6506422413017744
+Mississippi,1993,0,https://stacks.cdc.gov/view/cdc/5650,0.0
+Mississippi,1994,0,https://stacks.cdc.gov/view/cdc/5648,0.0
+Mississippi,1995,0,https://stacks.cdc.gov/view/cdc/5644,0.0
+Mississippi,1996,0,https://stacks.cdc.gov/view/cdc/5642,0.0
+Mississippi,1997,0,"https://www.cdc.gov/mmwr/preview/mmwrhtml/00056071.htm#:~:text=As%20of%20January%201%2C%201997,and%20control%20of%20the%20disease.",0.0
+Mississippi,1998,0,https://stacks.cdc.gov/view/cdc/5637,0.0
+Mississippi,1999,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.0
+Mississippi,2000,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4953a1.htm,0.0
+Mississippi,2001,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5053a1.htm,0.0
+Mississippi,2002,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.0
+Mississippi,2003,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.0
+Mississippi,2004,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0
+Mississippi,2005,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.0
+Mississippi,2006,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.0
+Mississippi,2007,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.0
+Mississippi,2008,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.0
+Mississippi,2009,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.0
+Mississippi,2010,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.0
+Mississippi,2011,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.0
+Mississippi,2012,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.0
+Mississippi,2013,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.0
+Mississippi,2014,0,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.0
+Mississippi,2015,0,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.0
+Mississippi,2016,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Mississippi,2017,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Mississippi,2018,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Mississippi,2019,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Mississippi,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Mississippi,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Mississippi,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Missouri,1889,7,Project Tycho - https://zenodo.org/records/11452259,
+Missouri,1890,15,Project Tycho - https://zenodo.org/records/11452259,
+Missouri,1891,4,Project Tycho - https://zenodo.org/records/11452259,
+Missouri,1892,1,Project Tycho - https://zenodo.org/records/11452259,
+Missouri,1899,1,Project Tycho - https://zenodo.org/records/11452259,
+Missouri,1906,274,Project Tycho - https://zenodo.org/records/11452259,8.4929033113954
+Missouri,1907,736,Project Tycho - https://zenodo.org/records/11452259,22.67935642395852
+Missouri,1908,331,Project Tycho - https://zenodo.org/records/11452259,10.143231002126708
+Missouri,1909,333,Project Tycho - https://zenodo.org/records/11452259,10.145389834319387
+Missouri,1910,2084,Project Tycho - https://zenodo.org/records/11452259,63.06931481121121
+Missouri,1911,147,Project Tycho - https://zenodo.org/records/11452259,4.427288117369516
+Missouri,1912,114,Project Tycho - https://zenodo.org/records/11452259,3.4056852238670423
+Missouri,1913,2023,Project Tycho - https://zenodo.org/records/11452259,59.283632178909386
+Missouri,1914,243,Project Tycho - https://zenodo.org/records/11452259,7.0019395084292695
+Missouri,1915,39,Project Tycho - https://zenodo.org/records/11452259,1.1157227652073014
+Missouri,1916,3245,Project Tycho - https://zenodo.org/records/11452259,91.91262380941996
+Missouri,1917,2196,Project Tycho - https://zenodo.org/records/11452259,63.2220805131468
+Missouri,1918,1085,Project Tycho - https://zenodo.org/records/11452259,32.59897996740102
+Missouri,1919,1291,Project Tycho - https://zenodo.org/records/11452259,38.25898219253307
+Missouri,1920,1395,Project Tycho - https://zenodo.org/records/11452259,40.94025833156268
+Missouri,1921,1484,Project Tycho - https://zenodo.org/records/11452259,43.23468890398024
+Missouri,1922,314,Project Tycho - https://zenodo.org/records/11452259,9.126747561428969
+Missouri,1923,4456,Project Tycho - https://zenodo.org/records/11452259,128.88096269682836
+Missouri,1924,1716,Project Tycho - https://zenodo.org/records/11452259,48.86789379377748
+Missouri,1925,162,Project Tycho - https://zenodo.org/records/11452259,4.589851441808333
+Missouri,1926,3524,Project Tycho - https://zenodo.org/records/11452259,99.00111137456469
+Missouri,1927,1791,Project Tycho - https://zenodo.org/records/11452259,50.03385875869097
+Missouri,1928,8298,Project Tycho - https://zenodo.org/records/11452259,230.20578421855845
+Missouri,1929,10827,Project Tycho - https://zenodo.org/records/11452259,298.62462220275586
+Missouri,1930,6598,Project Tycho - https://zenodo.org/records/11452259,180.7846569228906
+Missouri,1931,16925,Project Tycho - https://zenodo.org/records/11452259,455.62090832907325
+Missouri,1932,2002,Project Tycho - https://zenodo.org/records/11452259,53.39028296849973
+Missouri,1933,9185,Project Tycho - https://zenodo.org/records/11452259,243.19703619995167
+Missouri,1934,20564,Project Tycho - https://zenodo.org/records/11452259,542.9031856093167
+Missouri,1935,15365,Project Tycho - https://zenodo.org/records/11452259,404.1508780845274
+Missouri,1936,711,Project Tycho - https://zenodo.org/records/11452259,18.686916871605113
+Missouri,1937,7186,Project Tycho - https://zenodo.org/records/11452259,189.21510750714756
+Missouri,1938,20551,Project Tycho - https://zenodo.org/records/11452259,542.9904662911804
+Missouri,1939,455,Project Tycho - https://zenodo.org/records/11452259,12.015475933001706
+Missouri,1940,824,Project Tycho - https://zenodo.org/records/11452259,21.742652487501932
+Missouri,1941,8131,Project Tycho - https://zenodo.org/records/11452259,213.14293158953353
+Missouri,1942,8209,Project Tycho - https://zenodo.org/records/11452259,214.17600419950904
+Missouri,1943,9191,Project Tycho - https://zenodo.org/records/11452259,247.82235308551097
+Missouri,1944,6529,Project Tycho - https://zenodo.org/records/11452259,183.21566074375062
+Missouri,1945,1350,Project Tycho - https://zenodo.org/records/11452259,38.3575468899701
+Missouri,1946,8334,Project Tycho - https://zenodo.org/records/11452259,222.2550540756627
+Missouri,1947,1176,Project Tycho - https://zenodo.org/records/11452259,30.554620931734068
+Missouri,1948,6410,Project Tycho - https://zenodo.org/records/11452259,166.5867950987618
+Missouri,1949,7910,Project Tycho - https://zenodo.org/records/11452259,203.5573905743921
+Missouri,1950,2569,Project Tycho - https://zenodo.org/records/11452259,64.7435309392928
+Missouri,1951,7400,Project Tycho - https://zenodo.org/records/11452259,184.12471712596246
+Missouri,1952,3578,Project Tycho - https://zenodo.org/records/11452259,89.99057337425917
+Missouri,1953,10627,Project Tycho - https://zenodo.org/records/11452259,264.0891446861596
+Missouri,1954,1541,Project Tycho - https://zenodo.org/records/11452259,37.86179388737185
+Missouri,1955,3991,Project Tycho - https://zenodo.org/records/11452259,96.44443606707758
+Missouri,1956,5344,Project Tycho - https://zenodo.org/records/11452259,128.2407239649613
+Missouri,1957,4147,Project Tycho - https://zenodo.org/records/11452259,98.89847559935887
+Missouri,1958,3442,Project Tycho - https://zenodo.org/records/11452259,82.14432485813279
+Missouri,1959,3605,Project Tycho - https://zenodo.org/records/11452259,84.57958199620951
+Missouri,1960,751,Project Tycho - https://zenodo.org/records/11452259,17.34280513753468
+Missouri,1961,4442,Project Tycho - https://zenodo.org/records/11452259,102.03638623965136
+Missouri,1962,1400,Project Tycho - https://zenodo.org/records/11452259,32.100100954817506
+Missouri,1963,2793,Project Tycho - https://zenodo.org/records/11452259,63.529366808055336
+Missouri,1964,1074,Project Tycho - https://zenodo.org/records/11452259,24.154143920015148
+Missouri,1965,2688,Project Tycho - https://zenodo.org/records/11452259,60.114499335453
+Missouri,1966,568,Project Tycho - https://zenodo.org/records/11452259,12.54549121009435
+Missouri,1967,341,Project Tycho - https://zenodo.org/records/11452259,7.505162825718013
+Missouri,1968,31,Project Tycho - https://zenodo.org/records/11452259,0.677956019462149
+Missouri,1969,74,Project Tycho - https://zenodo.org/records/11452259,1.5932343518550414
+Missouri,1970,779,Project Tycho - https://zenodo.org/records/11452259,16.637122781538988
+Missouri,1971,2038,Project Tycho - https://zenodo.org/records/11452259,43.0822268057277
+Missouri,1972,179,Project Tycho - https://zenodo.org/records/11452259,3.7577111802194088
+Missouri,1973,59,Project Tycho - https://zenodo.org/records/11452259,1.2323947707192193
+Missouri,1974,264,Project Tycho - https://zenodo.org/records/11452259,5.499169396289102
+Missouri,1975,260,Project Tycho - https://zenodo.org/records/11452259,5.401905958634697
+Missouri,1976,230,Project Tycho - https://zenodo.org/records/11452259,4.748271422755534
+Missouri,1977,966,Project Tycho - https://zenodo.org/records/11452259,19.8437316404398
+Missouri,1978,173,Project Tycho - https://zenodo.org/records/11452259,3.5347327333413974
+Missouri,1979,475,Project Tycho - https://zenodo.org/records/11452259,9.659690133409471
+Missouri,1980,50,Project Tycho - https://zenodo.org/records/11452259,1.0148395934390213
+Missouri,1981,1,Project Tycho - https://zenodo.org/records/11452259,0.020255232129011244
+Missouri,1982,2,Project Tycho - https://zenodo.org/records/11452259,0.04053194119625971
+Missouri,1983,3,Project Tycho - https://zenodo.org/records/11452259,0.060622275533900385
+Missouri,1984,6,Project Tycho - https://zenodo.org/records/11452259,0.12047580715276915
+Missouri,1985,3,Project Tycho - https://zenodo.org/records/11452259,0.05993685053427709
+Missouri,1986,32,Project Tycho - https://zenodo.org/records/11452259,0.6364244402100121
+Missouri,1987,191,Project Tycho - https://zenodo.org/records/11452259,3.7733970372313776
+Missouri,1988,21,Project Tycho - https://zenodo.org/records/11452259,0.4128318357039382
+Missouri,1989,62,Project Tycho - https://zenodo.org/records/11452259,1.2154658223753536
+Missouri,1990,1,Project Tycho - https://zenodo.org/records/11452259,0.01948749448503906
+Missouri,1991,1,https://stacks.cdc.gov/view/cdc/36010,0.019368858014068378
+Missouri,1992,1,Project Tycho - https://zenodo.org/records/11452259,0.01923491583474053
+Missouri,1993,1,https://stacks.cdc.gov/view/cdc/5650,0.019073071607558584
+Missouri,1994,137,Project Tycho - https://zenodo.org/records/11452259,2.5915130407016984
+Missouri,1995,2,https://stacks.cdc.gov/view/cdc/5644,0.037523916806474523
+Missouri,1996,1,Project Tycho - https://zenodo.org/records/11452259,0.018610693145960876
+Missouri,1997,3,Project Tycho - https://zenodo.org/records/11452259,0.055427046920842785
+Missouri,1998,0,https://stacks.cdc.gov/view/cdc/5637,0.0
+Missouri,1999,1,Project Tycho - https://zenodo.org/records/11452259,0.018268824287890364
+Missouri,2000,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4953a1.htm,0.0
+Missouri,2001,3,Project Tycho - https://zenodo.org/records/11452259,0.05312759495096589
+Missouri,2002,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.035208174493121115
+Missouri,2003,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.0
+Missouri,2004,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.034761522054100054
+Missouri,2005,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.0
+Missouri,2006,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.01709826681708582
+Missouri,2007,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.0
+Missouri,2008,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.0168638642634311
+Missouri,2009,6,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.10055221601163322
+Missouri,2010,3,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.04998263103571509
+Missouri,2011,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.0
+Missouri,2012,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.0
+Missouri,2013,3,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.0495947202122125
+Missouri,2014,27,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.44516337413393053
+Missouri,2015,1,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.016443349536609968
+Missouri,2016,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Missouri,2017,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Missouri,2018,14,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.2283063695357113
+Missouri,2019,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.016269117229564565
+Missouri,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Missouri,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Missouri,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Montana,1907,39,Project Tycho - https://zenodo.org/records/11452259,11.735252699108122
+Montana,1908,48,Project Tycho - https://zenodo.org/records/11452259,13.85897339654565
+Montana,1909,22,Project Tycho - https://zenodo.org/records/11452259,6.054551509096964
+Montana,1910,21,Project Tycho - https://zenodo.org/records/11452259,5.520794994479205
+Montana,1911,10,Project Tycho - https://zenodo.org/records/11452259,2.516375312345086
+Montana,1912,5,Project Tycho - https://zenodo.org/records/11452259,1.2065229456533804
+Montana,1913,17,Project Tycho - https://zenodo.org/records/11452259,3.922174822867664
+Montana,1914,52,Project Tycho - https://zenodo.org/records/11452259,11.492931846914148
+Montana,1915,28,Project Tycho - https://zenodo.org/records/11452259,5.9641850686626805
+Montana,1916,1066,Project Tycho - https://zenodo.org/records/11452259,218.6724979332782
+Montana,1917,361,Project Tycho - https://zenodo.org/records/11452259,71.41373478007141
+Montana,1918,145,Project Tycho - https://zenodo.org/records/11452259,28.913202565897173
+Montana,1919,163,Project Tycho - https://zenodo.org/records/11452259,30.49385071856982
+Montana,1920,2134,Project Tycho - https://zenodo.org/records/11452259,392.6092323882379
+Montana,1921,1029,Project Tycho - https://zenodo.org/records/11452259,188.27326519634212
+Montana,1922,22,Project Tycho - https://zenodo.org/records/11452259,4.047517859672555
+Montana,1923,1013,Project Tycho - https://zenodo.org/records/11452259,188.10186096431448
+Montana,1924,2175,Project Tycho - https://zenodo.org/records/11452259,403.87122171508787
+Montana,1925,553,Project Tycho - https://zenodo.org/records/11452259,103.26122475655187
+Montana,1926,1047,Project Tycho - https://zenodo.org/records/11452259,196.97816307985798
+Montana,1927,416,Project Tycho - https://zenodo.org/records/11452259,78.85852288129327
+Montana,1928,1133,Project Tycho - https://zenodo.org/records/11452259,209.21776929170647
+Montana,1929,5425,Project Tycho - https://zenodo.org/records/11452259,1034.2710724390113
+Montana,1930,789,Project Tycho - https://zenodo.org/records/11452259,146.23595328604605
+Montana,1931,2322,Project Tycho - https://zenodo.org/records/11452259,429.5704295704296
+Montana,1932,7069,Project Tycho - https://zenodo.org/records/11452259,1307.7663077663078
+Montana,1933,2599,Project Tycho - https://zenodo.org/records/11452259,479.92672761619156
+Montana,1934,2485,Project Tycho - https://zenodo.org/records/11452259,455.5077949573362
+Montana,1935,9976,Project Tycho - https://zenodo.org/records/11452259,1812.0061756425393
+Montana,1936,484,Project Tycho - https://zenodo.org/records/11452259,87.27734359503313
+Montana,1937,758,Project Tycho - https://zenodo.org/records/11452259,136.68641827486593
+Montana,1938,3007,Project Tycho - https://zenodo.org/records/11452259,544.2021746369572
+Montana,1939,9925,Project Tycho - https://zenodo.org/records/11452259,1786.5017865017862
+Montana,1940,1448,Project Tycho - https://zenodo.org/records/11452259,259.2389689163883
+Montana,1941,1051,Project Tycho - https://zenodo.org/records/11452259,193.36096684162982
+Montana,1942,4625,Project Tycho - https://zenodo.org/records/11452259,891.9651776794634
+Montana,1943,7668,Project Tycho - https://zenodo.org/records/11452259,1579.4514763586928
+Montana,1944,3942,Project Tycho - https://zenodo.org/records/11452259,839.6720550238674
+Montana,1945,644,Project Tycho - https://zenodo.org/records/11452259,134.87560657371978
+Montana,1946,2797,Project Tycho - https://zenodo.org/records/11452259,543.6198043201933
+Montana,1947,6939,Project Tycho - https://zenodo.org/records/11452259,1305.474186830119
+Montana,1948,2028,Project Tycho - https://zenodo.org/records/11452259,373.7959457516653
+Montana,1949,3847,Project Tycho - https://zenodo.org/records/11452259,675.4229952823978
+Montana,1950,1873,Project Tycho - https://zenodo.org/records/11452259,315.53606595765115
+Montana,1951,2558,Project Tycho - https://zenodo.org/records/11452259,428.7658650074758
+Montana,1952,3875,Project Tycho - https://zenodo.org/records/11452259,643.0446629782178
+Montana,1953,3101,Project Tycho - https://zenodo.org/records/11452259,502.90618472436654
+Montana,1954,4680,Project Tycho - https://zenodo.org/records/11452259,749.2507492507493
+Montana,1955,2861,Project Tycho - https://zenodo.org/records/11452259,449.39337392167585
+Montana,1956,6768,Project Tycho - https://zenodo.org/records/11452259,1030.6766404327382
+Montana,1957,3502,Project Tycho - https://zenodo.org/records/11452259,524.5129682910792
+Montana,1958,7021,Project Tycho - https://zenodo.org/records/11452259,1053.151053151053
+Montana,1959,4185,Project Tycho - https://zenodo.org/records/11452259,624.9356025140778
+Montana,1960,2132,Project Tycho - https://zenodo.org/records/11452259,313.67748598970985
+Montana,1961,2270,Project Tycho - https://zenodo.org/records/11452259,325.82360168567067
+Montana,1962,8490,Project Tycho - https://zenodo.org/records/11452259,1215.117260962533
+Montana,1963,3202,Project Tycho - https://zenodo.org/records/11452259,455.0215076530866
+Montana,1964,4037,Project Tycho - https://zenodo.org/records/11452259,571.2417893721009
+Montana,1965,3928,Project Tycho - https://zenodo.org/records/11452259,555.8181195574963
+Montana,1966,1928,Project Tycho - https://zenodo.org/records/11452259,272.4291267431296
+Montana,1967,343,Project Tycho - https://zenodo.org/records/11452259,48.88121863870794
+Montana,1968,68,Project Tycho - https://zenodo.org/records/11452259,9.704581133152562
+Montana,1969,118,Project Tycho - https://zenodo.org/records/11452259,16.98589594843197
+Montana,1970,109,Project Tycho - https://zenodo.org/records/11452259,15.681129271489262
+Montana,1971,812,Project Tycho - https://zenodo.org/records/11452259,114.12123835597957
+Montana,1972,15,Project Tycho - https://zenodo.org/records/11452259,2.084925985127528
+Montana,1973,358,Project Tycho - https://zenodo.org/records/11452259,49.2079986364711
+Montana,1974,346,Project Tycho - https://zenodo.org/records/11452259,46.93721130562772
+Montana,1975,53,Project Tycho - https://zenodo.org/records/11452259,7.076517178579249
+Montana,1976,507,Project Tycho - https://zenodo.org/records/11452259,66.88001435216087
+Montana,1977,1020,Project Tycho - https://zenodo.org/records/11452259,132.3434390091369
+Montana,1978,111,Project Tycho - https://zenodo.org/records/11452259,14.17445303850471
+Montana,1979,60,Project Tycho - https://zenodo.org/records/11452259,7.613324332692121
+Montana,1980,1,Project Tycho - https://zenodo.org/records/11452259,0.1266560275603516
+Montana,1981,0,https://stacks.cdc.gov/view/cdc/1307,0.0
+Montana,1982,0,https://stacks.cdc.gov/view/cdc/35066,0.0
+Montana,1983,4,Project Tycho - https://zenodo.org/records/11452259,0.4908909056323595
+Montana,1984,0,https://stacks.cdc.gov/view/cdc/35267,0.0
+Montana,1985,151,Project Tycho - https://zenodo.org/records/11452259,18.34434398925094
+Montana,1986,10,Project Tycho - https://zenodo.org/records/11452259,1.2276687062336105
+Montana,1987,139,Project Tycho - https://zenodo.org/records/11452259,17.24848238173001
+Montana,1988,93,Project Tycho - https://zenodo.org/records/11452259,11.610457901478398
+Montana,1989,13,Project Tycho - https://zenodo.org/records/11452259,1.6241168864429967
+Montana,1990,1,Project Tycho - https://zenodo.org/records/11452259,0.12490273199745698
+Montana,1991,0,https://stacks.cdc.gov/view/cdc/36010,0.0
+Montana,1992,0,https://stacks.cdc.gov/view/cdc/36063,0.0
+Montana,1993,0,https://stacks.cdc.gov/view/cdc/5650,0.0
+Montana,1994,0,https://stacks.cdc.gov/view/cdc/5648,0.0
+Montana,1995,0,https://stacks.cdc.gov/view/cdc/5644,0.0
+Montana,1996,0,https://stacks.cdc.gov/view/cdc/5642,0.0
+Montana,1997,0,"https://www.cdc.gov/mmwr/preview/mmwrhtml/00056071.htm#:~:text=As%20of%20January%201%2C%201997,and%20control%20of%20the%20disease.",0.0
+Montana,1998,0,https://stacks.cdc.gov/view/cdc/5637,0.0
+Montana,1999,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.0
+Montana,2000,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4953a1.htm,0.0
+Montana,2001,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5053a1.htm,0.0
+Montana,2002,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.0
+Montana,2003,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.0
+Montana,2004,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0
+Montana,2005,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.0
+Montana,2006,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.0
+Montana,2007,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.0
+Montana,2008,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.0
+Montana,2009,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.0
+Montana,2010,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.0
+Montana,2011,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.0
+Montana,2012,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.0
+Montana,2013,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.0
+Montana,2014,0,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.0
+Montana,2015,0,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.0
+Montana,2016,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Montana,2017,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Montana,2018,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Montana,2019,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Montana,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Montana,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Montana,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Nebraska,1893,1,Project Tycho - https://zenodo.org/records/11452259,
+Nebraska,1894,15,Project Tycho - https://zenodo.org/records/11452259,
+Nebraska,1895,1,Project Tycho - https://zenodo.org/records/11452259,
+Nebraska,1897,14,Project Tycho - https://zenodo.org/records/11452259,
+Nebraska,1906,1,Project Tycho - https://zenodo.org/records/11452259,0.08778567653787336
+Nebraska,1907,324,Project Tycho - https://zenodo.org/records/11452259,28.170263157208325
+Nebraska,1908,158,Project Tycho - https://zenodo.org/records/11452259,13.595362432571733
+Nebraska,1909,88,Project Tycho - https://zenodo.org/records/11452259,7.469166347671021
+Nebraska,1910,100,Project Tycho - https://zenodo.org/records/11452259,8.338906502512511
+Nebraska,1911,73,Project Tycho - https://zenodo.org/records/11452259,5.997292181502708
+Nebraska,1912,33,Project Tycho - https://zenodo.org/records/11452259,2.6758955330383905
+Nebraska,1913,11,Project Tycho - https://zenodo.org/records/11452259,0.8819430970313796
+Nebraska,1915,343,Project Tycho - https://zenodo.org/records/11452259,26.93847033469675
+Nebraska,1916,340,Project Tycho - https://zenodo.org/records/11452259,26.64002664002664
+Nebraska,1917,2040,Project Tycho - https://zenodo.org/records/11452259,158.5962675456839
+Nebraska,1918,822,Project Tycho - https://zenodo.org/records/11452259,64.86404590669994
+Nebraska,1919,406,Project Tycho - https://zenodo.org/records/11452259,31.441426790264
+Nebraska,1920,2078,Project Tycho - https://zenodo.org/records/11452259,159.6864673787751
+Nebraska,1921,480,Project Tycho - https://zenodo.org/records/11452259,36.63258055924213
+Nebraska,1922,1200,Project Tycho - https://zenodo.org/records/11452259,91.37204259155479
+Nebraska,1923,509,Project Tycho - https://zenodo.org/records/11452259,38.49292267157521
+Nebraska,1924,2296,Project Tycho - https://zenodo.org/records/11452259,172.07098977541588
+Nebraska,1925,57,Project Tycho - https://zenodo.org/records/11452259,4.239989347956586
+Nebraska,1926,1148,Project Tycho - https://zenodo.org/records/11452259,84.7637211273575
+Nebraska,1927,2894,Project Tycho - https://zenodo.org/records/11452259,211.80284916548655
+Nebraska,1928,1148,Project Tycho - https://zenodo.org/records/11452259,83.65084951518212
+Nebraska,1929,5265,Project Tycho - https://zenodo.org/records/11452259,382.52656434474613
+Nebraska,1930,11334,Project Tycho - https://zenodo.org/records/11452259,820.4838639621249
+Nebraska,1931,387,Project Tycho - https://zenodo.org/records/11452259,27.93449325241233
+Nebraska,1932,487,Project Tycho - https://zenodo.org/records/11452259,35.10198315393121
+Nebraska,1933,2808,Project Tycho - https://zenodo.org/records/11452259,202.5411411693
+Nebraska,1934,7181,Project Tycho - https://zenodo.org/records/11452259,519.090171767451
+Nebraska,1935,9794,Project Tycho - https://zenodo.org/records/11452259,711.579329761148
+Nebraska,1936,1300,Project Tycho - https://zenodo.org/records/11452259,95.63337987491154
+Nebraska,1937,488,Project Tycho - https://zenodo.org/records/11452259,36.4086995901783
+Nebraska,1938,4257,Project Tycho - https://zenodo.org/records/11452259,320.72000397792254
+Nebraska,1939,5365,Project Tycho - https://zenodo.org/records/11452259,406.64949617908644
+Nebraska,1940,1056,Project Tycho - https://zenodo.org/records/11452259,80.1629980961288
+Nebraska,1941,601,Project Tycho - https://zenodo.org/records/11452259,47.201226446509466
+Nebraska,1942,7607,Project Tycho - https://zenodo.org/records/11452259,613.349523761146
+Nebraska,1943,5113,Project Tycho - https://zenodo.org/records/11452259,411.5948515626195
+Nebraska,1944,3108,Project Tycho - https://zenodo.org/records/11452259,255.33676849466323
+Nebraska,1945,1080,Project Tycho - https://zenodo.org/records/11452259,89.09340040636489
+Nebraska,1946,6276,Project Tycho - https://zenodo.org/records/11452259,499.18234631610426
+Nebraska,1947,520,Project Tycho - https://zenodo.org/records/11452259,41.06565371387506
+Nebraska,1948,4712,Project Tycho - https://zenodo.org/records/11452259,372.11800057649856
+Nebraska,1949,2708,Project Tycho - https://zenodo.org/records/11452259,207.77993128223542
+Nebraska,1950,3882,Project Tycho - https://zenodo.org/records/11452259,292.2473156082802
+Nebraska,1951,558,Project Tycho - https://zenodo.org/records/11452259,42.3588569485226
+Nebraska,1952,3562,Project Tycho - https://zenodo.org/records/11452259,271.429562047411
+Nebraska,1953,2707,Project Tycho - https://zenodo.org/records/11452259,205.1817681559715
+Nebraska,1954,2568,Project Tycho - https://zenodo.org/records/11452259,191.45034070407206
+Nebraska,1955,166,Project Tycho - https://zenodo.org/records/11452259,12.069444383854865
+Nebraska,1956,2502,Project Tycho - https://zenodo.org/records/11452259,178.91914813890477
+Nebraska,1957,228,Project Tycho - https://zenodo.org/records/11452259,16.339471145783914
+Nebraska,1958,1504,Project Tycho - https://zenodo.org/records/11452259,108.64045571203924
+Nebraska,1959,410,Project Tycho - https://zenodo.org/records/11452259,29.319284866886868
+Nebraska,1960,210,Project Tycho - https://zenodo.org/records/11452259,14.805237105872251
+Nebraska,1961,639,Project Tycho - https://zenodo.org/records/11452259,44.14672464464996
+Nebraska,1962,119,Project Tycho - https://zenodo.org/records/11452259,8.120295005540907
+Nebraska,1963,234,Project Tycho - https://zenodo.org/records/11452259,15.837820715869496
+Nebraska,1964,810,Project Tycho - https://zenodo.org/records/11452259,54.60126917616796
+Nebraska,1965,470,Project Tycho - https://zenodo.org/records/11452259,31.919134570392217
+Nebraska,1966,169,Project Tycho - https://zenodo.org/records/11452259,11.595547309833025
+Nebraska,1967,532,Project Tycho - https://zenodo.org/records/11452259,36.476906758306896
+Nebraska,1968,72,Project Tycho - https://zenodo.org/records/11452259,4.903072387734965
+Nebraska,1969,616,Project Tycho - https://zenodo.org/records/11452259,41.749295480638764
+Nebraska,1970,787,Project Tycho - https://zenodo.org/records/11452259,52.93183160279201
+Nebraska,1971,71,Project Tycho - https://zenodo.org/records/11452259,4.714137365979067
+Nebraska,1972,24,Project Tycho - https://zenodo.org/records/11452259,1.5783949301954843
+Nebraska,1973,6,Project Tycho - https://zenodo.org/records/11452259,0.39187614623772776
+Nebraska,1974,114,Project Tycho - https://zenodo.org/records/11452259,7.399090041733463
+Nebraska,1975,376,Project Tycho - https://zenodo.org/records/11452259,24.34192637862054
+Nebraska,1976,55,Project Tycho - https://zenodo.org/records/11452259,3.542762104812939
+Nebraska,1977,209,Project Tycho - https://zenodo.org/records/11452259,13.41120817660187
+Nebraska,1978,5,https://stacks.cdc.gov/view/cdc/51063,0.31939759059233563
+Nebraska,1979,68,Project Tycho - https://zenodo.org/records/11452259,4.334216536183378
+Nebraska,1980,56,Project Tycho - https://zenodo.org/records/11452259,3.558112878589564
+Nebraska,1981,1,Project Tycho - https://zenodo.org/records/11452259,0.0632874140952463
+Nebraska,1982,3,Project Tycho - https://zenodo.org/records/11452259,0.18947037346505313
+Nebraska,1983,0,https://stacks.cdc.gov/view/cdc/35188,0.0
+Nebraska,1984,0,https://stacks.cdc.gov/view/cdc/35267,0.0
+Nebraska,1985,0,https://stacks.cdc.gov/view/cdc/35429,0.0
+Nebraska,1986,1,https://stacks.cdc.gov/view/cdc/35496,0.0634555211697137
+Nebraska,1987,0,https://stacks.cdc.gov/view/cdc/35629,0.0
+Nebraska,1988,0,https://stacks.cdc.gov/view/cdc/35958,0.0
+Nebraska,1989,158,https://stacks.cdc.gov/view/cdc/35853,10.022595243200177
+Nebraska,1990,103,https://stacks.cdc.gov/view/cdc/35905,6.50974186029462
+Nebraska,1991,1,https://stacks.cdc.gov/view/cdc/36010,0.06279848906835302
+Nebraska,1992,0,https://stacks.cdc.gov/view/cdc/36063,0.0
+Nebraska,1993,0,https://stacks.cdc.gov/view/cdc/5650,0.0
+Nebraska,1994,2,https://stacks.cdc.gov/view/cdc/5648,0.12321553107126047
+Nebraska,1995,0,https://stacks.cdc.gov/view/cdc/5644,0.0
+Nebraska,1996,0,https://stacks.cdc.gov/view/cdc/5642,0.0
+Nebraska,1997,0,"https://www.cdc.gov/mmwr/preview/mmwrhtml/00056071.htm#:~:text=As%20of%20January%201%2C%201997,and%20control%20of%20the%20disease.",0.0
+Nebraska,1998,0,https://stacks.cdc.gov/view/cdc/5637,0.0
+Nebraska,1999,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.0
+Nebraska,2000,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4953a1.htm,0.0
+Nebraska,2001,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5053a1.htm,0.0
+Nebraska,2002,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.0
+Nebraska,2003,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.0
+Nebraska,2004,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0
+Nebraska,2005,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.0
+Nebraska,2006,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.0
+Nebraska,2007,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.0
+Nebraska,2008,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.0
+Nebraska,2009,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.0
+Nebraska,2010,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.0
+Nebraska,2011,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.0
+Nebraska,2012,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.0
+Nebraska,2013,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.0
+Nebraska,2014,1,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.05313964993724207
+Nebraska,2015,3,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.15839902933074826
+Nebraska,2016,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Nebraska,2017,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.052112809641286686
+Nebraska,2018,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Nebraska,2019,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Nebraska,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Nebraska,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Nebraska,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Nevada,1918,1,Project Tycho - https://zenodo.org/records/11452259,1.297403894806492
+Nevada,1919,2,Project Tycho - https://zenodo.org/records/11452259,2.594807789612984
+Nevada,1920,236,Project Tycho - https://zenodo.org/records/11452259,302.2618407233792
+Nevada,1921,4,Project Tycho - https://zenodo.org/records/11452259,4.995004995004995
+Nevada,1923,22,Project Tycho - https://zenodo.org/records/11452259,26.80246582685607
+Nevada,1924,128,Project Tycho - https://zenodo.org/records/11452259,152.2287236572951
+Nevada,1925,0,Project Tycho - https://zenodo.org/records/11452259,0.0
+Nevada,1926,3,Project Tycho - https://zenodo.org/records/11452259,3.444831031037927
+Nevada,1927,38,Project Tycho - https://zenodo.org/records/11452259,43.13867950231587
+Nevada,1928,2,Project Tycho - https://zenodo.org/records/11452259,2.2449460651707844
+Nevada,1929,10,Project Tycho - https://zenodo.org/records/11452259,11.1000111000111
+Nevada,1930,25,Project Tycho - https://zenodo.org/records/11452259,27.146766277201063
+Nevada,1931,15,Project Tycho - https://zenodo.org/records/11452259,15.94150530320743
+Nevada,1932,6,Project Tycho - https://zenodo.org/records/11452259,6.243756243756244
+Nevada,1933,3,Project Tycho - https://zenodo.org/records/11452259,3.121878121878122
+Nevada,1934,66,Project Tycho - https://zenodo.org/records/11452259,67.27965911639382
+Nevada,1935,18,Project Tycho - https://zenodo.org/records/11452259,17.982017982017982
+Nevada,1940,0,Project Tycho - https://zenodo.org/records/11452259,0.0
+Nevada,1941,331,Project Tycho - https://zenodo.org/records/11452259,275.5577755577756
+Nevada,1942,1160,Project Tycho - https://zenodo.org/records/11452259,845.8694590081452
+Nevada,1943,525,Project Tycho - https://zenodo.org/records/11452259,347.33478442087716
+Nevada,1944,432,Project Tycho - https://zenodo.org/records/11452259,282.07087030616447
+Nevada,1945,115,Project Tycho - https://zenodo.org/records/11452259,77.10410394974153
+Nevada,1946,186,Project Tycho - https://zenodo.org/records/11452259,129.93999007985022
+Nevada,1947,27,Project Tycho - https://zenodo.org/records/11452259,18.102702666461056
+Nevada,1948,60,Project Tycho - https://zenodo.org/records/11452259,38.42311534619227
+Nevada,1949,95,Project Tycho - https://zenodo.org/records/11452259,60.449105035092295
+Nevada,1950,121,Project Tycho - https://zenodo.org/records/11452259,74.61674128340795
+Nevada,1951,281,Project Tycho - https://zenodo.org/records/11452259,167.0948099519528
+Nevada,1952,464,Project Tycho - https://zenodo.org/records/11452259,256.09749366655444
+Nevada,1953,201,Project Tycho - https://zenodo.org/records/11452259,102.97394912779528
+Nevada,1954,388,Project Tycho - https://zenodo.org/records/11452259,181.97764676637917
+Nevada,1955,392,Project Tycho - https://zenodo.org/records/11452259,165.23560827358295
+Nevada,1956,142,Project Tycho - https://zenodo.org/records/11452259,56.74325674325674
+Nevada,1957,1536,Project Tycho - https://zenodo.org/records/11452259,590.1790517175132
+Nevada,1958,198,Project Tycho - https://zenodo.org/records/11452259,73.53241553985048
+Nevada,1959,614,Project Tycho - https://zenodo.org/records/11452259,219.85183275505855
+Nevada,1960,765,Project Tycho - https://zenodo.org/records/11452259,262.62397396418015
+Nevada,1961,648,Project Tycho - https://zenodo.org/records/11452259,205.50877693734836
+Nevada,1962,650,Project Tycho - https://zenodo.org/records/11452259,184.47461629279812
+Nevada,1963,279,Project Tycho - https://zenodo.org/records/11452259,70.20687121442789
+Nevada,1964,985,Project Tycho - https://zenodo.org/records/11452259,230.98966760938595
+Nevada,1965,223,Project Tycho - https://zenodo.org/records/11452259,50.175050175050174
+Nevada,1966,64,Project Tycho - https://zenodo.org/records/11452259,14.335440344408955
+Nevada,1967,269,Project Tycho - https://zenodo.org/records/11452259,59.85106207823357
+Nevada,1968,8,Project Tycho - https://zenodo.org/records/11452259,1.7224155155189635
+Nevada,1969,1,Project Tycho - https://zenodo.org/records/11452259,0.20812520812520813
+Nevada,1970,21,Project Tycho - https://zenodo.org/records/11452259,4.2924946752625575
+Nevada,1971,5,Project Tycho - https://zenodo.org/records/11452259,0.9605446672481164
+Nevada,1972,1,Project Tycho - https://zenodo.org/records/11452259,0.1827034631441439
+Nevada,1973,1,Project Tycho - https://zenodo.org/records/11452259,0.1755744356598702
+Nevada,1974,166,Project Tycho - https://zenodo.org/records/11452259,27.786240119982995
+Nevada,1975,27,Project Tycho - https://zenodo.org/records/11452259,4.350691518246317
+Nevada,1976,34,Project Tycho - https://zenodo.org/records/11452259,5.249984172841832
+Nevada,1977,78,Project Tycho - https://zenodo.org/records/11452259,11.487295493003796
+Nevada,1978,22,Project Tycho - https://zenodo.org/records/11452259,3.054897903923461
+Nevada,1979,20,Project Tycho - https://zenodo.org/records/11452259,2.610516203474075
+Nevada,1980,13,Project Tycho - https://zenodo.org/records/11452259,1.60290989796862
+Nevada,1981,14,Project Tycho - https://zenodo.org/records/11452259,1.6499666471027765
+Nevada,1982,0,https://stacks.cdc.gov/view/cdc/35066,0.0
+Nevada,1983,2,Project Tycho - https://zenodo.org/records/11452259,0.22151387009097573
+Nevada,1984,0,https://stacks.cdc.gov/view/cdc/35267,0.0
+Nevada,1985,0,https://stacks.cdc.gov/view/cdc/35429,0.0
+Nevada,1986,3,Project Tycho - https://zenodo.org/records/11452259,0.30562565136466946
+Nevada,1987,3,Project Tycho - https://zenodo.org/records/11452259,0.29285463964724684
+Nevada,1988,0,https://stacks.cdc.gov/view/cdc/35958,0.0
+Nevada,1989,7,Project Tycho - https://zenodo.org/records/11452259,0.6148338323734606
+Nevada,1990,218,Project Tycho - https://zenodo.org/records/11452259,17.871093669943853
+Nevada,1991,17,Project Tycho - https://zenodo.org/records/11452259,1.3215883003674793
+Nevada,1992,1,Project Tycho - https://zenodo.org/records/11452259,0.07507372239539228
+Nevada,1993,1,Project Tycho - https://zenodo.org/records/11452259,0.07238105440377192
+Nevada,1994,11,Project Tycho - https://zenodo.org/records/11452259,0.754538894422174
+Nevada,1995,2,Project Tycho - https://zenodo.org/records/11452259,0.13094987107985193
+Nevada,1996,2,Project Tycho - https://zenodo.org/records/11452259,0.12515080672210013
+Nevada,1997,1,Project Tycho - https://zenodo.org/records/11452259,0.05962119080211966
+Nevada,1998,0,https://stacks.cdc.gov/view/cdc/5637,0.0
+Nevada,1999,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.05521622120059943
+Nevada,2000,4,Project Tycho - https://zenodo.org/records/11452259,0.19794542545647453
+Nevada,2001,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5053a1.htm,0.0
+Nevada,2002,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.045956642665044095
+Nevada,2003,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.0
+Nevada,2004,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0
+Nevada,2005,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.0
+Nevada,2006,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.0
+Nevada,2007,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.0
+Nevada,2008,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.0
+Nevada,2009,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.0
+Nevada,2010,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.0
+Nevada,2011,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.036821196637341035
+Nevada,2012,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.0
+Nevada,2013,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.0
+Nevada,2014,0,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.0
+Nevada,2015,9,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.3134360637445371
+Nevada,2016,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Nevada,2017,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Nevada,2018,2,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.06592490164828736
+Nevada,2019,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Nevada,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Nevada,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Nevada,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+New Hampshire,1889,3,Project Tycho - https://zenodo.org/records/11452259,
+New Hampshire,1893,5,Project Tycho - https://zenodo.org/records/11452259,
+New Hampshire,1894,6,Project Tycho - https://zenodo.org/records/11452259,
+New Hampshire,1895,1,Project Tycho - https://zenodo.org/records/11452259,
+New Hampshire,1896,2,Project Tycho - https://zenodo.org/records/11452259,
+New Hampshire,1897,5,Project Tycho - https://zenodo.org/records/11452259,
+New Hampshire,1898,4,Project Tycho - https://zenodo.org/records/11452259,
+New Hampshire,1899,8,Project Tycho - https://zenodo.org/records/11452259,
+New Hampshire,1900,4,Project Tycho - https://zenodo.org/records/11452259,0.9699038825252417
+New Hampshire,1902,5,Project Tycho - https://zenodo.org/records/11452259,1.2212726149156465
+New Hampshire,1903,2,Project Tycho - https://zenodo.org/records/11452259,0.5071071060918777
+New Hampshire,1905,4,Project Tycho - https://zenodo.org/records/11452259,0.9446817957456256
+New Hampshire,1906,3,Project Tycho - https://zenodo.org/records/11452259,0.722169396868192
+New Hampshire,1907,989,Project Tycho - https://zenodo.org/records/11452259,233.5725739981059
+New Hampshire,1908,68,Project Tycho - https://zenodo.org/records/11452259,15.87197848880092
+New Hampshire,1909,1876,Project Tycho - https://zenodo.org/records/11452259,434.8319893563513
+New Hampshire,1910,253,Project Tycho - https://zenodo.org/records/11452259,58.64205400168277
+New Hampshire,1911,574,Project Tycho - https://zenodo.org/records/11452259,132.73763273763274
+New Hampshire,1912,567,Project Tycho - https://zenodo.org/records/11452259,130.5146466436789
+New Hampshire,1913,1187,Project Tycho - https://zenodo.org/records/11452259,270.11712660915396
+New Hampshire,1914,245,Project Tycho - https://zenodo.org/records/11452259,55.37448976363004
+New Hampshire,1915,33,Project Tycho - https://zenodo.org/records/11452259,7.441768164115794
+New Hampshire,1916,1712,Project Tycho - https://zenodo.org/records/11452259,384.33476635723827
+New Hampshire,1917,1080,Project Tycho - https://zenodo.org/records/11452259,241.3693688861474
+New Hampshire,1918,559,Project Tycho - https://zenodo.org/records/11452259,126.91853600944509
+New Hampshire,1919,32,Project Tycho - https://zenodo.org/records/11452259,7.216260037930467
+New Hampshire,1920,2157,Project Tycho - https://zenodo.org/records/11452259,485.3254853254854
+New Hampshire,1921,238,Project Tycho - https://zenodo.org/records/11452259,52.953727786689925
+New Hampshire,1922,323,Project Tycho - https://zenodo.org/records/11452259,71.54707819896291
+New Hampshire,1923,1332,Project Tycho - https://zenodo.org/records/11452259,293.7459891102275
+New Hampshire,1924,634,Project Tycho - https://zenodo.org/records/11452259,138.59226113055433
+New Hampshire,1925,98,Project Tycho - https://zenodo.org/records/11452259,21.329433094138977
+New Hampshire,1926,436,Project Tycho - https://zenodo.org/records/11452259,94.07439213054764
+New Hampshire,1927,646,Project Tycho - https://zenodo.org/records/11452259,138.48812132073934
+New Hampshire,1928,1480,Project Tycho - https://zenodo.org/records/11452259,315.92339284646977
+New Hampshire,1929,1823,Project Tycho - https://zenodo.org/records/11452259,389.9740516442872
+New Hampshire,1930,764,Project Tycho - https://zenodo.org/records/11452259,163.78471314093633
+New Hampshire,1931,1697,Project Tycho - https://zenodo.org/records/11452259,360.70312666057345
+New Hampshire,1932,757,Project Tycho - https://zenodo.org/records/11452259,159.545096253957
+New Hampshire,1933,1180,Project Tycho - https://zenodo.org/records/11452259,247.13232260402071
+New Hampshire,1934,4727,Project Tycho - https://zenodo.org/records/11452259,983.8078588078588
+New Hampshire,1935,247,Project Tycho - https://zenodo.org/records/11452259,51.300051300051294
+New Hampshire,1936,1161,Project Tycho - https://zenodo.org/records/11452259,241.1310103617796
+New Hampshire,1937,2033,Project Tycho - https://zenodo.org/records/11452259,422.23888377734534
+New Hampshire,1938,1246,Project Tycho - https://zenodo.org/records/11452259,256.6505659289164
+New Hampshire,1939,260,Project Tycho - https://zenodo.org/records/11452259,53.00821627352239
+New Hampshire,1940,1519,Project Tycho - https://zenodo.org/records/11452259,308.4314059923816
+New Hampshire,1941,996,Project Tycho - https://zenodo.org/records/11452259,203.0622438785704
+New Hampshire,1942,863,Project Tycho - https://zenodo.org/records/11452259,179.23864077710232
+New Hampshire,1943,1025,Project Tycho - https://zenodo.org/records/11452259,221.63983202944243
+New Hampshire,1944,594,Project Tycho - https://zenodo.org/records/11452259,130.13302486986697
+New Hampshire,1945,241,Project Tycho - https://zenodo.org/records/11452259,52.452993629464224
+New Hampshire,1946,1215,Project Tycho - https://zenodo.org/records/11452259,245.70571129275584
+New Hampshire,1947,258,Project Tycho - https://zenodo.org/records/11452259,50.83673722726977
+New Hampshire,1948,458,Project Tycho - https://zenodo.org/records/11452259,87.9889341427803
+New Hampshire,1949,1229,Project Tycho - https://zenodo.org/records/11452259,230.35126224619657
+New Hampshire,1950,186,Project Tycho - https://zenodo.org/records/11452259,34.92747853650109
+New Hampshire,1951,1202,Project Tycho - https://zenodo.org/records/11452259,226.9941778448395
+New Hampshire,1952,2217,Project Tycho - https://zenodo.org/records/11452259,413.9785448196663
+New Hampshire,1953,133,Project Tycho - https://zenodo.org/records/11452259,24.290152260901802
+New Hampshire,1954,932,Project Tycho - https://zenodo.org/records/11452259,168.06298394746048
+New Hampshire,1955,4631,Project Tycho - https://zenodo.org/records/11452259,830.5877246631286
+New Hampshire,1956,201,Project Tycho - https://zenodo.org/records/11452259,35.47689060056551
+New Hampshire,1957,420,Project Tycho - https://zenodo.org/records/11452259,73.35322020636706
+New Hampshire,1958,2112,Project Tycho - https://zenodo.org/records/11452259,363.1480395680052
+New Hampshire,1959,456,Project Tycho - https://zenodo.org/records/11452259,76.43363348061335
+New Hampshire,1960,1135,Project Tycho - https://zenodo.org/records/11452259,186.18491524895467
+New Hampshire,1961,1525,Project Tycho - https://zenodo.org/records/11452259,246.51723680849895
+New Hampshire,1962,960,Project Tycho - https://zenodo.org/records/11452259,151.74698719002518
+New Hampshire,1963,44,Project Tycho - https://zenodo.org/records/11452259,6.772888128820331
+New Hampshire,1964,890,Project Tycho - https://zenodo.org/records/11452259,134.10420650239655
+New Hampshire,1965,358,Project Tycho - https://zenodo.org/records/11452259,52.90567420744935
+New Hampshire,1966,79,Project Tycho - https://zenodo.org/records/11452259,11.588998373139342
+New Hampshire,1967,24,Project Tycho - https://zenodo.org/records/11452259,3.439888662270298
+New Hampshire,1968,88,Project Tycho - https://zenodo.org/records/11452259,12.399448224554007
+New Hampshire,1969,196,Project Tycho - https://zenodo.org/records/11452259,27.044778425993893
+New Hampshire,1970,64,Project Tycho - https://zenodo.org/records/11452259,8.667177669016736
+New Hampshire,1971,207,Project Tycho - https://zenodo.org/records/11452259,27.14355399600321
+New Hampshire,1972,784,Project Tycho - https://zenodo.org/records/11452259,100.27011541294917
+New Hampshire,1973,725,Project Tycho - https://zenodo.org/records/11452259,90.42707773361056
+New Hampshire,1974,147,Project Tycho - https://zenodo.org/records/11452259,17.998626227304285
+New Hampshire,1975,18,Project Tycho - https://zenodo.org/records/11452259,2.1702880333934984
+New Hampshire,1976,8,Project Tycho - https://zenodo.org/records/11452259,0.9455225371206238
+New Hampshire,1977,265,Project Tycho - https://zenodo.org/records/11452259,30.43765907984085
+New Hampshire,1978,54,Project Tycho - https://zenodo.org/records/11452259,6.051023575460186
+New Hampshire,1979,19,Project Tycho - https://zenodo.org/records/11452259,2.087951093591858
+New Hampshire,1980,242,Project Tycho - https://zenodo.org/records/11452259,26.15724177289894
+New Hampshire,1981,5,Project Tycho - https://zenodo.org/records/11452259,0.5333009086380882
+New Hampshire,1982,5,Project Tycho - https://zenodo.org/records/11452259,0.5270558868980231
+New Hampshire,1983,1,Project Tycho - https://zenodo.org/records/11452259,0.10426528424801793
+New Hampshire,1984,25,Project Tycho - https://zenodo.org/records/11452259,2.5566554855600097
+New Hampshire,1985,0,https://stacks.cdc.gov/view/cdc/35429,0.0
+New Hampshire,1986,23,Project Tycho - https://zenodo.org/records/11452259,2.2415449897571142
+New Hampshire,1987,139,Project Tycho - https://zenodo.org/records/11452259,13.17107329086373
+New Hampshire,1988,111,Project Tycho - https://zenodo.org/records/11452259,10.24307462033721
+New Hampshire,1989,16,Project Tycho - https://zenodo.org/records/11452259,1.4471439709268776
+New Hampshire,1990,9,Project Tycho - https://zenodo.org/records/11452259,0.8086674777301962
+New Hampshire,1991,0,https://stacks.cdc.gov/view/cdc/36010,0.0
+New Hampshire,1992,16,Project Tycho - https://zenodo.org/records/11452259,1.4364230193970973
+New Hampshire,1993,1,Project Tycho - https://zenodo.org/records/11452259,0.08902238289773197
+New Hampshire,1994,1,https://stacks.cdc.gov/view/cdc/5648,0.0881688822037283
+New Hampshire,1995,0,https://stacks.cdc.gov/view/cdc/5644,0.0
+New Hampshire,1996,0,https://stacks.cdc.gov/view/cdc/5642,0.0
+New Hampshire,1997,1,"https://www.cdc.gov/mmwr/preview/mmwrhtml/00056071.htm#:~:text=As%20of%20January%201%2C%201997,and%20control%20of%20the%20disease.",0.08514899370919235
+New Hampshire,1998,0,https://stacks.cdc.gov/view/cdc/5637,0.0
+New Hampshire,1999,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.08317149546507421
+New Hampshire,2000,3,Project Tycho - https://zenodo.org/records/11452259,0.24171696393824615
+New Hampshire,2001,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5053a1.htm,0.0
+New Hampshire,2002,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.0
+New Hampshire,2003,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.07805676131569354
+New Hampshire,2004,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0
+New Hampshire,2005,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.07693550496618684
+New Hampshire,2006,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.07635353826113979
+New Hampshire,2007,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.0
+New Hampshire,2008,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.0
+New Hampshire,2009,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.0
+New Hampshire,2010,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.0
+New Hampshire,2011,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.07565647120060767
+New Hampshire,2012,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.0
+New Hampshire,2013,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.0
+New Hampshire,2014,0,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.0
+New Hampshire,2015,0,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.0
+New Hampshire,2016,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+New Hampshire,2017,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+New Hampshire,2018,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+New Hampshire,2019,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.07341373115744822
+New Hampshire,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+New Hampshire,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+New Hampshire,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+New Jersey,1888,1,Project Tycho - https://zenodo.org/records/11452259,
+New Jersey,1889,18,Project Tycho - https://zenodo.org/records/11452259,
+New Jersey,1890,11,Project Tycho - https://zenodo.org/records/11452259,
+New Jersey,1892,13,Project Tycho - https://zenodo.org/records/11452259,
+New Jersey,1894,44,Project Tycho - https://zenodo.org/records/11452259,
+New Jersey,1895,4,Project Tycho - https://zenodo.org/records/11452259,
+New Jersey,1896,35,Project Tycho - https://zenodo.org/records/11452259,
+New Jersey,1897,7,Project Tycho - https://zenodo.org/records/11452259,
+New Jersey,1898,20,Project Tycho - https://zenodo.org/records/11452259,
+New Jersey,1899,11,Project Tycho - https://zenodo.org/records/11452259,
+New Jersey,1900,59,Project Tycho - https://zenodo.org/records/11452259,3.1285063132196886
+New Jersey,1901,20,Project Tycho - https://zenodo.org/records/11452259,1.0577035457924817
+New Jersey,1902,48,Project Tycho - https://zenodo.org/records/11452259,2.5014109521151777
+New Jersey,1903,19,Project Tycho - https://zenodo.org/records/11452259,0.963992838040578
+New Jersey,1904,43,Project Tycho - https://zenodo.org/records/11452259,2.0954655100996566
+New Jersey,1905,16,Project Tycho - https://zenodo.org/records/11452259,0.7430969774066009
+New Jersey,1906,54,Project Tycho - https://zenodo.org/records/11452259,2.409381596518711
+New Jersey,1907,505,Project Tycho - https://zenodo.org/records/11452259,21.8018800559855
+New Jersey,1908,2812,Project Tycho - https://zenodo.org/records/11452259,116.90348769000454
+New Jersey,1909,2090,Project Tycho - https://zenodo.org/records/11452259,83.95303932095247
+New Jersey,1910,1585,Project Tycho - https://zenodo.org/records/11452259,62.094767977120924
+New Jersey,1911,1849,Project Tycho - https://zenodo.org/records/11452259,70.77213973765699
+New Jersey,1912,3172,Project Tycho - https://zenodo.org/records/11452259,118.6828153120288
+New Jersey,1913,7441,Project Tycho - https://zenodo.org/records/11452259,272.3915878917711
+New Jersey,1914,8619,Project Tycho - https://zenodo.org/records/11452259,308.7267698239373
+New Jersey,1915,6376,Project Tycho - https://zenodo.org/records/11452259,223.49580244317087
+New Jersey,1916,11593,Project Tycho - https://zenodo.org/records/11452259,396.8957704392934
+New Jersey,1917,7852,Project Tycho - https://zenodo.org/records/11452259,263.5805055159894
+New Jersey,1918,17090,Project Tycho - https://zenodo.org/records/11452259,561.0557697314188
+New Jersey,1919,3276,Project Tycho - https://zenodo.org/records/11452259,104.35992578849721
+New Jersey,1920,15344,Project Tycho - https://zenodo.org/records/11452259,479.3205543674587
+New Jersey,1921,4605,Project Tycho - https://zenodo.org/records/11452259,139.53289658476191
+New Jersey,1922,13168,Project Tycho - https://zenodo.org/records/11452259,389.1966022143537
+New Jersey,1923,12143,Project Tycho - https://zenodo.org/records/11452259,349.39139201812014
+New Jersey,1924,3792,Project Tycho - https://zenodo.org/records/11452259,106.02327982680627
+New Jersey,1925,3120,Project Tycho - https://zenodo.org/records/11452259,85.06777065729031
+New Jersey,1926,8417,Project Tycho - https://zenodo.org/records/11452259,223.75176712590232
+New Jersey,1927,894,Project Tycho - https://zenodo.org/records/11452259,22.953145543739222
+New Jersey,1928,39422,Project Tycho - https://zenodo.org/records/11452259,992.5054783925751
+New Jersey,1929,8050,Project Tycho - https://zenodo.org/records/11452259,201.60336028974785
+New Jersey,1930,30941,Project Tycho - https://zenodo.org/records/11452259,759.8350518704501
+New Jersey,1931,21952,Project Tycho - https://zenodo.org/records/11452259,532.2832507298526
+New Jersey,1932,17094,Project Tycho - https://zenodo.org/records/11452259,414.48842419716203
+New Jersey,1933,38007,Project Tycho - https://zenodo.org/records/11452259,924.4955190901136
+New Jersey,1934,17632,Project Tycho - https://zenodo.org/records/11452259,430.77489886000524
+New Jersey,1935,39800,Project Tycho - https://zenodo.org/records/11452259,973.3228827476074
+New Jersey,1936,9964,Project Tycho - https://zenodo.org/records/11452259,243.73276087281963
+New Jersey,1937,54524,Project Tycho - https://zenodo.org/records/11452259,1332.424913638221
+New Jersey,1938,28543,Project Tycho - https://zenodo.org/records/11452259,695.4752564508661
+New Jersey,1939,1445,Project Tycho - https://zenodo.org/records/11452259,34.961405753365064
+New Jersey,1940,23756,Project Tycho - https://zenodo.org/records/11452259,568.4375504734786
+New Jersey,1941,48538,Project Tycho - https://zenodo.org/records/11452259,1139.856852127656
+New Jersey,1942,17429,Project Tycho - https://zenodo.org/records/11452259,405.20336075374473
+New Jersey,1943,48381,Project Tycho - https://zenodo.org/records/11452259,1143.6977598832782
+New Jersey,1944,30045,Project Tycho - https://zenodo.org/records/11452259,721.8611114715011
+New Jersey,1945,2056,Project Tycho - https://zenodo.org/records/11452259,49.99868680491855
+New Jersey,1946,69722,Project Tycho - https://zenodo.org/records/11452259,1550.5865461341864
+New Jersey,1947,12561,Project Tycho - https://zenodo.org/records/11452259,271.72913703879493
+New Jersey,1948,40404,Project Tycho - https://zenodo.org/records/11452259,845.4888220284115
+New Jersey,1949,34473,Project Tycho - https://zenodo.org/records/11452259,704.4091110362332
+New Jersey,1950,30989,Project Tycho - https://zenodo.org/records/11452259,635.4277906002044
+New Jersey,1951,20838,Project Tycho - https://zenodo.org/records/11452259,415.84464277232956
+New Jersey,1952,85914,Project Tycho - https://zenodo.org/records/11452259,1674.6960356716454
+New Jersey,1953,4151,Project Tycho - https://zenodo.org/records/11452259,79.30489858200701
+New Jersey,1954,23896,Project Tycho - https://zenodo.org/records/11452259,445.3755200023857
+New Jersey,1955,51559,Project Tycho - https://zenodo.org/records/11452259,936.1594421572611
+New Jersey,1956,19471,Project Tycho - https://zenodo.org/records/11452259,346.4211656553598
+New Jersey,1957,25953,Project Tycho - https://zenodo.org/records/11452259,451.9273649481075
+New Jersey,1958,25239,Project Tycho - https://zenodo.org/records/11452259,428.07786441063183
+New Jersey,1959,30207,Project Tycho - https://zenodo.org/records/11452259,501.69282089481595
+New Jersey,1960,10697,Project Tycho - https://zenodo.org/records/11452259,175.09935583014396
+New Jersey,1961,18642,Project Tycho - https://zenodo.org/records/11452259,297.2606005327474
+New Jersey,1962,32323,Project Tycho - https://zenodo.org/records/11452259,506.4414882482636
+New Jersey,1963,10625,Project Tycho - https://zenodo.org/records/11452259,162.52312990944134
+New Jersey,1964,11563,Project Tycho - https://zenodo.org/records/11452259,173.44517344517342
+New Jersey,1965,4140,Project Tycho - https://zenodo.org/records/11452259,61.1181341194641
+New Jersey,1966,2015,Project Tycho - https://zenodo.org/records/11452259,29.382382323558797
+New Jersey,1967,626,Project Tycho - https://zenodo.org/records/11452259,9.026769996746902
+New Jersey,1968,681,Project Tycho - https://zenodo.org/records/11452259,9.711915493500076
+New Jersey,1969,942,Project Tycho - https://zenodo.org/records/11452259,13.263691910626372
+New Jersey,1970,1710,Project Tycho - https://zenodo.org/records/11452259,23.82185266309506
+New Jersey,1971,1268,Project Tycho - https://zenodo.org/records/11452259,17.39753701367161
+New Jersey,1972,431,Project Tycho - https://zenodo.org/records/11452259,5.870033641693964
+New Jersey,1973,780,Project Tycho - https://zenodo.org/records/11452259,10.626100755052574
+New Jersey,1974,5450,Project Tycho - https://zenodo.org/records/11452259,74.2532810753728
+New Jersey,1975,478,Project Tycho - https://zenodo.org/records/11452259,6.507738081785658
+New Jersey,1976,626,Project Tycho - https://zenodo.org/records/11452259,8.520387135903169
+New Jersey,1977,198,Project Tycho - https://zenodo.org/records/11452259,2.695892684953896
+New Jersey,1978,75,Project Tycho - https://zenodo.org/records/11452259,1.0192773894104417
+New Jersey,1979,47,Project Tycho - https://zenodo.org/records/11452259,0.6373851045542115
+New Jersey,1980,648,Project Tycho - https://zenodo.org/records/11452259,8.776080737775853
+New Jersey,1981,59,Project Tycho - https://zenodo.org/records/11452259,0.7956974078740866
+New Jersey,1982,6,Project Tycho - https://zenodo.org/records/11452259,0.08066252975439066
+New Jersey,1983,26,Project Tycho - https://zenodo.org/records/11452259,0.3478143613084883
+New Jersey,1984,5,Project Tycho - https://zenodo.org/records/11452259,0.0664629532839877
+New Jersey,1985,27,Project Tycho - https://zenodo.org/records/11452259,0.35652539853927584
+New Jersey,1986,862,Project Tycho - https://zenodo.org/records/11452259,11.297834105592283
+New Jersey,1987,19,Project Tycho - https://zenodo.org/records/11452259,0.24744699815534776
+New Jersey,1988,252,Project Tycho - https://zenodo.org/records/11452259,3.264229677417683
+New Jersey,1989,1,Project Tycho - https://zenodo.org/records/11452259,0.0129302291301253
+New Jersey,1990,3,Project Tycho - https://zenodo.org/records/11452259,0.03863532311686606
+New Jersey,1991,1118,https://stacks.cdc.gov/view/cdc/36010,14.347951688726962
+New Jersey,1992,23,Project Tycho - https://zenodo.org/records/11452259,0.2935321967171104
+New Jersey,1993,11,https://stacks.cdc.gov/view/cdc/5650,0.13954494393781877
+New Jersey,1994,19,Project Tycho - https://zenodo.org/records/11452259,0.23969579323790413
+New Jersey,1995,8,https://stacks.cdc.gov/view/cdc/5644,0.10033250191133417
+New Jersey,1996,3,https://stacks.cdc.gov/view/cdc/5642,0.037417527093095926
+New Jersey,1997,3,"https://www.cdc.gov/mmwr/preview/mmwrhtml/00056071.htm#:~:text=As%20of%20January%201%2C%201997,and%20control%20of%20the%20disease.",0.037210539215443074
+New Jersey,1998,8,https://stacks.cdc.gov/view/cdc/5637,0.09872110510379475
+New Jersey,1999,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.0
+New Jersey,2000,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4953a1.htm,0.0
+New Jersey,2001,1,Project Tycho - https://zenodo.org/records/11452259,0.011763096413984769
+New Jersey,2002,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.011680612344421543
+New Jersey,2003,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.023228795622951583
+New Jersey,2004,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0231395913201079
+New Jersey,2005,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.023093021577542037
+New Jersey,2006,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.011533573077872379
+New Jersey,2007,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.011512034335333127
+New Jersey,2008,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.01146815162410243
+New Jersey,2009,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.022819700292902263
+New Jersey,2010,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.0
+New Jersey,2011,4,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.04526228361799538
+New Jersey,2012,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.022587344130384993
+New Jersey,2013,15,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.16917271609502454
+New Jersey,2014,3,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.033798460232281044
+New Jersey,2015,3,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.0337868961352521
+New Jersey,2016,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+New Jersey,2017,3,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.033719098553619264
+New Jersey,2018,37,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.4157013314014831
+New Jersey,2019,19,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.2134795720835685
+New Jersey,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+New Jersey,2021,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.010776081538729615
+New Jersey,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+New Mexico,1918,3,Project Tycho - https://zenodo.org/records/11452259,0.7845557583777479
+New Mexico,1919,7,Project Tycho - https://zenodo.org/records/11452259,1.9317698875709925
+New Mexico,1920,107,Project Tycho - https://zenodo.org/records/11452259,29.447136885153416
+New Mexico,1921,50,Project Tycho - https://zenodo.org/records/11452259,13.500013500013498
+New Mexico,1922,2,Project Tycho - https://zenodo.org/records/11452259,0.5328005328005329
+New Mexico,1923,79,Project Tycho - https://zenodo.org/records/11452259,20.65996830394736
+New Mexico,1924,376,Project Tycho - https://zenodo.org/records/11452259,96.31394246778862
+New Mexico,1925,14,Project Tycho - https://zenodo.org/records/11452259,3.531821713639895
+New Mexico,1926,49,Project Tycho - https://zenodo.org/records/11452259,12.146662270731749
+New Mexico,1927,617,Project Tycho - https://zenodo.org/records/11452259,150.33746741063814
+New Mexico,1928,3316,Project Tycho - https://zenodo.org/records/11452259,796.3190655498348
+New Mexico,1929,245,Project Tycho - https://zenodo.org/records/11452259,58.27505827505828
+New Mexico,1930,2543,Project Tycho - https://zenodo.org/records/11452259,594.9553958921641
+New Mexico,1931,1461,Project Tycho - https://zenodo.org/records/11452259,334.7569861331329
+New Mexico,1932,1825,Project Tycho - https://zenodo.org/records/11452259,413.41878076571953
+New Mexico,1933,761,Project Tycho - https://zenodo.org/records/11452259,169.3184321246682
+New Mexico,1934,3665,Project Tycho - https://zenodo.org/records/11452259,794.2166293576272
+New Mexico,1935,777,Project Tycho - https://zenodo.org/records/11452259,163.41553183658448
+New Mexico,1936,1263,Project Tycho - https://zenodo.org/records/11452259,258.0241844045525
+New Mexico,1937,2749,Project Tycho - https://zenodo.org/records/11452259,545.9748998516394
+New Mexico,1938,2521,Project Tycho - https://zenodo.org/records/11452259,490.93206987943825
+New Mexico,1939,722,Project Tycho - https://zenodo.org/records/11452259,137.9118013917249
+New Mexico,1940,1249,Project Tycho - https://zenodo.org/records/11452259,234.98159091379432
+New Mexico,1941,4290,Project Tycho - https://zenodo.org/records/11452259,846.979107848673
+New Mexico,1942,1537,Project Tycho - https://zenodo.org/records/11452259,305.8694293754055
+New Mexico,1943,440,Project Tycho - https://zenodo.org/records/11452259,82.3146890562621
+New Mexico,1944,1740,Project Tycho - https://zenodo.org/records/11452259,329.84093705156323
+New Mexico,1945,249,Project Tycho - https://zenodo.org/records/11452259,46.32239269110777
+New Mexico,1946,1222,Project Tycho - https://zenodo.org/records/11452259,217.6077042387203
+New Mexico,1947,1327,Project Tycho - https://zenodo.org/records/11452259,227.7790937584752
+New Mexico,1948,1057,Project Tycho - https://zenodo.org/records/11452259,174.82517482517483
+New Mexico,1949,4324,Project Tycho - https://zenodo.org/records/11452259,670.7578136149565
+New Mexico,1950,974,Project Tycho - https://zenodo.org/records/11452259,141.22307300826893
+New Mexico,1951,2171,Project Tycho - https://zenodo.org/records/11452259,302.4869133655744
+New Mexico,1952,1522,Project Tycho - https://zenodo.org/records/11452259,206.86796197000277
+New Mexico,1953,5537,Project Tycho - https://zenodo.org/records/11452259,731.6757316757316
+New Mexico,1954,2716,Project Tycho - https://zenodo.org/records/11452259,355.60769505723636
+New Mexico,1955,4881,Project Tycho - https://zenodo.org/records/11452259,621.1622772132326
+New Mexico,1956,4005,Project Tycho - https://zenodo.org/records/11452259,496.40186116612915
+New Mexico,1957,6317,Project Tycho - https://zenodo.org/records/11452259,745.0636730447828
+New Mexico,1958,8082,Project Tycho - https://zenodo.org/records/11452259,911.2783379149067
+New Mexico,1959,4448,Project Tycho - https://zenodo.org/records/11452259,483.5208317254019
+New Mexico,1960,65,Project Tycho - https://zenodo.org/records/11452259,6.8066105801954855
+New Mexico,1961,20,Project Tycho - https://zenodo.org/records/11452259,2.070468391711915
+New Mexico,1962,1451,https://stacks.cdc.gov/view/cdc/380,148.06439729830944
+New Mexico,1963,5,Project Tycho - https://zenodo.org/records/11452259,0.5050561167851361
+New Mexico,1964,1113,Project Tycho - https://zenodo.org/records/11452259,110.52565724533915
+New Mexico,1965,690,Project Tycho - https://zenodo.org/records/11452259,68.11370447734085
+New Mexico,1966,1272,Project Tycho - https://zenodo.org/records/11452259,126.1895998738104
+New Mexico,1967,612,Project Tycho - https://zenodo.org/records/11452259,61.138861138861145
+New Mexico,1968,177,Project Tycho - https://zenodo.org/records/11452259,17.789051994283383
+New Mexico,1969,285,Project Tycho - https://zenodo.org/records/11452259,28.161749229998485
+New Mexico,1970,302,Project Tycho - https://zenodo.org/records/11452259,29.663913750697397
+New Mexico,1971,402,Project Tycho - https://zenodo.org/records/11452259,38.111851648195376
+New Mexico,1972,137,Project Tycho - https://zenodo.org/records/11452259,12.687828482785765
+New Mexico,1973,155,Project Tycho - https://zenodo.org/records/11452259,14.006437539421345
+New Mexico,1974,154,Project Tycho - https://zenodo.org/records/11452259,13.598954469993995
+New Mexico,1975,16,Project Tycho - https://zenodo.org/records/11452259,1.3780000568425024
+New Mexico,1976,16,Project Tycho - https://zenodo.org/records/11452259,1.3439911834178369
+New Mexico,1977,25,Project Tycho - https://zenodo.org/records/11452259,2.054341439764655
+New Mexico,1978,0,https://stacks.cdc.gov/view/cdc/51063,0.0
+New Mexico,1979,30,Project Tycho - https://zenodo.org/records/11452259,2.332804046015337
+New Mexico,1980,1,Project Tycho - https://zenodo.org/records/11452259,0.07629458560214357
+New Mexico,1981,8,Project Tycho - https://zenodo.org/records/11452259,0.5996641880546894
+New Mexico,1982,0,https://stacks.cdc.gov/view/cdc/35066,0.0
+New Mexico,1983,0,https://stacks.cdc.gov/view/cdc/35188,0.0
+New Mexico,1984,1,Project Tycho - https://zenodo.org/records/11452259,0.07051524786462202
+New Mexico,1985,6,https://stacks.cdc.gov/view/cdc/35429,0.41672483450815007
+New Mexico,1986,36,Project Tycho - https://zenodo.org/records/11452259,2.458695620994802
+New Mexico,1987,126,Project Tycho - https://zenodo.org/records/11452259,8.51352501827705
+New Mexico,1988,0,https://stacks.cdc.gov/view/cdc/35958,0.0
+New Mexico,1989,25,Project Tycho - https://zenodo.org/records/11452259,1.6606837765809046
+New Mexico,1990,77,Project Tycho - https://zenodo.org/records/11452259,5.0609549298959156
+New Mexico,1991,70,Project Tycho - https://zenodo.org/records/11452259,4.5200308395247
+New Mexico,1992,2,Project Tycho - https://zenodo.org/records/11452259,0.12639588454999906
+New Mexico,1993,0,https://stacks.cdc.gov/view/cdc/5650,0.0
+New Mexico,1994,2,https://stacks.cdc.gov/view/cdc/5648,0.12084723580075192
+New Mexico,1995,19,Project Tycho - https://zenodo.org/records/11452259,1.1281997079744126
+New Mexico,1996,15,Project Tycho - https://zenodo.org/records/11452259,0.8782936744704035
+New Mexico,1997,1,Project Tycho - https://zenodo.org/records/11452259,0.05798240929666758
+New Mexico,1998,0,https://stacks.cdc.gov/view/cdc/5637,0.0
+New Mexico,1999,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.0
+New Mexico,2000,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4953a1.htm,0.0
+New Mexico,2001,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5053a1.htm,0.0
+New Mexico,2002,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.0
+New Mexico,2003,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.0
+New Mexico,2004,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0
+New Mexico,2005,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.0
+New Mexico,2006,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.0
+New Mexico,2007,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.05019929118600845
+New Mexico,2008,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.04968519460697024
+New Mexico,2009,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.0
+New Mexico,2010,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.04838683142705347
+New Mexico,2011,4,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.19205036328726846
+New Mexico,2012,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.09570284648976315
+New Mexico,2013,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.0
+New Mexico,2014,1,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.047793699452188615
+New Mexico,2015,0,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.0
+New Mexico,2016,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+New Mexico,2017,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+New Mexico,2018,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+New Mexico,2019,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.04757978296957796
+New Mexico,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+New Mexico,2021,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.04718205194743919
+New Mexico,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+New York,1888,34,Project Tycho - https://zenodo.org/records/11452259,
+New York,1889,209,Project Tycho - https://zenodo.org/records/11452259,
+New York,1890,136,Project Tycho - https://zenodo.org/records/11452259,
+New York,1891,202,Project Tycho - https://zenodo.org/records/11452259,
+New York,1892,160,Project Tycho - https://zenodo.org/records/11452259,
+New York,1893,122,Project Tycho - https://zenodo.org/records/11452259,
+New York,1894,219,Project Tycho - https://zenodo.org/records/11452259,
+New York,1895,198,Project Tycho - https://zenodo.org/records/11452259,
+New York,1896,342,Project Tycho - https://zenodo.org/records/11452259,
+New York,1897,212,Project Tycho - https://zenodo.org/records/11452259,
+New York,1898,7,Project Tycho - https://zenodo.org/records/11452259,
+New York,1899,11,Project Tycho - https://zenodo.org/records/11452259,
+New York,1900,21,Project Tycho - https://zenodo.org/records/11452259,0.2880546612525193
+New York,1901,7,Project Tycho - https://zenodo.org/records/11452259,0.09387846681443138
+New York,1902,7,Project Tycho - https://zenodo.org/records/11452259,0.0918681948634655
+New York,1903,28,Project Tycho - https://zenodo.org/records/11452259,0.3599540338698748
+New York,1904,60,Project Tycho - https://zenodo.org/records/11452259,0.7561506236919382
+New York,1905,32,Project Tycho - https://zenodo.org/records/11452259,0.3954481935679363
+New York,1906,54,Project Tycho - https://zenodo.org/records/11452259,0.65081498306254
+New York,1907,1194,Project Tycho - https://zenodo.org/records/11452259,14.034676936194762
+New York,1908,1439,Project Tycho - https://zenodo.org/records/11452259,16.49715902642228
+New York,1909,1436,Project Tycho - https://zenodo.org/records/11452259,16.0555728546775
+New York,1910,6762,Project Tycho - https://zenodo.org/records/11452259,73.93285274427882
+New York,1911,2853,Project Tycho - https://zenodo.org/records/11452259,30.81576224618716
+New York,1912,4705,Project Tycho - https://zenodo.org/records/11452259,50.21151266210555
+New York,1913,7452,Project Tycho - https://zenodo.org/records/11452259,78.58709431600806
+New York,1914,4378,Project Tycho - https://zenodo.org/records/11452259,45.629904784834366
+New York,1915,7717,Project Tycho - https://zenodo.org/records/11452259,79.47722380712072
+New York,1916,9000,Project Tycho - https://zenodo.org/records/11452259,91.29781672429927
+New York,1917,9885,Project Tycho - https://zenodo.org/records/11452259,98.82042304738192
+New York,1918,15587,Project Tycho - https://zenodo.org/records/11452259,156.71727628249369
+New York,1919,4712,Project Tycho - https://zenodo.org/records/11452259,45.91584771061947
+New York,1920,14621,Project Tycho - https://zenodo.org/records/11452259,142.05790319386898
+New York,1921,9273,Project Tycho - https://zenodo.org/records/11452259,88.93756013571681
+New York,1922,7508,Project Tycho - https://zenodo.org/records/11452259,70.8329351260695
+New York,1923,18878,Project Tycho - https://zenodo.org/records/11452259,175.4012356690928
+New York,1924,2977,Project Tycho - https://zenodo.org/records/11452259,27.152615484579332
+New York,1925,5974,Project Tycho - https://zenodo.org/records/11452259,53.35269057779339
+New York,1926,6807,Project Tycho - https://zenodo.org/records/11452259,60.40863285244559
+New York,1927,6169,Project Tycho - https://zenodo.org/records/11452259,55.153366411644555
+New York,1928,86276,Project Tycho - https://zenodo.org/records/11452259,743.0796636762668
+New York,1929,31286,Project Tycho - https://zenodo.org/records/11452259,256.79685526863244
+New York,1930,41130,Project Tycho - https://zenodo.org/records/11452259,324.8905755429042
+New York,1931,61743,Project Tycho - https://zenodo.org/records/11452259,480.08498350964106
+New York,1932,72438,Project Tycho - https://zenodo.org/records/11452259,556.6159092810889
+New York,1933,74621,Project Tycho - https://zenodo.org/records/11452259,567.9297085666124
+New York,1934,39669,Project Tycho - https://zenodo.org/records/11452259,299.02188658696616
+New York,1935,83454,Project Tycho - https://zenodo.org/records/11452259,623.3318083785373
+New York,1936,67472,Project Tycho - https://zenodo.org/records/11452259,499.996998773054
+New York,1937,30221,Project Tycho - https://zenodo.org/records/11452259,223.45355037235726
+New York,1938,71685,Project Tycho - https://zenodo.org/records/11452259,529.9984207621864
+New York,1939,51991,Project Tycho - https://zenodo.org/records/11452259,384.0794271911628
+New York,1940,24808,Project Tycho - https://zenodo.org/records/11452259,184.1796728835968
+New York,1941,109663,Project Tycho - https://zenodo.org/records/11452259,825.7590001767283
+New York,1942,28477,Project Tycho - https://zenodo.org/records/11452259,218.80134939664242
+New York,1943,71473,Project Tycho - https://zenodo.org/records/11452259,557.5200937112392
+New York,1944,41953,Project Tycho - https://zenodo.org/records/11452259,331.8901560903461
+New York,1945,6369,Project Tycho - https://zenodo.org/records/11452259,50.92146748809414
+New York,1946,101117,Project Tycho - https://zenodo.org/records/11452259,753.9631587997015
+New York,1947,14744,Project Tycho - https://zenodo.org/records/11452259,105.34451959140846
+New York,1948,49350,Project Tycho - https://zenodo.org/records/11452259,340.07518314616334
+New York,1949,52580,Project Tycho - https://zenodo.org/records/11452259,352.72275401203683
+New York,1950,31920,Project Tycho - https://zenodo.org/records/11452259,214.51807526479575
+New York,1951,36681,Project Tycho - https://zenodo.org/records/11452259,246.1004408620258
+New York,1952,84822,Project Tycho - https://zenodo.org/records/11452259,557.7755577755578
+New York,1953,11274,Project Tycho - https://zenodo.org/records/11452259,72.53646720382085
+New York,1954,86718,Project Tycho - https://zenodo.org/records/11452259,547.8143963030772
+New York,1955,38542,Project Tycho - https://zenodo.org/records/11452259,241.15931669482964
+New York,1956,50183,Project Tycho - https://zenodo.org/records/11452259,311.152353108659
+New York,1957,38325,Project Tycho - https://zenodo.org/records/11452259,233.82626900398978
+New York,1958,59920,Project Tycho - https://zenodo.org/records/11452259,360.58153039057805
+New York,1959,23392,Project Tycho - https://zenodo.org/records/11452259,140.05772471460216
+New York,1960,46685,Project Tycho - https://zenodo.org/records/11452259,276.98278678205037
+New York,1961,35806,Project Tycho - https://zenodo.org/records/11452259,209.6608039987678
+New York,1962,46913,Project Tycho - https://zenodo.org/records/11452259,270.8868496973231
+New York,1963,18671,Project Tycho - https://zenodo.org/records/11452259,106.82290620438492
+New York,1964,28559,https://stacks.cdc.gov/view/cdc/698,162.20631946369625
+New York,1965,8607,https://stacks.cdc.gov/view/cdc/740,48.485404299095514
+New York,1966,11101,https://stacks.cdc.gov/view/cdc/615,62.15272145889194
+New York,1968,3811,https://stacks.cdc.gov/view/cdc/1717,21.091312432512368
+New York,1969,5681,https://stacks.cdc.gov/view/cdc/838,31.346725630072772
+New York,1970,1581,https://stacks.cdc.gov/view/cdc/951,8.658443937972025
+New York,1971,4563,https://stacks.cdc.gov/view/cdc/1829,24.830843619069064
+New York,1972,673,https://stacks.cdc.gov/view/cdc/1895,3.666028806706534
+New York,1973,1791,https://stacks.cdc.gov/view/cdc/1849,9.843233724864305
+New York,1974,1654,https://stacks.cdc.gov/view/cdc/1743,9.15439512804641
+New York,1975,1245,https://stacks.cdc.gov/view/cdc/1041,6.908419548929588
+New York,1976,3495,https://stacks.cdc.gov/view/cdc/1130,19.461556910074965
+New York,1977,4763,https://stacks.cdc.gov/view/cdc/51062,26.71278412267937
+New York,1978,1844,https://stacks.cdc.gov/view/cdc/51063,10.419098048515366
+New York,1979,1538,https://stacks.cdc.gov/view/cdc/1577,8.737930875012875
+New York,1980,1945,https://stacks.cdc.gov/view/cdc/1484,11.060990700806173
+New York,1981,336,https://stacks.cdc.gov/view/cdc/1307,1.9106866581356783
+New York,1982,161,https://stacks.cdc.gov/view/cdc/35066,0.9143920596238145
+New York,1983,90,https://stacks.cdc.gov/view/cdc/35188,0.5083427230823915
+New York,1984,170,https://stacks.cdc.gov/view/cdc/35267,0.9570224307480273
+New York,1985,166,https://stacks.cdc.gov/view/cdc/35429,0.9320887440570218
+New York,1986,1049,https://stacks.cdc.gov/view/cdc/35496,5.8763385335661615
+New York,1987,512,https://stacks.cdc.gov/view/cdc/35629,2.8624594922846653
+New York,1988,97,https://stacks.cdc.gov/view/cdc/35958,0.5401116416331417
+New York,1989,333,https://stacks.cdc.gov/view/cdc/35853,1.8498901370801923
+New York,1990,1689,https://stacks.cdc.gov/view/cdc/35905,9.3724732403126
+New York,1991,2306,https://stacks.cdc.gov/view/cdc/36010,12.777349803665993
+New York,1992,180,https://stacks.cdc.gov/view/cdc/36063,0.9944688746159279
+New York,1993,30,https://stacks.cdc.gov/view/cdc/5650,0.16520702588034142
+New York,1994,87,https://stacks.cdc.gov/view/cdc/5648,0.47868456161957806
+New York,1995,6,https://stacks.cdc.gov/view/cdc/5644,0.03302313964418007
+New York,1996,23,https://stacks.cdc.gov/view/cdc/5642,0.12663839803968166
+New York,1997,32,"https://www.cdc.gov/mmwr/preview/mmwrhtml/00056071.htm#:~:text=As%20of%20January%201%2C%201997,and%20control%20of%20the%20disease.",0.17619857844088155
+New York,1998,4,https://stacks.cdc.gov/view/cdc/5637,0.02200542719850997
+New York,1999,5,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.027450209848619234
+New York,2000,23,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4953a1.htm,0.1209203765081991
+New York,2001,11,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5053a1.htm,0.05758583430356739
+New York,2002,7,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.03654028825171791
+New York,2003,7,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.03646761358124781
+New York,2004,5,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.026054235121129785
+New York,2005,7,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.03655019997658698
+New York,2006,10,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.05229104042698773
+New York,2007,7,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.036550724808705255
+New York,2008,30,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.15599287174973253
+New York,2009,18,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.09313697919418196
+New York,2010,8,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.04119601294687697
+New York,2011,32,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.16393929737666385
+New York,2012,5,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.02551809906901809
+New York,2013,65,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.3308542340739752
+New York,2014,32,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.1626587880171711
+New York,2015,7,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.03557456841187707
+New York,2016,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.005087498099183523
+New York,2017,4,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.02039417660602356
+New York,2018,187,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.9558547432017004
+New York,2019,911,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,4.675968713406439
+New York,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+New York,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+New York,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+North Carolina,1906,2,Project Tycho - https://zenodo.org/records/11452259,0.09619653336552711
+North Carolina,1907,275,Project Tycho - https://zenodo.org/records/11452259,13.051081934692386
+North Carolina,1908,62,Project Tycho - https://zenodo.org/records/11452259,2.8915995302549926
+North Carolina,1909,309,Project Tycho - https://zenodo.org/records/11452259,14.199232230510978
+North Carolina,1910,248,Project Tycho - https://zenodo.org/records/11452259,11.154986391366402
+North Carolina,1911,8,Project Tycho - https://zenodo.org/records/11452259,0.35114270615149346
+North Carolina,1912,125,Project Tycho - https://zenodo.org/records/11452259,5.398838083662986
+North Carolina,1913,267,Project Tycho - https://zenodo.org/records/11452259,11.292686991247534
+North Carolina,1914,199,Project Tycho - https://zenodo.org/records/11452259,8.211532375101148
+North Carolina,1915,1,Project Tycho - https://zenodo.org/records/11452259,0.04039632021839867
+North Carolina,1916,49,Project Tycho - https://zenodo.org/records/11452259,1.9479128114225606
+North Carolina,1917,1443,Project Tycho - https://zenodo.org/records/11452259,56.62052009263321
+North Carolina,1918,1303,Project Tycho - https://zenodo.org/records/11452259,51.61373123308096
+North Carolina,1919,802,Project Tycho - https://zenodo.org/records/11452259,31.605475392457645
+North Carolina,1920,736,Project Tycho - https://zenodo.org/records/11452259,28.410538456906313
+North Carolina,1921,3703,Project Tycho - https://zenodo.org/records/11452259,139.54359484348169
+North Carolina,1922,22,Project Tycho - https://zenodo.org/records/11452259,0.8140008140008139
+North Carolina,1923,4949,Project Tycho - https://zenodo.org/records/11452259,179.06758218239565
+North Carolina,1924,1946,Project Tycho - https://zenodo.org/records/11452259,68.69455632706516
+North Carolina,1925,176,Project Tycho - https://zenodo.org/records/11452259,6.073373949021618
+North Carolina,1926,1559,Project Tycho - https://zenodo.org/records/11452259,52.63408440157342
+North Carolina,1927,6646,Project Tycho - https://zenodo.org/records/11452259,219.33797949655235
+North Carolina,1928,59814,Project Tycho - https://zenodo.org/records/11452259,1938.813944005378
+North Carolina,1929,1232,Project Tycho - https://zenodo.org/records/11452259,39.284048221169186
+North Carolina,1930,1481,Project Tycho - https://zenodo.org/records/11452259,46.71678179729963
+North Carolina,1931,17348,Project Tycho - https://zenodo.org/records/11452259,544.304941289866
+North Carolina,1932,14648,Project Tycho - https://zenodo.org/records/11452259,453.4665829986561
+North Carolina,1933,20472,Project Tycho - https://zenodo.org/records/11452259,625.8123761183737
+North Carolina,1934,57410,Project Tycho - https://zenodo.org/records/11452259,1735.8549440873896
+North Carolina,1935,10312,Project Tycho - https://zenodo.org/records/11452259,310.01198620819446
+North Carolina,1936,2651,Project Tycho - https://zenodo.org/records/11452259,79.14978028546469
+North Carolina,1937,7719,Project Tycho - https://zenodo.org/records/11452259,227.8076428741126
+North Carolina,1938,49440,Project Tycho - https://zenodo.org/records/11452259,1435.7735287967846
+North Carolina,1939,21353,Project Tycho - https://zenodo.org/records/11452259,607.0480458642098
+North Carolina,1940,3601,Project Tycho - https://zenodo.org/records/11452259,100.65480127035808
+North Carolina,1941,27360,Project Tycho - https://zenodo.org/records/11452259,761.5677718770503
+North Carolina,1942,23019,Project Tycho - https://zenodo.org/records/11452259,644.3262537406555
+North Carolina,1943,5052,Project Tycho - https://zenodo.org/records/11452259,138.12132038733023
+North Carolina,1944,26391,Project Tycho - https://zenodo.org/records/11452259,740.5796450740271
+North Carolina,1945,1390,Project Tycho - https://zenodo.org/records/11452259,39.304030246572
+North Carolina,1946,10463,Project Tycho - https://zenodo.org/records/11452259,282.04391399210607
+North Carolina,1947,5578,Project Tycho - https://zenodo.org/records/11452259,147.84896716443546
+North Carolina,1948,1083,Project Tycho - https://zenodo.org/records/11452259,28.196978939746728
+North Carolina,1949,17306,Project Tycho - https://zenodo.org/records/11452259,442.0534719690946
+North Carolina,1950,5163,Project Tycho - https://zenodo.org/records/11452259,126.79061351627723
+North Carolina,1951,3342,Project Tycho - https://zenodo.org/records/11452259,81.03546938498394
+North Carolina,1952,4063,Project Tycho - https://zenodo.org/records/11452259,98.7817244814081
+North Carolina,1953,5891,Project Tycho - https://zenodo.org/records/11452259,142.84259429890497
+North Carolina,1954,9472,Project Tycho - https://zenodo.org/records/11452259,229.0616669701637
+North Carolina,1955,1259,Project Tycho - https://zenodo.org/records/11452259,29.649746764315363
+North Carolina,1956,7720,Project Tycho - https://zenodo.org/records/11452259,178.98091697116993
+North Carolina,1957,1933,Project Tycho - https://zenodo.org/records/11452259,44.20945355011289
+North Carolina,1958,4061,Project Tycho - https://zenodo.org/records/11452259,92.7089364018066
+North Carolina,1959,3260,Project Tycho - https://zenodo.org/records/11452259,73.0539088547164
+North Carolina,1960,1239,Project Tycho - https://zenodo.org/records/11452259,27.066744757538547
+North Carolina,1961,5175,Project Tycho - https://zenodo.org/records/11452259,110.86918657152412
+North Carolina,1962,907,Project Tycho - https://zenodo.org/records/11452259,19.249923647629192
+North Carolina,1963,1448,Project Tycho - https://zenodo.org/records/11452259,30.50513383706129
+North Carolina,1964,1253,Project Tycho - https://zenodo.org/records/11452259,26.06722723340799
+North Carolina,1965,419,Project Tycho - https://zenodo.org/records/11452259,8.607473135542229
+North Carolina,1966,778,Project Tycho - https://zenodo.org/records/11452259,15.874648227589406
+North Carolina,1967,943,Project Tycho - https://zenodo.org/records/11452259,19.02378719826216
+North Carolina,1968,326,Project Tycho - https://zenodo.org/records/11452259,6.508279889574853
+North Carolina,1969,371,Project Tycho - https://zenodo.org/records/11452259,7.366912554747975
+North Carolina,1970,1013,Project Tycho - https://zenodo.org/records/11452259,19.903742905730333
+North Carolina,1971,1896,Project Tycho - https://zenodo.org/records/11452259,36.40039979004495
+North Carolina,1972,39,Project Tycho - https://zenodo.org/records/11452259,0.7349544921831936
+North Carolina,1973,4,Project Tycho - https://zenodo.org/records/11452259,0.07413941286404074
+North Carolina,1974,6,Project Tycho - https://zenodo.org/records/11452259,0.10956140560709708
+North Carolina,1975,3,Project Tycho - https://zenodo.org/records/11452259,0.05402742972607193
+North Carolina,1976,19,Project Tycho - https://zenodo.org/records/11452259,0.3384654794604005
+North Carolina,1977,66,Project Tycho - https://zenodo.org/records/11452259,1.15966638155273
+North Carolina,1978,125,Project Tycho - https://zenodo.org/records/11452259,2.168162322854634
+North Carolina,1979,115,Project Tycho - https://zenodo.org/records/11452259,1.9727878786423239
+North Carolina,1980,131,Project Tycho - https://zenodo.org/records/11452259,2.21850476843044
+North Carolina,1981,4,Project Tycho - https://zenodo.org/records/11452259,0.06708472750770678
+North Carolina,1982,2,Project Tycho - https://zenodo.org/records/11452259,0.03319435961441432
+North Carolina,1983,1,Project Tycho - https://zenodo.org/records/11452259,0.016438897522049904
+North Carolina,1984,1,Project Tycho - https://zenodo.org/records/11452259,0.01620700888306157
+North Carolina,1985,9,Project Tycho - https://zenodo.org/records/11452259,0.14376521415346172
+North Carolina,1986,4,Project Tycho - https://zenodo.org/records/11452259,0.06321213407483274
+North Carolina,1987,15,Project Tycho - https://zenodo.org/records/11452259,0.23400560022202452
+North Carolina,1988,4,Project Tycho - https://zenodo.org/records/11452259,0.06166108171419041
+North Carolina,1989,195,Project Tycho - https://zenodo.org/records/11452259,2.967122457252134
+North Carolina,1990,40,Project Tycho - https://zenodo.org/records/11452259,0.6002722534805661
+North Carolina,1991,45,Project Tycho - https://zenodo.org/records/11452259,0.6661847436883807
+North Carolina,1992,25,Project Tycho - https://zenodo.org/records/11452259,0.36556757070552054
+North Carolina,1993,1,https://stacks.cdc.gov/view/cdc/5650,0.014379470487502875
+North Carolina,1994,3,Project Tycho - https://zenodo.org/records/11452259,0.042444707633072294
+North Carolina,1995,0,https://stacks.cdc.gov/view/cdc/5644,0.0
+North Carolina,1996,4,Project Tycho - https://zenodo.org/records/11452259,0.054682421583698626
+North Carolina,1997,3,Project Tycho - https://zenodo.org/records/11452259,0.040343728567394196
+North Carolina,1998,1,https://stacks.cdc.gov/view/cdc/5637,0.013239118470648807
+North Carolina,1999,1,Project Tycho - https://zenodo.org/records/11452259,0.013057491219816466
+North Carolina,2000,1,Project Tycho - https://zenodo.org/records/11452259,0.012361405467078796
+North Carolina,2001,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5053a1.htm,0.0
+North Carolina,2002,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.0
+North Carolina,2003,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.011861097533449185
+North Carolina,2004,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.023359833117352208
+North Carolina,2005,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.0
+North Carolina,2006,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.0
+North Carolina,2007,3,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.03286894985348666
+North Carolina,2008,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.0
+North Carolina,2009,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.0
+North Carolina,2010,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.0
+North Carolina,2011,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.020685580113131506
+North Carolina,2012,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.0
+North Carolina,2013,22,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.22320153587005936
+North Carolina,2014,1,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.010053047923281572
+North Carolina,2015,0,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.0
+North Carolina,2016,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.009830944135365022
+North Carolina,2017,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+North Carolina,2018,3,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.028841303515399187
+North Carolina,2019,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+North Carolina,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+North Carolina,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+North Carolina,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+North Dakota,1918,34,Project Tycho - https://zenodo.org/records/11452259,5.340571378307227
+North Dakota,1919,209,Project Tycho - https://zenodo.org/records/11452259,32.22086555419889
+North Dakota,1920,101,Project Tycho - https://zenodo.org/records/11452259,15.619055866733886
+North Dakota,1921,203,Project Tycho - https://zenodo.org/records/11452259,31.39275585096019
+North Dakota,1922,8,Project Tycho - https://zenodo.org/records/11452259,1.2352408024741874
+North Dakota,1923,31,Project Tycho - https://zenodo.org/records/11452259,4.779171445838113
+North Dakota,1924,259,Project Tycho - https://zenodo.org/records/11452259,40.30237675097488
+North Dakota,1925,8,Project Tycho - https://zenodo.org/records/11452259,1.2429250376373238
+North Dakota,1926,288,Project Tycho - https://zenodo.org/records/11452259,44.195435900505025
+North Dakota,1927,815,Project Tycho - https://zenodo.org/records/11452259,123.92478145902804
+North Dakota,1928,398,Project Tycho - https://zenodo.org/records/11452259,59.78983422592445
+North Dakota,1929,2725,Project Tycho - https://zenodo.org/records/11452259,403.8987718512941
+North Dakota,1930,796,Project Tycho - https://zenodo.org/records/11452259,116.59894357841571
+North Dakota,1931,1045,Project Tycho - https://zenodo.org/records/11452259,153.5229476405947
+North Dakota,1932,3013,Project Tycho - https://zenodo.org/records/11452259,445.2647943772204
+North Dakota,1933,2800,Project Tycho - https://zenodo.org/records/11452259,415.015251810504
+North Dakota,1934,5891,Project Tycho - https://zenodo.org/records/11452259,875.7611436182864
+North Dakota,1935,1902,Project Tycho - https://zenodo.org/records/11452259,283.59700001491046
+North Dakota,1936,138,Project Tycho - https://zenodo.org/records/11452259,20.762370159960522
+North Dakota,1937,64,Project Tycho - https://zenodo.org/records/11452259,9.761231135276937
+North Dakota,1938,6741,Project Tycho - https://zenodo.org/records/11452259,1040.844781184812
+North Dakota,1939,3322,Project Tycho - https://zenodo.org/records/11452259,515.3231861306396
+North Dakota,1940,205,Project Tycho - https://zenodo.org/records/11452259,31.99925074925075
+North Dakota,1941,1702,Project Tycho - https://zenodo.org/records/11452259,276.4714959836911
+North Dakota,1942,1641,Project Tycho - https://zenodo.org/records/11452259,281.1939347102297
+North Dakota,1943,4513,Project Tycho - https://zenodo.org/records/11452259,825.7310455112653
+North Dakota,1944,3459,Project Tycho - https://zenodo.org/records/11452259,647.1057032854785
+North Dakota,1945,138,Project Tycho - https://zenodo.org/records/11452259,25.24947579892635
+North Dakota,1946,249,Project Tycho - https://zenodo.org/records/11452259,43.64056995635943
+North Dakota,1947,1564,Project Tycho - https://zenodo.org/records/11452259,270.31791737674087
+North Dakota,1948,1327,Project Tycho - https://zenodo.org/records/11452259,228.56453890936652
+North Dakota,1949,1468,Project Tycho - https://zenodo.org/records/11452259,245.6504969067783
+North Dakota,1950,403,Project Tycho - https://zenodo.org/records/11452259,65.039968109435
+North Dakota,1951,2655,Project Tycho - https://zenodo.org/records/11452259,439.13040601782325
+North Dakota,1952,2565,Project Tycho - https://zenodo.org/records/11452259,421.4535464535465
+North Dakota,1953,1548,Project Tycho - https://zenodo.org/records/11452259,253.93325885936724
+North Dakota,1954,2775,Project Tycho - https://zenodo.org/records/11452259,453.71976632205764
+North Dakota,1955,2508,Project Tycho - https://zenodo.org/records/11452259,407.3974805682123
+North Dakota,1956,2259,Project Tycho - https://zenodo.org/records/11452259,368.1473502028151
+North Dakota,1957,3858,Project Tycho - https://zenodo.org/records/11452259,629.7623944682769
+North Dakota,1958,4286,Project Tycho - https://zenodo.org/records/11452259,706.5541719007066
+North Dakota,1959,5559,Project Tycho - https://zenodo.org/records/11452259,898.6159471596364
+North Dakota,1960,2476,Project Tycho - https://zenodo.org/records/11452259,390.1461314710526
+North Dakota,1961,2871,Project Tycho - https://zenodo.org/records/11452259,447.4464692873429
+North Dakota,1962,3745,Project Tycho - https://zenodo.org/records/11452259,587.324763148939
+North Dakota,1963,4320,Project Tycho - https://zenodo.org/records/11452259,670.137316100049
+North Dakota,1964,5237,Project Tycho - https://zenodo.org/records/11452259,806.1276166052745
+North Dakota,1965,4045,Project Tycho - https://zenodo.org/records/11452259,622.6439200245055
+North Dakota,1966,1376,Project Tycho - https://zenodo.org/records/11452259,212.4614180255602
+North Dakota,1967,902,Project Tycho - https://zenodo.org/records/11452259,143.94551135765192
+North Dakota,1968,136,Project Tycho - https://zenodo.org/records/11452259,21.878282747847965
+North Dakota,1969,81,Project Tycho - https://zenodo.org/records/11452259,13.03044781305651
+North Dakota,1970,321,Project Tycho - https://zenodo.org/records/11452259,51.90739462071219
+North Dakota,1971,227,Project Tycho - https://zenodo.org/records/11452259,36.181872085127814
+North Dakota,1972,59,Project Tycho - https://zenodo.org/records/11452259,9.339137316976652
+North Dakota,1973,71,Project Tycho - https://zenodo.org/records/11452259,11.210992457054793
+North Dakota,1974,37,Project Tycho - https://zenodo.org/records/11452259,5.825001220101607
+North Dakota,1975,852,Project Tycho - https://zenodo.org/records/11452259,133.22408541352632
+North Dakota,1976,1,Project Tycho - https://zenodo.org/records/11452259,0.15469291908632174
+North Dakota,1977,23,Project Tycho - https://zenodo.org/records/11452259,3.5361874978859746
+North Dakota,1978,179,Project Tycho - https://zenodo.org/records/11452259,27.45600903133973
+North Dakota,1979,11,Project Tycho - https://zenodo.org/records/11452259,1.6831204440989798
+North Dakota,1980,0,https://stacks.cdc.gov/view/cdc/1484,0.0
+North Dakota,1981,0,https://stacks.cdc.gov/view/cdc/1307,0.0
+North Dakota,1982,0,https://stacks.cdc.gov/view/cdc/35066,0.0
+North Dakota,1983,0,https://stacks.cdc.gov/view/cdc/35188,0.0
+North Dakota,1984,0,https://stacks.cdc.gov/view/cdc/35267,0.0
+North Dakota,1985,1,Project Tycho - https://zenodo.org/records/11452259,0.14756749737329855
+North Dakota,1986,25,https://stacks.cdc.gov/view/cdc/35496,3.7303355362208115
+North Dakota,1987,2,https://stacks.cdc.gov/view/cdc/35629,0.3022074744974667
+North Dakota,1988,0,https://stacks.cdc.gov/view/cdc/35958,0.0
+North Dakota,1989,0,https://stacks.cdc.gov/view/cdc/35853,0.0
+North Dakota,1990,0,https://stacks.cdc.gov/view/cdc/35905,0.0
+North Dakota,1991,0,https://stacks.cdc.gov/view/cdc/36010,0.0
+North Dakota,1992,0,https://stacks.cdc.gov/view/cdc/36063,0.0
+North Dakota,1993,0,https://stacks.cdc.gov/view/cdc/5650,0.0
+North Dakota,1994,0,https://stacks.cdc.gov/view/cdc/5648,0.0
+North Dakota,1995,0,https://stacks.cdc.gov/view/cdc/5644,0.0
+North Dakota,1996,0,https://stacks.cdc.gov/view/cdc/5642,0.0
+North Dakota,1997,0,"https://www.cdc.gov/mmwr/preview/mmwrhtml/00056071.htm#:~:text=As%20of%20January%201%2C%201997,and%20control%20of%20the%20disease.",0.0
+North Dakota,1998,0,https://stacks.cdc.gov/view/cdc/5637,0.0
+North Dakota,1999,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.0
+North Dakota,2000,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4953a1.htm,0.0
+North Dakota,2001,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5053a1.htm,0.0
+North Dakota,2002,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.0
+North Dakota,2003,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.0
+North Dakota,2004,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0
+North Dakota,2005,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.0
+North Dakota,2006,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.0
+North Dakota,2007,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.0
+North Dakota,2008,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.0
+North Dakota,2009,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.0
+North Dakota,2010,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.0
+North Dakota,2011,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.14572777177865118
+North Dakota,2012,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.0
+North Dakota,2013,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.0
+North Dakota,2014,0,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.0
+North Dakota,2015,0,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.0
+North Dakota,2016,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+North Dakota,2017,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+North Dakota,2018,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+North Dakota,2019,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+North Dakota,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+North Dakota,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+North Dakota,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Northern Mariana Islands,1990,10,Project Tycho - https://zenodo.org/records/11452259,
+Northern Mariana Islands,1993,84,Project Tycho - https://zenodo.org/records/11452259,
+Northern Mariana Islands,1994,19,Project Tycho - https://zenodo.org/records/11452259,
+Ohio,1888,3,Project Tycho - https://zenodo.org/records/11452259,
+Ohio,1889,98,Project Tycho - https://zenodo.org/records/11452259,
+Ohio,1890,109,Project Tycho - https://zenodo.org/records/11452259,
+Ohio,1891,29,Project Tycho - https://zenodo.org/records/11452259,
+Ohio,1892,39,Project Tycho - https://zenodo.org/records/11452259,
+Ohio,1893,55,Project Tycho - https://zenodo.org/records/11452259,
+Ohio,1894,111,Project Tycho - https://zenodo.org/records/11452259,
+Ohio,1895,96,Project Tycho - https://zenodo.org/records/11452259,
+Ohio,1896,128,Project Tycho - https://zenodo.org/records/11452259,
+Ohio,1897,52,Project Tycho - https://zenodo.org/records/11452259,
+Ohio,1898,54,Project Tycho - https://zenodo.org/records/11452259,
+Ohio,1899,46,Project Tycho - https://zenodo.org/records/11452259,
+Ohio,1900,25,Project Tycho - https://zenodo.org/records/11452259,0.600216894376952
+Ohio,1901,64,Project Tycho - https://zenodo.org/records/11452259,1.5165100554094861
+Ohio,1902,70,Project Tycho - https://zenodo.org/records/11452259,1.6180025434999983
+Ohio,1903,31,Project Tycho - https://zenodo.org/records/11452259,0.706088257387847
+Ohio,1904,98,Project Tycho - https://zenodo.org/records/11452259,2.1960991005405543
+Ohio,1905,12,Project Tycho - https://zenodo.org/records/11452259,0.2646360262254302
+Ohio,1906,625,Project Tycho - https://zenodo.org/records/11452259,13.6118514143367
+Ohio,1907,5078,Project Tycho - https://zenodo.org/records/11452259,109.5664594584681
+Ohio,1908,4694,Project Tycho - https://zenodo.org/records/11452259,100.26321764615543
+Ohio,1909,3883,Project Tycho - https://zenodo.org/records/11452259,82.51692999618973
+Ohio,1910,9925,Project Tycho - https://zenodo.org/records/11452259,207.1685105533831
+Ohio,1911,3091,Project Tycho - https://zenodo.org/records/11452259,64.05127749247227
+Ohio,1912,8593,Project Tycho - https://zenodo.org/records/11452259,175.44278733733054
+Ohio,1913,10362,Project Tycho - https://zenodo.org/records/11452259,207.1572613898009
+Ohio,1914,4034,Project Tycho - https://zenodo.org/records/11452259,78.8798205122339
+Ohio,1915,7701,Project Tycho - https://zenodo.org/records/11452259,146.51126820237465
+Ohio,1916,18358,Project Tycho - https://zenodo.org/records/11452259,341.7752579139087
+Ohio,1917,8163,Project Tycho - https://zenodo.org/records/11452259,148.0008195071716
+Ohio,1918,5630,Project Tycho - https://zenodo.org/records/11452259,101.39490939923607
+Ohio,1919,10597,Project Tycho - https://zenodo.org/records/11452259,186.28213243733217
+Ohio,1920,18777,Project Tycho - https://zenodo.org/records/11452259,323.4737326822169
+Ohio,1921,3686,Project Tycho - https://zenodo.org/records/11452259,62.1908069974275
+Ohio,1922,16822,Project Tycho - https://zenodo.org/records/11452259,277.5882855169277
+Ohio,1923,23755,Project Tycho - https://zenodo.org/records/11452259,383.8147942951436
+Ohio,1924,6026,Project Tycho - https://zenodo.org/records/11452259,95.26792245576864
+Ohio,1925,4787,Project Tycho - https://zenodo.org/records/11452259,74.32728912368329
+Ohio,1926,24870,Project Tycho - https://zenodo.org/records/11452259,381.998075725013
+Ohio,1927,1834,Project Tycho - https://zenodo.org/records/11452259,27.85719677919769
+Ohio,1928,37339,Project Tycho - https://zenodo.org/records/11452259,564.4930130402286
+Ohio,1929,51493,Project Tycho - https://zenodo.org/records/11452259,776.3591675454036
+Ohio,1930,24662,Project Tycho - https://zenodo.org/records/11452259,369.8193130795953
+Ohio,1931,25948,Project Tycho - https://zenodo.org/records/11452259,387.24347060170186
+Ohio,1932,54240,Project Tycho - https://zenodo.org/records/11452259,806.6966530566351
+Ohio,1933,23340,Project Tycho - https://zenodo.org/records/11452259,345.944856330613
+Ohio,1934,37240,Project Tycho - https://zenodo.org/records/11452259,551.0709110175857
+Ohio,1935,49305,Project Tycho - https://zenodo.org/records/11452259,725.736617883369
+Ohio,1936,12897,Project Tycho - https://zenodo.org/records/11452259,189.4444329380368
+Ohio,1937,38149,Project Tycho - https://zenodo.org/records/11452259,559.713454411648
+Ohio,1938,56078,Project Tycho - https://zenodo.org/records/11452259,819.3941498022236
+Ohio,1939,1963,Project Tycho - https://zenodo.org/records/11452259,28.478637250057524
+Ohio,1940,2571,Project Tycho - https://zenodo.org/records/11452259,37.06785349157986
+Ohio,1941,114788,Project Tycho - https://zenodo.org/records/11452259,1648.0788541725592
+Ohio,1942,8651,Project Tycho - https://zenodo.org/records/11452259,124.0114455783849
+Ohio,1943,23868,Project Tycho - https://zenodo.org/records/11452259,347.17757490034717
+Ohio,1944,49184,Project Tycho - https://zenodo.org/records/11452259,710.2466772891752
+Ohio,1945,1903,Project Tycho - https://zenodo.org/records/11452259,27.488416730753343
+Ohio,1946,21250,Project Tycho - https://zenodo.org/records/11452259,282.5981260486053
+Ohio,1947,26234,Project Tycho - https://zenodo.org/records/11452259,340.1400675897756
+Ohio,1948,26744,Project Tycho - https://zenodo.org/records/11452259,339.2240060599634
+Ohio,1949,21389,Project Tycho - https://zenodo.org/records/11452259,267.9999042723237
+Ohio,1950,13778,Project Tycho - https://zenodo.org/records/11452259,172.48415744656344
+Ohio,1951,23773,Project Tycho - https://zenodo.org/records/11452259,294.61916324588447
+Ohio,1952,29854,Project Tycho - https://zenodo.org/records/11452259,360.4130008963846
+Ohio,1953,36660,Project Tycho - https://zenodo.org/records/11452259,426.2993437711166
+Ohio,1954,28597,Project Tycho - https://zenodo.org/records/11452259,321.97037719408956
+Ohio,1955,15356,Project Tycho - https://zenodo.org/records/11452259,170.13041300498327
+Ohio,1956,44526,Project Tycho - https://zenodo.org/records/11452259,483.1271693441781
+Ohio,1957,8214,Project Tycho - https://zenodo.org/records/11452259,87.20291398293524
+Ohio,1958,29906,Project Tycho - https://zenodo.org/records/11452259,311.24204475595246
+Ohio,1959,12029,Project Tycho - https://zenodo.org/records/11452259,124.25791559283442
+Ohio,1960,18605,Project Tycho - https://zenodo.org/records/11452259,190.94322566687475
+Ohio,1961,20611,Project Tycho - https://zenodo.org/records/11452259,208.9548365172477
+Ohio,1962,11890,Project Tycho - https://zenodo.org/records/11452259,119.63059601291044
+Ohio,1963,14571,Project Tycho - https://zenodo.org/records/11452259,145.76851148050827
+Ohio,1964,19172,Project Tycho - https://zenodo.org/records/11452259,190.00840429411858
+Ohio,1965,9277,Project Tycho - https://zenodo.org/records/11452259,90.85121329018986
+Ohio,1966,6503,Project Tycho - https://zenodo.org/records/11452259,62.88967566799125
+Ohio,1967,1228,Project Tycho - https://zenodo.org/records/11452259,11.780038666921708
+Ohio,1968,326,Project Tycho - https://zenodo.org/records/11452259,3.096941096180351
+Ohio,1969,565,Project Tycho - https://zenodo.org/records/11452259,5.343515709888899
+Ohio,1970,4044,Project Tycho - https://zenodo.org/records/11452259,37.907477259263146
+Ohio,1971,3982,Project Tycho - https://zenodo.org/records/11452259,37.057193525283765
+Ohio,1972,297,Project Tycho - https://zenodo.org/records/11452259,2.76080317620645
+Ohio,1973,445,Project Tycho - https://zenodo.org/records/11452259,4.1287498210488485
+Ohio,1974,2911,Project Tycho - https://zenodo.org/records/11452259,27.012420702631015
+Ohio,1975,111,Project Tycho - https://zenodo.org/records/11452259,1.029570469692831
+Ohio,1976,626,Project Tycho - https://zenodo.org/records/11452259,5.815998529834493
+Ohio,1977,1874,Project Tycho - https://zenodo.org/records/11452259,17.380553905454054
+Ohio,1978,501,Project Tycho - https://zenodo.org/records/11452259,4.636151842208712
+Ohio,1979,321,Project Tycho - https://zenodo.org/records/11452259,2.9697210571540857
+Ohio,1980,380,Project Tycho - https://zenodo.org/records/11452259,3.5147921879118895
+Ohio,1981,20,Project Tycho - https://zenodo.org/records/11452259,0.1852003098771585
+Ohio,1982,3,Project Tycho - https://zenodo.org/records/11452259,0.027860730523213376
+Ohio,1983,89,Project Tycho - https://zenodo.org/records/11452259,0.8280326066215256
+Ohio,1984,9,Project Tycho - https://zenodo.org/records/11452259,0.08373274628615034
+Ohio,1985,16,Project Tycho - https://zenodo.org/records/11452259,0.14889732226778066
+Ohio,1986,10,Project Tycho - https://zenodo.org/records/11452259,0.09310121834116346
+Ohio,1987,5,Project Tycho - https://zenodo.org/records/11452259,0.04642159161068996
+Ohio,1988,96,Project Tycho - https://zenodo.org/records/11452259,0.8881200072159751
+Ohio,1989,2721,Project Tycho - https://zenodo.org/records/11452259,25.101369496033506
+Ohio,1990,566,Project Tycho - https://zenodo.org/records/11452259,5.205699634074265
+Ohio,1991,12,Project Tycho - https://zenodo.org/records/11452259,0.1096429513835844
+Ohio,1992,6,Project Tycho - https://zenodo.org/records/11452259,0.05445329976105892
+Ohio,1993,8,Project Tycho - https://zenodo.org/records/11452259,0.07219268588827009
+Ohio,1994,17,https://stacks.cdc.gov/view/cdc/5648,0.15284248359325847
+Ohio,1995,2,Project Tycho - https://zenodo.org/records/11452259,0.017910477701097053
+Ohio,1996,6,Project Tycho - https://zenodo.org/records/11452259,0.05357994874006305
+Ohio,1997,0,"https://www.cdc.gov/mmwr/preview/mmwrhtml/00056071.htm#:~:text=As%20of%20January%201%2C%201997,and%20control%20of%20the%20disease.",0.0
+Ohio,1998,1,Project Tycho - https://zenodo.org/records/11452259,0.008889687775496981
+Ohio,1999,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.0
+Ohio,2000,2,Project Tycho - https://zenodo.org/records/11452259,0.017582562880080064
+Ohio,2001,3,Project Tycho - https://zenodo.org/records/11452259,0.02631858062841928
+Ohio,2002,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.008757107268258919
+Ohio,2003,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.017473014239982414
+Ohio,2004,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0
+Ohio,2005,3,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.02614428525576475
+Ohio,2006,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.0
+Ohio,2007,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.0
+Ohio,2008,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.0
+Ohio,2009,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.008665192890659822
+Ohio,2010,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.017314536211101593
+Ohio,2011,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.0
+Ohio,2012,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.008648632940861253
+Ohio,2013,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.0
+Ohio,2014,382,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,3.2879507192994706
+Ohio,2015,1,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.008595542506375958
+Ohio,2016,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Ohio,2017,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0085635713723577
+Ohio,2018,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Ohio,2019,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.008541020342746022
+Ohio,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Ohio,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Ohio,2022,87,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.7379353298922928
+Oklahoma,1907,1,Project Tycho - https://zenodo.org/records/11452259,0.07065070714292779
+Oklahoma,1910,141,Project Tycho - https://zenodo.org/records/11452259,8.429631409882756
+Oklahoma,1911,143,Project Tycho - https://zenodo.org/records/11452259,8.334722453742291
+Oklahoma,1912,15,Project Tycho - https://zenodo.org/records/11452259,0.8626951632132979
+Oklahoma,1913,103,Project Tycho - https://zenodo.org/records/11452259,5.790495379690653
+Oklahoma,1914,27,Project Tycho - https://zenodo.org/records/11452259,1.4787843735212156
+Oklahoma,1915,1,Project Tycho - https://zenodo.org/records/11452259,0.05370973112908597
+Oklahoma,1916,251,Project Tycho - https://zenodo.org/records/11452259,13.148885723610423
+Oklahoma,1917,956,Project Tycho - https://zenodo.org/records/11452259,48.72678342066097
+Oklahoma,1918,356,Project Tycho - https://zenodo.org/records/11452259,18.06218159697083
+Oklahoma,1919,66,Project Tycho - https://zenodo.org/records/11452259,3.29176564823095
+Oklahoma,1920,883,Project Tycho - https://zenodo.org/records/11452259,42.9254443852984
+Oklahoma,1921,141,Project Tycho - https://zenodo.org/records/11452259,6.6821224316480485
+Oklahoma,1922,210,Project Tycho - https://zenodo.org/records/11452259,9.803280831318215
+Oklahoma,1923,450,Project Tycho - https://zenodo.org/records/11452259,20.82216070173458
+Oklahoma,1924,190,Project Tycho - https://zenodo.org/records/11452259,8.710885259760891
+Oklahoma,1925,32,Project Tycho - https://zenodo.org/records/11452259,1.4426007205790599
+Oklahoma,1926,106,Project Tycho - https://zenodo.org/records/11452259,4.693887672611076
+Oklahoma,1927,1583,Project Tycho - https://zenodo.org/records/11452259,68.57842937634786
+Oklahoma,1928,6708,Project Tycho - https://zenodo.org/records/11452259,285.89158281991047
+Oklahoma,1929,1330,Project Tycho - https://zenodo.org/records/11452259,56.014811495418584
+Oklahoma,1930,6661,Project Tycho - https://zenodo.org/records/11452259,277.148923546258
+Oklahoma,1931,860,Project Tycho - https://zenodo.org/records/11452259,35.75284474160879
+Oklahoma,1932,1252,Project Tycho - https://zenodo.org/records/11452259,52.24516502711992
+Oklahoma,1933,3181,Project Tycho - https://zenodo.org/records/11452259,132.85209773504087
+Oklahoma,1934,9528,Project Tycho - https://zenodo.org/records/11452259,398.0962575692814
+Oklahoma,1935,2545,Project Tycho - https://zenodo.org/records/11452259,106.55731527483414
+Oklahoma,1936,394,Project Tycho - https://zenodo.org/records/11452259,16.64297647384328
+Oklahoma,1937,1246,Project Tycho - https://zenodo.org/records/11452259,53.33141579928212
+Oklahoma,1938,3832,Project Tycho - https://zenodo.org/records/11452259,164.72340052374477
+Oklahoma,1939,5134,Project Tycho - https://zenodo.org/records/11452259,219.84016840424897
+Oklahoma,1940,391,Project Tycho - https://zenodo.org/records/11452259,16.80040389717809
+Oklahoma,1941,3678,Project Tycho - https://zenodo.org/records/11452259,162.43703246355767
+Oklahoma,1942,5951,Project Tycho - https://zenodo.org/records/11452259,268.3997717857763
+Oklahoma,1943,1256,Project Tycho - https://zenodo.org/records/11452259,56.90454670046507
+Oklahoma,1944,3892,Project Tycho - https://zenodo.org/records/11452259,190.3138467015119
+Oklahoma,1945,903,Project Tycho - https://zenodo.org/records/11452259,44.482145073861055
+Oklahoma,1946,4281,Project Tycho - https://zenodo.org/records/11452259,200.9738381918833
+Oklahoma,1947,167,Project Tycho - https://zenodo.org/records/11452259,7.8215268088685805
+Oklahoma,1948,1554,Project Tycho - https://zenodo.org/records/11452259,74.31534477968178
+Oklahoma,1949,7453,Project Tycho - https://zenodo.org/records/11452259,353.70804967004494
+Oklahoma,1950,745,Project Tycho - https://zenodo.org/records/11452259,33.38966999801455
+Oklahoma,1951,7860,Project Tycho - https://zenodo.org/records/11452259,355.30080778949554
+Oklahoma,1952,1879,Project Tycho - https://zenodo.org/records/11452259,84.59318959544287
+Oklahoma,1953,4723,Project Tycho - https://zenodo.org/records/11452259,216.23655904132534
+Oklahoma,1954,3361,Project Tycho - https://zenodo.org/records/11452259,151.99829595483737
+Oklahoma,1955,2976,Project Tycho - https://zenodo.org/records/11452259,132.13453213453212
+Oklahoma,1956,10018,Project Tycho - https://zenodo.org/records/11452259,440.29881249414905
+Oklahoma,1957,1510,Project Tycho - https://zenodo.org/records/11452259,66.10392237035533
+Oklahoma,1958,7197,Project Tycho - https://zenodo.org/records/11452259,317.1508685403701
+Oklahoma,1959,668,Project Tycho - https://zenodo.org/records/11452259,29.153895471064537
+Oklahoma,1960,1208,Project Tycho - https://zenodo.org/records/11452259,51.66066809902427
+Oklahoma,1961,622,Project Tycho - https://zenodo.org/records/11452259,26.108345436076526
+Oklahoma,1962,2075,Project Tycho - https://zenodo.org/records/11452259,85.4110866471806
+Oklahoma,1963,347,Project Tycho - https://zenodo.org/records/11452259,14.212929342080633
+Oklahoma,1964,1037,Project Tycho - https://zenodo.org/records/11452259,42.353394765496155
+Oklahoma,1965,244,Project Tycho - https://zenodo.org/records/11452259,9.99000999000999
+Oklahoma,1966,620,Project Tycho - https://zenodo.org/records/11452259,25.239634041590033
+Oklahoma,1967,811,Project Tycho - https://zenodo.org/records/11452259,32.550815997983534
+Oklahoma,1968,89,Project Tycho - https://zenodo.org/records/11452259,3.5521809393163766
+Oklahoma,1969,142,Project Tycho - https://zenodo.org/records/11452259,5.595981927342874
+Oklahoma,1970,802,Project Tycho - https://zenodo.org/records/11452259,31.303400204994336
+Oklahoma,1971,666,Project Tycho - https://zenodo.org/records/11452259,25.408025807839785
+Oklahoma,1972,13,Project Tycho - https://zenodo.org/records/11452259,0.4884823379816811
+Oklahoma,1973,60,Project Tycho - https://zenodo.org/records/11452259,2.2233536621969847
+Oklahoma,1974,29,Project Tycho - https://zenodo.org/records/11452259,1.0593599566319953
+Oklahoma,1975,202,Project Tycho - https://zenodo.org/records/11452259,7.272839867547905
+Oklahoma,1976,289,Project Tycho - https://zenodo.org/records/11452259,10.213309744946445
+Oklahoma,1977,63,Project Tycho - https://zenodo.org/records/11452259,2.1929183357211777
+Oklahoma,1978,20,Project Tycho - https://zenodo.org/records/11452259,0.6848721668978681
+Oklahoma,1979,26,Project Tycho - https://zenodo.org/records/11452259,0.8729856276346958
+Oklahoma,1980,672,Project Tycho - https://zenodo.org/records/11452259,22.077680581957146
+Oklahoma,1981,8,Project Tycho - https://zenodo.org/records/11452259,0.2581261333350542
+Oklahoma,1982,33,Project Tycho - https://zenodo.org/records/11452259,1.0282523231491691
+Oklahoma,1983,1,Project Tycho - https://zenodo.org/records/11452259,0.030361065940591896
+Oklahoma,1984,11,Project Tycho - https://zenodo.org/records/11452259,0.33446666857211316
+Oklahoma,1985,1,Project Tycho - https://zenodo.org/records/11452259,0.0305380530097847
+Oklahoma,1986,32,Project Tycho - https://zenodo.org/records/11452259,0.9828049067763477
+Oklahoma,1987,5,Project Tycho - https://zenodo.org/records/11452259,0.15560172431606817
+Oklahoma,1988,8,Project Tycho - https://zenodo.org/records/11452259,0.2523480990617698
+Oklahoma,1989,127,Project Tycho - https://zenodo.org/records/11452259,4.027326201054906
+Oklahoma,1990,175,Project Tycho - https://zenodo.org/records/11452259,5.5551111466638226
+Oklahoma,1991,0,https://stacks.cdc.gov/view/cdc/36010,0.0
+Oklahoma,1992,8,Project Tycho - https://zenodo.org/records/11452259,0.2494249196695868
+Oklahoma,1993,0,https://stacks.cdc.gov/view/cdc/5650,0.0
+Oklahoma,1994,0,https://stacks.cdc.gov/view/cdc/5648,0.0
+Oklahoma,1995,0,https://stacks.cdc.gov/view/cdc/5644,0.0
+Oklahoma,1996,0,https://stacks.cdc.gov/view/cdc/5642,0.0
+Oklahoma,1997,1,Project Tycho - https://zenodo.org/records/11452259,0.03014251683384209
+Oklahoma,1998,0,https://stacks.cdc.gov/view/cdc/5637,0.0
+Oklahoma,1999,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.0
+Oklahoma,2000,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4953a1.htm,0.0
+Oklahoma,2001,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5053a1.htm,0.0
+Oklahoma,2002,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.0
+Oklahoma,2003,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.0
+Oklahoma,2004,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0
+Oklahoma,2005,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.0
+Oklahoma,2006,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.0
+Oklahoma,2007,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.0
+Oklahoma,2008,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.0
+Oklahoma,2009,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.0
+Oklahoma,2010,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.0
+Oklahoma,2011,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.0
+Oklahoma,2012,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.0
+Oklahoma,2013,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.0
+Oklahoma,2014,0,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.0
+Oklahoma,2015,1,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.025546516630271396
+Oklahoma,2016,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Oklahoma,2017,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Oklahoma,2018,3,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.07599879516576731
+Oklahoma,2019,4,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.10089198604865617
+Oklahoma,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Oklahoma,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Oklahoma,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Oregon,1907,2,Project Tycho - https://zenodo.org/records/11452259,0.34448310310379276
+Oregon,1908,12,Project Tycho - https://zenodo.org/records/11452259,1.965247866887211
+Oregon,1913,5,Project Tycho - https://zenodo.org/records/11452259,0.6918289466765921
+Oregon,1914,440,Project Tycho - https://zenodo.org/records/11452259,59.72288580984234
+Oregon,1915,205,Project Tycho - https://zenodo.org/records/11452259,27.48928923425568
+Oregon,1916,830,Project Tycho - https://zenodo.org/records/11452259,109.67868110725253
+Oregon,1917,2232,Project Tycho - https://zenodo.org/records/11452259,292.23725160815593
+Oregon,1918,3736,Project Tycho - https://zenodo.org/records/11452259,489.1569767061248
+Oregon,1919,121,Project Tycho - https://zenodo.org/records/11452259,15.617457477922596
+Oregon,1920,1550,Project Tycho - https://zenodo.org/records/11452259,196.5040036106026
+Oregon,1921,1699,Project Tycho - https://zenodo.org/records/11452259,212.69457359682923
+Oregon,1922,66,Project Tycho - https://zenodo.org/records/11452259,8.1000081000081
+Oregon,1923,2510,Project Tycho - https://zenodo.org/records/11452259,301.01950870258196
+Oregon,1924,609,Project Tycho - https://zenodo.org/records/11452259,71.07378602705705
+Oregon,1925,65,Project Tycho - https://zenodo.org/records/11452259,7.353914488682325
+Oregon,1926,776,Project Tycho - https://zenodo.org/records/11452259,85.66019615743372
+Oregon,1927,2457,Project Tycho - https://zenodo.org/records/11452259,265.35626535626534
+Oregon,1928,2769,Project Tycho - https://zenodo.org/records/11452259,295.53779553779555
+Oregon,1929,6024,Project Tycho - https://zenodo.org/records/11452259,635.478565784796
+Oregon,1930,3236,Project Tycho - https://zenodo.org/records/11452259,338.1555682810913
+Oregon,1931,3061,Project Tycho - https://zenodo.org/records/11452259,316.5571488552855
+Oregon,1932,7270,Project Tycho - https://zenodo.org/records/11452259,747.195191639636
+Oregon,1933,2919,Project Tycho - https://zenodo.org/records/11452259,298.1680895791325
+Oregon,1934,2158,Project Tycho - https://zenodo.org/records/11452259,218.8674269892544
+Oregon,1935,9736,Project Tycho - https://zenodo.org/records/11452259,971.6557169104622
+Oregon,1936,11765,Project Tycho - https://zenodo.org/records/11452259,1146.6582198289516
+Oregon,1937,500,Project Tycho - https://zenodo.org/records/11452259,47.662261402719416
+Oregon,1938,1332,Project Tycho - https://zenodo.org/records/11452259,124.71127747603849
+Oregon,1939,2251,Project Tycho - https://zenodo.org/records/11452259,208.02509239141986
+Oregon,1940,12721,Project Tycho - https://zenodo.org/records/11452259,1170.192606656695
+Oregon,1941,6361,Project Tycho - https://zenodo.org/records/11452259,593.337568127484
+Oregon,1942,5630,Project Tycho - https://zenodo.org/records/11452259,508.0736788053861
+Oregon,1943,8883,Project Tycho - https://zenodo.org/records/11452259,726.7916358825449
+Oregon,1944,2946,Project Tycho - https://zenodo.org/records/11452259,238.69074963965474
+Oregon,1945,1934,Project Tycho - https://zenodo.org/records/11452259,154.56543456543457
+Oregon,1946,6420,Project Tycho - https://zenodo.org/records/11452259,479.34128651617436
+Oregon,1947,917,Project Tycho - https://zenodo.org/records/11452259,67.30961910976606
+Oregon,1948,5177,Project Tycho - https://zenodo.org/records/11452259,368.1016492404393
+Oregon,1949,9793,Project Tycho - https://zenodo.org/records/11452259,683.6629478138913
+Oregon,1950,789,Project Tycho - https://zenodo.org/records/11452259,51.44985562740133
+Oregon,1951,9624,Project Tycho - https://zenodo.org/records/11452259,617.8911063229829
+Oregon,1952,3362,Project Tycho - https://zenodo.org/records/11452259,212.3034992820075
+Oregon,1953,9422,Project Tycho - https://zenodo.org/records/11452259,587.9192637468715
+Oregon,1954,3973,Project Tycho - https://zenodo.org/records/11452259,244.09784557386035
+Oregon,1955,4897,Project Tycho - https://zenodo.org/records/11452259,294.88293502760047
+Oregon,1956,2366,Project Tycho - https://zenodo.org/records/11452259,139.20119927187065
+Oregon,1957,15163,Project Tycho - https://zenodo.org/records/11452259,884.80444788856
+Oregon,1958,8905,Project Tycho - https://zenodo.org/records/11452259,517.8174561178054
+Oregon,1959,7815,Project Tycho - https://zenodo.org/records/11452259,447.1473543638492
+Oregon,1960,11074,Project Tycho - https://zenodo.org/records/11452259,624.319247344078
+Oregon,1961,5914,Project Tycho - https://zenodo.org/records/11452259,330.6151039782825
+Oregon,1962,13804,Project Tycho - https://zenodo.org/records/11452259,758.5373922007585
+Oregon,1963,4786,Project Tycho - https://zenodo.org/records/11452259,258.0258381661512
+Oregon,1964,8520,Project Tycho - https://zenodo.org/records/11452259,450.8203660746034
+Oregon,1965,3520,Project Tycho - https://zenodo.org/records/11452259,181.54277317932454
+Oregon,1966,2499,Project Tycho - https://zenodo.org/records/11452259,126.79042643491603
+Oregon,1967,1730,Project Tycho - https://zenodo.org/records/11452259,87.33055726486752
+Oregon,1968,605,Project Tycho - https://zenodo.org/records/11452259,30.159461297185846
+Oregon,1969,198,Project Tycho - https://zenodo.org/records/11452259,9.592735101949456
+Oregon,1970,455,Project Tycho - https://zenodo.org/records/11452259,21.73265113506532
+Oregon,1971,350,Project Tycho - https://zenodo.org/records/11452259,16.255080293130185
+Oregon,1972,201,Project Tycho - https://zenodo.org/records/11452259,9.138465483424824
+Oregon,1973,438,Project Tycho - https://zenodo.org/records/11452259,19.517211908351094
+Oregon,1974,24,Project Tycho - https://zenodo.org/records/11452259,1.0492729849805316
+Oregon,1975,199,Project Tycho - https://zenodo.org/records/11452259,8.533484277376832
+Oregon,1976,175,Project Tycho - https://zenodo.org/records/11452259,7.350964446535385
+Oregon,1977,359,Project Tycho - https://zenodo.org/records/11452259,14.658332241103842
+Oregon,1978,532,Project Tycho - https://zenodo.org/records/11452259,21.104277345113648
+Oregon,1979,72,Project Tycho - https://zenodo.org/records/11452259,2.779278931521655
+Oregon,1980,2,Project Tycho - https://zenodo.org/records/11452259,0.07564699932938936
+Oregon,1981,5,Project Tycho - https://zenodo.org/records/11452259,0.18722040972063345
+Oregon,1982,12,Project Tycho - https://zenodo.org/records/11452259,0.44984491596522097
+Oregon,1983,10,Project Tycho - https://zenodo.org/records/11452259,0.3765458619680772
+Oregon,1984,0,https://stacks.cdc.gov/view/cdc/35267,0.0
+Oregon,1985,5,Project Tycho - https://zenodo.org/records/11452259,0.1868932510604323
+Oregon,1986,10,Project Tycho - https://zenodo.org/records/11452259,0.3722715750922023
+Oregon,1987,101,Project Tycho - https://zenodo.org/records/11452259,3.735633990718614
+Oregon,1988,34,Project Tycho - https://zenodo.org/records/11452259,1.2390498965393335
+Oregon,1989,57,Project Tycho - https://zenodo.org/records/11452259,2.040549659639897
+Oregon,1990,11,Project Tycho - https://zenodo.org/records/11452259,0.38442653172130475
+Oregon,1991,75,Project Tycho - https://zenodo.org/records/11452259,2.5670311736843026
+Oregon,1992,9,Project Tycho - https://zenodo.org/records/11452259,0.30232721411854657
+Oregon,1993,4,https://stacks.cdc.gov/view/cdc/5650,0.13168620231478007
+Oregon,1994,2,https://stacks.cdc.gov/view/cdc/5648,0.06472012268346455
+Oregon,1995,3,Project Tycho - https://zenodo.org/records/11452259,0.09540279377541293
+Oregon,1996,1,Project Tycho - https://zenodo.org/records/11452259,0.031266786355924836
+Oregon,1997,0,"https://www.cdc.gov/mmwr/preview/mmwrhtml/00056071.htm#:~:text=As%20of%20January%201%2C%201997,and%20control%20of%20the%20disease.",0.0
+Oregon,1998,0,https://stacks.cdc.gov/view/cdc/5637,0.0
+Oregon,1999,12,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.3615034930275014
+Oregon,2000,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4953a1.htm,0.0
+Oregon,2001,7,Project Tycho - https://zenodo.org/records/11452259,0.2016475178342826
+Oregon,2002,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.0
+Oregon,2003,3,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.08448507613372636
+Oregon,2004,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0
+Oregon,2005,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.05529727121790858
+Oregon,2006,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.0544283889768361
+Oregon,2007,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.026837431453845387
+Oregon,2008,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.02650750851686249
+Oregon,2009,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.0
+Oregon,2010,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.0
+Oregon,2011,3,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.07738851925839098
+Oregon,2012,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.025614740976054828
+Oregon,2013,6,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.1527481686767477
+Oregon,2014,6,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.15115588908382402
+Oregon,2015,0,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.0
+Oregon,2016,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Oregon,2017,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Oregon,2018,5,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.11939668378098732
+Oregon,2019,25,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.5923704580587499
+Oregon,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Oregon,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Oregon,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Pennsylvania,1888,24,Project Tycho - https://zenodo.org/records/11452259,
+Pennsylvania,1889,133,Project Tycho - https://zenodo.org/records/11452259,
+Pennsylvania,1890,182,Project Tycho - https://zenodo.org/records/11452259,
+Pennsylvania,1891,38,Project Tycho - https://zenodo.org/records/11452259,
+Pennsylvania,1892,94,Project Tycho - https://zenodo.org/records/11452259,
+Pennsylvania,1893,235,Project Tycho - https://zenodo.org/records/11452259,
+Pennsylvania,1894,132,Project Tycho - https://zenodo.org/records/11452259,
+Pennsylvania,1895,101,Project Tycho - https://zenodo.org/records/11452259,
+Pennsylvania,1896,186,Project Tycho - https://zenodo.org/records/11452259,
+Pennsylvania,1897,123,Project Tycho - https://zenodo.org/records/11452259,
+Pennsylvania,1898,301,Project Tycho - https://zenodo.org/records/11452259,
+Pennsylvania,1899,76,Project Tycho - https://zenodo.org/records/11452259,
+Pennsylvania,1900,498,Project Tycho - https://zenodo.org/records/11452259,7.880603476991881
+Pennsylvania,1901,140,Project Tycho - https://zenodo.org/records/11452259,2.17207858145892
+Pennsylvania,1902,262,Project Tycho - https://zenodo.org/records/11452259,3.9856595361392078
+Pennsylvania,1903,197,Project Tycho - https://zenodo.org/records/11452259,2.9377996238721718
+Pennsylvania,1904,292,Project Tycho - https://zenodo.org/records/11452259,4.269110079149593
+Pennsylvania,1905,88,Project Tycho - https://zenodo.org/records/11452259,1.2612925094991092
+Pennsylvania,1906,569,Project Tycho - https://zenodo.org/records/11452259,7.9948181214003995
+Pennsylvania,1907,5077,Project Tycho - https://zenodo.org/records/11452259,69.9286925676006
+Pennsylvania,1908,13641,Project Tycho - https://zenodo.org/records/11452259,184.20346887500173
+Pennsylvania,1909,11139,Project Tycho - https://zenodo.org/records/11452259,147.46716310458692
+Pennsylvania,1910,12748,Project Tycho - https://zenodo.org/records/11452259,165.26427115578426
+Pennsylvania,1911,15565,Project Tycho - https://zenodo.org/records/11452259,198.0821726044656
+Pennsylvania,1912,13507,Project Tycho - https://zenodo.org/records/11452259,168.9645190772163
+Pennsylvania,1913,22090,Project Tycho - https://zenodo.org/records/11452259,271.1381259114396
+Pennsylvania,1914,11391,Project Tycho - https://zenodo.org/records/11452259,137.50145456283687
+Pennsylvania,1915,21060,Project Tycho - https://zenodo.org/records/11452259,251.60202151352593
+Pennsylvania,1916,27856,Project Tycho - https://zenodo.org/records/11452259,328.821597875125
+Pennsylvania,1917,10596,Project Tycho - https://zenodo.org/records/11452259,123.40189537671468
+Pennsylvania,1918,27884,Project Tycho - https://zenodo.org/records/11452259,326.7966196168918
+Pennsylvania,1919,16192,Project Tycho - https://zenodo.org/records/11452259,187.1552027747793
+Pennsylvania,1920,24626,Project Tycho - https://zenodo.org/records/11452259,281.4805331967803
+Pennsylvania,1921,8033,Project Tycho - https://zenodo.org/records/11452259,90.16825870758456
+Pennsylvania,1922,36150,Project Tycho - https://zenodo.org/records/11452259,402.06954034609345
+Pennsylvania,1923,38178,Project Tycho - https://zenodo.org/records/11452259,416.9202026657208
+Pennsylvania,1924,5067,Project Tycho - https://zenodo.org/records/11452259,53.947970392604304
+Pennsylvania,1925,16686,Project Tycho - https://zenodo.org/records/11452259,175.87392561015687
+Pennsylvania,1926,15518,Project Tycho - https://zenodo.org/records/11452259,161.58533982173756
+Pennsylvania,1927,8831,Project Tycho - https://zenodo.org/records/11452259,90.53030089459027
+Pennsylvania,1928,76976,Project Tycho - https://zenodo.org/records/11452259,784.5245959916435
+Pennsylvania,1929,52473,Project Tycho - https://zenodo.org/records/11452259,539.1399714139609
+Pennsylvania,1930,44485,Project Tycho - https://zenodo.org/records/11452259,460.57165965964805
+Pennsylvania,1931,100196,Project Tycho - https://zenodo.org/records/11452259,1031.1723920459883
+Pennsylvania,1932,51772,Project Tycho - https://zenodo.org/records/11452259,529.7038070491573
+Pennsylvania,1933,42372,Project Tycho - https://zenodo.org/records/11452259,432.6417654299911
+Pennsylvania,1934,107031,Project Tycho - https://zenodo.org/records/11452259,1091.6189476679522
+Pennsylvania,1935,104244,Project Tycho - https://zenodo.org/records/11452259,1065.4784135447119
+Pennsylvania,1936,35717,Project Tycho - https://zenodo.org/records/11452259,365.325265499321
+Pennsylvania,1937,48561,Project Tycho - https://zenodo.org/records/11452259,495.5310266852657
+Pennsylvania,1938,146467,Project Tycho - https://zenodo.org/records/11452259,1470.2640606981445
+Pennsylvania,1939,5621,Project Tycho - https://zenodo.org/records/11452259,56.715327900056714
+Pennsylvania,1940,23445,Project Tycho - https://zenodo.org/records/11452259,236.67722738054184
+Pennsylvania,1941,137180,Project Tycho - https://zenodo.org/records/11452259,1382.7359201186262
+Pennsylvania,1942,40183,Project Tycho - https://zenodo.org/records/11452259,413.67330114238604
+Pennsylvania,1943,76590,Project Tycho - https://zenodo.org/records/11452259,810.1809245392474
+Pennsylvania,1944,26752,Project Tycho - https://zenodo.org/records/11452259,290.050735025773
+Pennsylvania,1945,16278,Project Tycho - https://zenodo.org/records/11452259,177.85998317552512
+Pennsylvania,1946,83276,Project Tycho - https://zenodo.org/records/11452259,843.2273179891262
+Pennsylvania,1947,13433,Project Tycho - https://zenodo.org/records/11452259,131.6161280853317
+Pennsylvania,1948,45357,Project Tycho - https://zenodo.org/records/11452259,440.47524362484995
+Pennsylvania,1949,50284,Project Tycho - https://zenodo.org/records/11452259,483.4818694298964
+Pennsylvania,1950,18594,Project Tycho - https://zenodo.org/records/11452259,176.79094485033383
+Pennsylvania,1951,32497,Project Tycho - https://zenodo.org/records/11452259,310.33873878726183
+Pennsylvania,1952,49439,Project Tycho - https://zenodo.org/records/11452259,470.2428866953288
+Pennsylvania,1953,18030,Project Tycho - https://zenodo.org/records/11452259,168.93629724243118
+Pennsylvania,1954,38057,Project Tycho - https://zenodo.org/records/11452259,351.4743553571324
+Pennsylvania,1955,18647,Project Tycho - https://zenodo.org/records/11452259,170.29318610816006
+Pennsylvania,1956,43979,Project Tycho - https://zenodo.org/records/11452259,400.4289549313246
+Pennsylvania,1957,12511,Project Tycho - https://zenodo.org/records/11452259,114.09988587275423
+Pennsylvania,1958,33968,Project Tycho - https://zenodo.org/records/11452259,306.8734484903774
+Pennsylvania,1959,27808,Project Tycho - https://zenodo.org/records/11452259,247.2869839791684
+Pennsylvania,1960,6767,Project Tycho - https://zenodo.org/records/11452259,59.671990115983405
+Pennsylvania,1961,25846,Project Tycho - https://zenodo.org/records/11452259,226.65185937657847
+Pennsylvania,1962,9436,Project Tycho - https://zenodo.org/records/11452259,83.01693902750706
+Pennsylvania,1963,12184,Project Tycho - https://zenodo.org/records/11452259,106.54611494947629
+Pennsylvania,1964,11587,Project Tycho - https://zenodo.org/records/11452259,100.48983918243403
+Pennsylvania,1965,6644,Project Tycho - https://zenodo.org/records/11452259,57.12016039038414
+Pennsylvania,1966,5499,Project Tycho - https://zenodo.org/records/11452259,47.09796376463043
+Pennsylvania,1967,792,Project Tycho - https://zenodo.org/records/11452259,6.773467949737105
+Pennsylvania,1968,304,Project Tycho - https://zenodo.org/records/11452259,2.586630642162539
+Pennsylvania,1969,1242,Project Tycho - https://zenodo.org/records/11452259,10.567747557782479
+Pennsylvania,1970,2098,Project Tycho - https://zenodo.org/records/11452259,17.76074732619483
+Pennsylvania,1971,1854,Project Tycho - https://zenodo.org/records/11452259,15.582076275524054
+Pennsylvania,1972,57,Project Tycho - https://zenodo.org/records/11452259,0.47818226311249173
+Pennsylvania,1973,418,Project Tycho - https://zenodo.org/records/11452259,3.5118917443406663
+Pennsylvania,1974,906,Project Tycho - https://zenodo.org/records/11452259,7.6244951296643855
+Pennsylvania,1975,563,Project Tycho - https://zenodo.org/records/11452259,4.7239465745975355
+Pennsylvania,1976,3383,Project Tycho - https://zenodo.org/records/11452259,28.406431121961663
+Pennsylvania,1977,3444,Project Tycho - https://zenodo.org/records/11452259,28.92784535261229
+Pennsylvania,1978,294,Project Tycho - https://zenodo.org/records/11452259,2.472400983073724
+Pennsylvania,1979,43,Project Tycho - https://zenodo.org/records/11452259,0.36134872824575615
+Pennsylvania,1980,1127,Project Tycho - https://zenodo.org/records/11452259,9.486393842917945
+Pennsylvania,1981,484,Project Tycho - https://zenodo.org/records/11452259,4.077360330400976
+Pennsylvania,1982,7,Project Tycho - https://zenodo.org/records/11452259,0.059036900677414704
+Pennsylvania,1983,3,https://stacks.cdc.gov/view/cdc/35188,0.02531739575140343
+Pennsylvania,1984,8,Project Tycho - https://zenodo.org/records/11452259,0.06764191082648523
+Pennsylvania,1985,35,Project Tycho - https://zenodo.org/records/11452259,0.29704738296163374
+Pennsylvania,1986,27,Project Tycho - https://zenodo.org/records/11452259,0.2289195995365311
+Pennsylvania,1987,37,Project Tycho - https://zenodo.org/records/11452259,0.31295791240494114
+Pennsylvania,1988,510,Project Tycho - https://zenodo.org/records/11452259,4.301040084259905
+Pennsylvania,1989,220,Project Tycho - https://zenodo.org/records/11452259,1.8521853387575424
+Pennsylvania,1990,434,Project Tycho - https://zenodo.org/records/11452259,3.6447620108975025
+Pennsylvania,1991,1402,Project Tycho - https://zenodo.org/records/11452259,11.727209711200313
+Pennsylvania,1992,7,Project Tycho - https://zenodo.org/records/11452259,0.058368359212891005
+Pennsylvania,1993,0,https://stacks.cdc.gov/view/cdc/5650,0.0
+Pennsylvania,1994,7,Project Tycho - https://zenodo.org/records/11452259,0.05806918146594321
+Pennsylvania,1995,1,Project Tycho - https://zenodo.org/records/11452259,0.008294058203055796
+Pennsylvania,1996,13,Project Tycho - https://zenodo.org/records/11452259,0.1078834055903189
+Pennsylvania,1997,9,Project Tycho - https://zenodo.org/records/11452259,0.07482601081834464
+Pennsylvania,1998,3,Project Tycho - https://zenodo.org/records/11452259,0.024970179363295385
+Pennsylvania,1999,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.0
+Pennsylvania,2000,1,Project Tycho - https://zenodo.org/records/11452259,0.008132423835581257
+Pennsylvania,2001,2,Project Tycho - https://zenodo.org/records/11452259,0.016245280339929242
+Pennsylvania,2002,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.008101520477160113
+Pennsylvania,2003,9,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.07265662993362737
+Pennsylvania,2004,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0
+Pennsylvania,2005,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.0
+Pennsylvania,2006,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.015970207258954275
+Pennsylvania,2007,3,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.0238540134377609
+Pennsylvania,2008,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.007920856700850708
+Pennsylvania,2009,14,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.11041423952507996
+Pennsylvania,2010,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.01571818303776993
+Pennsylvania,2011,13,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.10188248263158378
+Pennsylvania,2012,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.015647135807437585
+Pennsylvania,2013,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.0
+Pennsylvania,2014,3,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.023428011655279614
+Pennsylvania,2015,1,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.007810896935449264
+Pennsylvania,2016,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Pennsylvania,2017,4,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.03123176601660609
+Pennsylvania,2018,2,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.01559829279804984
+Pennsylvania,2019,17,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.13269140872302393
+Pennsylvania,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Pennsylvania,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Pennsylvania,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Puerto Rico,1954,4257,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1955,3574,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1956,2194,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1957,2427,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1958,2985,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1959,2055,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1960,1065,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1961,1720,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1962,3668,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1963,1395,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1964,6494,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1965,2987,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1966,4370,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1967,2245,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1968,512,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1969,1922,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1970,776,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1971,423,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1972,1050,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1973,1942,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1974,607,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1975,690,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1976,493,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1977,916,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1978,265,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1979,375,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1980,134,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1981,268,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1982,124,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1983,63,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1984,115,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1985,56,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1986,26,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1987,699,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1988,223,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1989,494,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1990,658,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1991,79,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1992,229,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1993,134,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1994,13,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1995,11,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1996,7,Project Tycho - https://zenodo.org/records/11452259,
+Puerto Rico,1998,635,Project Tycho - https://zenodo.org/records/11452259,
+Rhode Island,1895,1,Project Tycho - https://zenodo.org/records/11452259,
+Rhode Island,1896,2,Project Tycho - https://zenodo.org/records/11452259,
+Rhode Island,1897,3,Project Tycho - https://zenodo.org/records/11452259,
+Rhode Island,1906,2,Project Tycho - https://zenodo.org/records/11452259,0.4060979670735768
+Rhode Island,1907,3,Project Tycho - https://zenodo.org/records/11452259,0.5934659400005935
+Rhode Island,1908,6,Project Tycho - https://zenodo.org/records/11452259,1.1549144497121377
+Rhode Island,1909,1,Project Tycho - https://zenodo.org/records/11452259,0.18778214266936072
+Rhode Island,1914,138,Project Tycho - https://zenodo.org/records/11452259,23.40613546046483
+Rhode Island,1915,2,Project Tycho - https://zenodo.org/records/11452259,0.33467370150787235
+Rhode Island,1916,131,Project Tycho - https://zenodo.org/records/11452259,21.884470045005163
+Rhode Island,1917,51,Project Tycho - https://zenodo.org/records/11452259,8.407434150008408
+Rhode Island,1918,74,Project Tycho - https://zenodo.org/records/11452259,12.239416212926146
+Rhode Island,1919,218,https://www.jstor.org/stable/4575902,36.116454026901785
+Rhode Island,1920,147,Project Tycho - https://zenodo.org/records/11452259,23.9564676758804
+Rhode Island,1921,6,Project Tycho - https://zenodo.org/records/11452259,0.9529421294127176
+Rhode Island,1922,3,Project Tycho - https://zenodo.org/records/11452259,0.46537313618058956
+Rhode Island,1923,95,Project Tycho - https://zenodo.org/records/11452259,14.467240076996175
+Rhode Island,1924,230,https://www.jstor.org/stable/4577735?seq=13,34.34532582514645
+Rhode Island,1925,2350,https://www.jstor.org/stable/4578131,345.24299230181583
+Rhode Island,1927,30,Project Tycho - https://zenodo.org/records/11452259,4.426887735602654
+Rhode Island,1928,5037,Project Tycho - https://zenodo.org/records/11452259,742.1781758064944
+Rhode Island,1929,1804,Project Tycho - https://zenodo.org/records/11452259,263.4792108476319
+Rhode Island,1930,268,Project Tycho - https://zenodo.org/records/11452259,39.02802736621978
+Rhode Island,1931,4529,Project Tycho - https://zenodo.org/records/11452259,664.3870079993428
+Rhode Island,1932,9970,Project Tycho - https://zenodo.org/records/11452259,1471.2023574652821
+Rhode Island,1933,65,Project Tycho - https://zenodo.org/records/11452259,9.62000962000962
+Rhode Island,1934,453,Project Tycho - https://zenodo.org/records/11452259,67.04406704406705
+Rhode Island,1935,6864,Project Tycho - https://zenodo.org/records/11452259,1011.3780025284451
+Rhode Island,1936,2442,Project Tycho - https://zenodo.org/records/11452259,355.6210553295101
+Rhode Island,1937,4714,Project Tycho - https://zenodo.org/records/11452259,678.5721483127824
+Rhode Island,1938,76,Project Tycho - https://zenodo.org/records/11452259,10.940068576956186
+Rhode Island,1939,1830,Project Tycho - https://zenodo.org/records/11452259,260.7948399674505
+Rhode Island,1940,3799,Project Tycho - https://zenodo.org/records/11452259,527.8448950215293
+Rhode Island,1941,278,Project Tycho - https://zenodo.org/records/11452259,37.99210365557835
+Rhode Island,1942,4734,Project Tycho - https://zenodo.org/records/11452259,632.2554450896697
+Rhode Island,1943,1874,Project Tycho - https://zenodo.org/records/11452259,246.3326147536674
+Rhode Island,1944,4293,Project Tycho - https://zenodo.org/records/11452259,539.4605394605395
+Rhode Island,1945,199,Project Tycho - https://zenodo.org/records/11452259,25.618711185721494
+Rhode Island,1946,1247,Project Tycho - https://zenodo.org/records/11452259,161.7862656823696
+Rhode Island,1947,4033,Project Tycho - https://zenodo.org/records/11452259,519.197297547813
+Rhode Island,1948,381,Project Tycho - https://zenodo.org/records/11452259,48.363326635245315
+Rhode Island,1949,4499,Project Tycho - https://zenodo.org/records/11452259,561.1117970668532
+Rhode Island,1950,265,Project Tycho - https://zenodo.org/records/11452259,33.68133139125506
+Rhode Island,1951,1066,Project Tycho - https://zenodo.org/records/11452259,135.83355420090115
+Rhode Island,1952,4973,Project Tycho - https://zenodo.org/records/11452259,619.4553576099711
+Rhode Island,1953,130,Project Tycho - https://zenodo.org/records/11452259,15.934985260138633
+Rhode Island,1954,1825,Project Tycho - https://zenodo.org/records/11452259,223.42853225206164
+Rhode Island,1955,5409,Project Tycho - https://zenodo.org/records/11452259,656.5730745560636
+Rhode Island,1956,193,Project Tycho - https://zenodo.org/records/11452259,22.953237238951527
+Rhode Island,1957,621,Project Tycho - https://zenodo.org/records/11452259,72.9000729000729
+Rhode Island,1958,4255,Project Tycho - https://zenodo.org/records/11452259,495.42532060014577
+Rhode Island,1959,308,Project Tycho - https://zenodo.org/records/11452259,35.90341980073602
+Rhode Island,1960,1948,Project Tycho - https://zenodo.org/records/11452259,227.60864866128023
+Rhode Island,1961,6681,Project Tycho - https://zenodo.org/records/11452259,777.8934352360925
+Rhode Island,1962,3224,Project Tycho - https://zenodo.org/records/11452259,369.7794742570862
+Rhode Island,1963,1198,Project Tycho - https://zenodo.org/records/11452259,136.62136949808183
+Rhode Island,1964,2466,Project Tycho - https://zenodo.org/records/11452259,278.36570209451565
+Rhode Island,1965,3972,Project Tycho - https://zenodo.org/records/11452259,444.34848466203454
+Rhode Island,1966,88,Project Tycho - https://zenodo.org/records/11452259,9.778875184881858
+Rhode Island,1967,61,Project Tycho - https://zenodo.org/records/11452259,6.703967100006704
+Rhode Island,1968,67,Project Tycho - https://zenodo.org/records/11452259,7.259551728098367
+Rhode Island,1969,18,Project Tycho - https://zenodo.org/records/11452259,1.9294010710319724
+Rhode Island,1970,110,Project Tycho - https://zenodo.org/records/11452259,11.570762576367033
+Rhode Island,1971,227,Project Tycho - https://zenodo.org/records/11452259,23.546008069953427
+Rhode Island,1972,512,Project Tycho - https://zenodo.org/records/11452259,52.47170422356225
+Rhode Island,1973,654,Project Tycho - https://zenodo.org/records/11452259,66.95928077132177
+Rhode Island,1974,50,Project Tycho - https://zenodo.org/records/11452259,5.254501794412363
+Rhode Island,1975,5,Project Tycho - https://zenodo.org/records/11452259,0.5298125523189895
+Rhode Island,1976,16,Project Tycho - https://zenodo.org/records/11452259,1.6894834932183078
+Rhode Island,1977,65,Project Tycho - https://zenodo.org/records/11452259,6.8336171912782016
+Rhode Island,1978,8,Project Tycho - https://zenodo.org/records/11452259,0.8396596439633194
+Rhode Island,1979,103,Project Tycho - https://zenodo.org/records/11452259,10.826924774947127
+Rhode Island,1980,2,Project Tycho - https://zenodo.org/records/11452259,0.21058816220763782
+Rhode Island,1981,0,https://stacks.cdc.gov/view/cdc/1307,0.0
+Rhode Island,1982,0,https://stacks.cdc.gov/view/cdc/35066,0.0
+Rhode Island,1983,0,https://stacks.cdc.gov/view/cdc/35188,0.0
+Rhode Island,1984,0,https://stacks.cdc.gov/view/cdc/35267,0.0
+Rhode Island,1985,0,https://stacks.cdc.gov/view/cdc/35429,0.0
+Rhode Island,1986,2,Project Tycho - https://zenodo.org/records/11452259,0.20443250558611822
+Rhode Island,1987,2,Project Tycho - https://zenodo.org/records/11452259,0.20189926639901554
+Rhode Island,1988,0,https://stacks.cdc.gov/view/cdc/35958,0.0
+Rhode Island,1989,38,Project Tycho - https://zenodo.org/records/11452259,3.793679729570535
+Rhode Island,1990,30,Project Tycho - https://zenodo.org/records/11452259,2.9831363303246747
+Rhode Island,1991,4,Project Tycho - https://zenodo.org/records/11452259,0.398012722476674
+Rhode Island,1992,11,Project Tycho - https://zenodo.org/records/11452259,1.0982746105867682
+Rhode Island,1993,1,Project Tycho - https://zenodo.org/records/11452259,0.1001152326327603
+Rhode Island,1994,5,Project Tycho - https://zenodo.org/records/11452259,0.5028132400782377
+Rhode Island,1995,5,Project Tycho - https://zenodo.org/records/11452259,0.5049525748541698
+Rhode Island,1996,1,https://stacks.cdc.gov/view/cdc/5642,0.10112808377450459
+Rhode Island,1997,0,"https://www.cdc.gov/mmwr/preview/mmwrhtml/00056071.htm#:~:text=As%20of%20January%201%2C%201997,and%20control%20of%20the%20disease.",0.0
+Rhode Island,1998,0,https://stacks.cdc.gov/view/cdc/5637,0.0
+Rhode Island,1999,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.0
+Rhode Island,2000,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4953a1.htm,0.0
+Rhode Island,2001,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5053a1.htm,0.0
+Rhode Island,2002,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.0
+Rhode Island,2003,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.0
+Rhode Island,2004,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0
+Rhode Island,2005,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.0
+Rhode Island,2006,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.0
+Rhode Island,2007,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.0
+Rhode Island,2008,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.0
+Rhode Island,2009,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.0
+Rhode Island,2010,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.0
+Rhode Island,2011,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.09479733278224485
+Rhode Island,2012,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.0
+Rhode Island,2013,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.09464185157318418
+Rhode Island,2014,0,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.0
+Rhode Island,2015,0,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.0
+Rhode Island,2016,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Rhode Island,2017,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Rhode Island,2018,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Rhode Island,2019,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Rhode Island,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Rhode Island,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Rhode Island,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+South Carolina,1888,1,Project Tycho - https://zenodo.org/records/11452259,
+South Carolina,1889,9,Project Tycho - https://zenodo.org/records/11452259,
+South Carolina,1890,4,Project Tycho - https://zenodo.org/records/11452259,
+South Carolina,1891,6,Project Tycho - https://zenodo.org/records/11452259,
+South Carolina,1896,13,Project Tycho - https://zenodo.org/records/11452259,
+South Carolina,1899,1,Project Tycho - https://zenodo.org/records/11452259,
+South Carolina,1903,1,Project Tycho - https://zenodo.org/records/11452259,0.07151045089484602
+South Carolina,1905,4,Project Tycho - https://zenodo.org/records/11452259,0.278855826657641
+South Carolina,1907,2,Project Tycho - https://zenodo.org/records/11452259,0.13610367833801076
+South Carolina,1908,43,Project Tycho - https://zenodo.org/records/11452259,2.892730165457438
+South Carolina,1909,60,Project Tycho - https://zenodo.org/records/11452259,3.990683085223698
+South Carolina,1912,1,Project Tycho - https://zenodo.org/records/11452259,0.06354968187029256
+South Carolina,1914,19,Project Tycho - https://zenodo.org/records/11452259,1.1702231184352023
+South Carolina,1915,2,Project Tycho - https://zenodo.org/records/11452259,0.12220195706434238
+South Carolina,1916,128,Project Tycho - https://zenodo.org/records/11452259,7.749825931644113
+South Carolina,1917,113,Project Tycho - https://zenodo.org/records/11452259,6.7395291275888285
+South Carolina,1918,347,Project Tycho - https://zenodo.org/records/11452259,19.85414356548377
+South Carolina,1919,109,Project Tycho - https://zenodo.org/records/11452259,6.454718962128565
+South Carolina,1920,157,Project Tycho - https://zenodo.org/records/11452259,9.308199219178448
+South Carolina,1921,602,Project Tycho - https://zenodo.org/records/11452259,35.522658086154834
+South Carolina,1922,7,Project Tycho - https://zenodo.org/records/11452259,0.4132982856387112
+South Carolina,1923,903,Project Tycho - https://zenodo.org/records/11452259,53.09581530888182
+South Carolina,1924,1434,Project Tycho - https://zenodo.org/records/11452259,83.77587324955746
+South Carolina,1925,15,Project Tycho - https://zenodo.org/records/11452259,0.8722360293955171
+South Carolina,1926,106,Project Tycho - https://zenodo.org/records/11452259,6.135232091199645
+South Carolina,1927,3098,Project Tycho - https://zenodo.org/records/11452259,178.27794325490177
+South Carolina,1928,21615,Project Tycho - https://zenodo.org/records/11452259,1241.7140076714545
+South Carolina,1929,219,Project Tycho - https://zenodo.org/records/11452259,12.580863644693432
+South Carolina,1930,282,Project Tycho - https://zenodo.org/records/11452259,16.144314138583482
+South Carolina,1931,3903,Project Tycho - https://zenodo.org/records/11452259,222.42446657734735
+South Carolina,1932,4258,Project Tycho - https://zenodo.org/records/11452259,243.3493280175202
+South Carolina,1933,6897,Project Tycho - https://zenodo.org/records/11452259,393.2711124491946
+South Carolina,1934,11377,Project Tycho - https://zenodo.org/records/11452259,645.774679865589
+South Carolina,1935,850,Project Tycho - https://zenodo.org/records/11452259,48.00174387511866
+South Carolina,1936,1122,Project Tycho - https://zenodo.org/records/11452259,62.93538017288719
+South Carolina,1937,1875,Project Tycho - https://zenodo.org/records/11452259,103.94710727674101
+South Carolina,1938,7647,Project Tycho - https://zenodo.org/records/11452259,416.5409290818233
+South Carolina,1939,677,Project Tycho - https://zenodo.org/records/11452259,36.1284015130169
+South Carolina,1940,716,Project Tycho - https://zenodo.org/records/11452259,37.606977670069156
+South Carolina,1941,10788,Project Tycho - https://zenodo.org/records/11452259,549.297797004219
+South Carolina,1942,4126,Project Tycho - https://zenodo.org/records/11452259,205.37509326746996
+South Carolina,1943,2984,Project Tycho - https://zenodo.org/records/11452259,151.55154961967366
+South Carolina,1944,7777,Project Tycho - https://zenodo.org/records/11452259,399.85747654301434
+South Carolina,1945,1269,Project Tycho - https://zenodo.org/records/11452259,65.5497553119063
+South Carolina,1946,7759,Project Tycho - https://zenodo.org/records/11452259,400.3744189694603
+South Carolina,1947,3415,Project Tycho - https://zenodo.org/records/11452259,171.26447849339417
+South Carolina,1948,2434,Project Tycho - https://zenodo.org/records/11452259,121.82206570984127
+South Carolina,1949,9193,Project Tycho - https://zenodo.org/records/11452259,452.62770743303025
+South Carolina,1950,1982,Project Tycho - https://zenodo.org/records/11452259,93.70657737908093
+South Carolina,1951,739,Project Tycho - https://zenodo.org/records/11452259,34.06837740017251
+South Carolina,1952,2487,Project Tycho - https://zenodo.org/records/11452259,114.07325456912233
+South Carolina,1953,2119,Project Tycho - https://zenodo.org/records/11452259,97.06020710147257
+South Carolina,1954,5546,Project Tycho - https://zenodo.org/records/11452259,254.61670682258918
+South Carolina,1955,1173,Project Tycho - https://zenodo.org/records/11452259,53.264916901280536
+South Carolina,1956,8646,Project Tycho - https://zenodo.org/records/11452259,387.49944537293123
+South Carolina,1957,5665,Project Tycho - https://zenodo.org/records/11452259,248.87162090328317
+South Carolina,1958,10788,Project Tycho - https://zenodo.org/records/11452259,467.7614052614053
+South Carolina,1959,1946,Project Tycho - https://zenodo.org/records/11452259,82.796249746846
+South Carolina,1960,1284,Project Tycho - https://zenodo.org/records/11452259,53.62530446142486
+South Carolina,1961,3298,Project Tycho - https://zenodo.org/records/11452259,136.7665128561766
+South Carolina,1962,925,Project Tycho - https://zenodo.org/records/11452259,38.13767742781362
+South Carolina,1963,2408,Project Tycho - https://zenodo.org/records/11452259,97.7883904713173
+South Carolina,1964,3948,Project Tycho - https://zenodo.org/records/11452259,159.35579571943208
+South Carolina,1965,1262,Project Tycho - https://zenodo.org/records/11452259,50.55089257174261
+South Carolina,1966,663,Project Tycho - https://zenodo.org/records/11452259,26.283240568954852
+South Carolina,1967,517,Project Tycho - https://zenodo.org/records/11452259,20.390190149368987
+South Carolina,1968,41,Project Tycho - https://zenodo.org/records/11452259,1.6005877670590452
+South Carolina,1969,133,Project Tycho - https://zenodo.org/records/11452259,5.169927348915675
+South Carolina,1970,638,Project Tycho - https://zenodo.org/records/11452259,24.601830175648583
+South Carolina,1971,892,Project Tycho - https://zenodo.org/records/11452259,33.47178594867935
+South Carolina,1972,210,Project Tycho - https://zenodo.org/records/11452259,7.715153590338571
+South Carolina,1973,83,Project Tycho - https://zenodo.org/records/11452259,2.9862764406894917
+South Carolina,1974,56,Project Tycho - https://zenodo.org/records/11452259,1.966573172500424
+South Carolina,1975,15,Project Tycho - https://zenodo.org/records/11452259,0.5163635612562093
+South Carolina,1976,5,Project Tycho - https://zenodo.org/records/11452259,0.16968709699314463
+South Carolina,1977,165,Project Tycho - https://zenodo.org/records/11452259,5.509785378832808
+South Carolina,1978,200,Project Tycho - https://zenodo.org/records/11452259,6.562954484598058
+South Carolina,1979,95,Project Tycho - https://zenodo.org/records/11452259,3.0710971931141473
+South Carolina,1980,160,Project Tycho - https://zenodo.org/records/11452259,5.0993805527473555
+South Carolina,1981,2,https://stacks.cdc.gov/view/cdc/1307,0.06284497966022233
+South Carolina,1982,0,https://stacks.cdc.gov/view/cdc/35066,0.0
+South Carolina,1983,4,Project Tycho - https://zenodo.org/records/11452259,0.12355975658727952
+South Carolina,1984,1,https://stacks.cdc.gov/view/cdc/35267,0.03053305523826622
+South Carolina,1985,1,Project Tycho - https://zenodo.org/records/11452259,0.03024335009218173
+South Carolina,1986,249,Project Tycho - https://zenodo.org/records/11452259,7.441499058605541
+South Carolina,1987,2,Project Tycho - https://zenodo.org/records/11452259,0.059103645926606274
+South Carolina,1988,0,https://stacks.cdc.gov/view/cdc/35958,0.0
+South Carolina,1989,18,Project Tycho - https://zenodo.org/records/11452259,0.5201964839919647
+South Carolina,1990,4,Project Tycho - https://zenodo.org/records/11452259,0.11420208572979273
+South Carolina,1991,13,Project Tycho - https://zenodo.org/records/11452259,0.36485810247404665
+South Carolina,1992,29,Project Tycho - https://zenodo.org/records/11452259,0.8046221938107351
+South Carolina,1993,0,https://stacks.cdc.gov/view/cdc/5650,0.0
+South Carolina,1994,0,https://stacks.cdc.gov/view/cdc/5648,0.0
+South Carolina,1995,0,https://stacks.cdc.gov/view/cdc/5644,0.0
+South Carolina,1996,0,https://stacks.cdc.gov/view/cdc/5642,0.0
+South Carolina,1997,1,Project Tycho - https://zenodo.org/records/11452259,0.02635840685571619
+South Carolina,1998,0,https://stacks.cdc.gov/view/cdc/5637,0.0
+South Carolina,1999,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.0
+South Carolina,2000,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4953a1.htm,0.0
+South Carolina,2001,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5053a1.htm,0.0
+South Carolina,2002,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.0
+South Carolina,2003,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.0
+South Carolina,2004,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0
+South Carolina,2005,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.0
+South Carolina,2006,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.0
+South Carolina,2007,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.0
+South Carolina,2008,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.0
+South Carolina,2009,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.0
+South Carolina,2010,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.0
+South Carolina,2011,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.0
+South Carolina,2012,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.0
+South Carolina,2013,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.0
+South Carolina,2014,0,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.0
+South Carolina,2015,0,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.0
+South Carolina,2016,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+South Carolina,2017,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+South Carolina,2018,6,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.11772108461144097
+South Carolina,2019,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.01936911312123767
+South Carolina,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+South Carolina,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+South Carolina,2022,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.018892085009848444
+South Dakota,1906,2,Project Tycho - https://zenodo.org/records/11452259,0.41886834339664525
+South Dakota,1907,5,Project Tycho - https://zenodo.org/records/11452259,1.0030130512058224
+South Dakota,1908,3,Project Tycho - https://zenodo.org/records/11452259,0.5686912707785573
+South Dakota,1918,6,Project Tycho - https://zenodo.org/records/11452259,1.05157999894842
+South Dakota,1919,36,Project Tycho - https://zenodo.org/records/11452259,5.934659400005935
+South Dakota,1920,615,Project Tycho - https://zenodo.org/records/11452259,95.99775224775225
+South Dakota,1921,34,Project Tycho - https://zenodo.org/records/11452259,5.209514411968399
+South Dakota,1922,52,Project Tycho - https://zenodo.org/records/11452259,7.870916961826053
+South Dakota,1923,271,Project Tycho - https://zenodo.org/records/11452259,40.467753472237774
+South Dakota,1924,619,Project Tycho - https://zenodo.org/records/11452259,91.88434151287049
+South Dakota,1925,9,Project Tycho - https://zenodo.org/records/11452259,1.3183297640775646
+South Dakota,1926,447,Project Tycho - https://zenodo.org/records/11452259,65.38117811909906
+South Dakota,1927,1452,Project Tycho - https://zenodo.org/records/11452259,212.69053527118044
+South Dakota,1928,1149,Project Tycho - https://zenodo.org/records/11452259,167.56965662075152
+South Dakota,1929,2449,Project Tycho - https://zenodo.org/records/11452259,354.57296326861547
+South Dakota,1930,3006,Project Tycho - https://zenodo.org/records/11452259,433.3329008653684
+South Dakota,1931,1904,Project Tycho - https://zenodo.org/records/11452259,274.0775075069023
+South Dakota,1932,1010,Project Tycho - https://zenodo.org/records/11452259,145.80794927615736
+South Dakota,1933,2818,Project Tycho - https://zenodo.org/records/11452259,407.9977993021471
+South Dakota,1934,10156,Project Tycho - https://zenodo.org/records/11452259,1487.661898219083
+South Dakota,1935,1349,Project Tycho - https://zenodo.org/records/11452259,199.94841953298925
+South Dakota,1936,232,Project Tycho - https://zenodo.org/records/11452259,34.8000348000348
+South Dakota,1937,68,Project Tycho - https://zenodo.org/records/11452259,10.355498160376209
+South Dakota,1938,1256,Project Tycho - https://zenodo.org/records/11452259,193.33517022268947
+South Dakota,1939,7902,Project Tycho - https://zenodo.org/records/11452259,1223.8923866830844
+South Dakota,1940,155,Project Tycho - https://zenodo.org/records/11452259,24.156810428261288
+South Dakota,1941,357,Project Tycho - https://zenodo.org/records/11452259,58.17999292713811
+South Dakota,1942,871,Project Tycho - https://zenodo.org/records/11452259,147.73002888452802
+South Dakota,1943,3221,Project Tycho - https://zenodo.org/records/11452259,548.1741427226947
+South Dakota,1944,1425,Project Tycho - https://zenodo.org/records/11452259,251.96042895157942
+South Dakota,1945,492,Project Tycho - https://zenodo.org/records/11452259,84.88920406018852
+South Dakota,1946,1150,Project Tycho - https://zenodo.org/records/11452259,195.38284844407292
+South Dakota,1947,1259,Project Tycho - https://zenodo.org/records/11452259,209.2749180935537
+South Dakota,1948,864,Project Tycho - https://zenodo.org/records/11452259,141.03543515308223
+South Dakota,1949,993,Project Tycho - https://zenodo.org/records/11452259,157.21204310744724
+South Dakota,1950,731,Project Tycho - https://zenodo.org/records/11452259,111.49156187324127
+South Dakota,1951,690,Project Tycho - https://zenodo.org/records/11452259,105.23827317720448
+South Dakota,1952,908,Project Tycho - https://zenodo.org/records/11452259,139.33838818631446
+South Dakota,1953,446,Project Tycho - https://zenodo.org/records/11452259,68.75840209173542
+South Dakota,1954,809,Project Tycho - https://zenodo.org/records/11452259,123.38806231936003
+South Dakota,1955,422,Project Tycho - https://zenodo.org/records/11452259,63.58648892585545
+South Dakota,1956,581,Project Tycho - https://zenodo.org/records/11452259,86.62978812232544
+South Dakota,1957,543,Project Tycho - https://zenodo.org/records/11452259,81.45008145008144
+South Dakota,1958,121,Project Tycho - https://zenodo.org/records/11452259,18.426695255963548
+South Dakota,1959,861,Project Tycho - https://zenodo.org/records/11452259,128.95650077059372
+South Dakota,1960,120,Project Tycho - https://zenodo.org/records/11452259,17.551994125932634
+South Dakota,1961,217,Project Tycho - https://zenodo.org/records/11452259,31.281849463667648
+South Dakota,1962,398,Project Tycho - https://zenodo.org/records/11452259,56.39750320601385
+South Dakota,1963,79,Project Tycho - https://zenodo.org/records/11452259,11.14704504535013
+South Dakota,1964,68,Project Tycho - https://zenodo.org/records/11452259,9.690737222834228
+South Dakota,1965,116,Project Tycho - https://zenodo.org/records/11452259,16.746259520825998
+South Dakota,1966,40,Project Tycho - https://zenodo.org/records/11452259,5.850664708644211
+South Dakota,1967,58,Project Tycho - https://zenodo.org/records/11452259,8.63518002117108
+South Dakota,1968,4,Project Tycho - https://zenodo.org/records/11452259,0.5973100143503731
+South Dakota,1969,3,Project Tycho - https://zenodo.org/records/11452259,0.44865314326392175
+South Dakota,1970,106,Project Tycho - https://zenodo.org/records/11452259,15.893888799756493
+South Dakota,1971,211,Project Tycho - https://zenodo.org/records/11452259,31.400304776417926
+South Dakota,1972,12,Project Tycho - https://zenodo.org/records/11452259,1.7701438684429076
+South Dakota,1973,3,Project Tycho - https://zenodo.org/records/11452259,0.4415706373189009
+South Dakota,1974,31,Project Tycho - https://zenodo.org/records/11452259,4.557054320087495
+South Dakota,1975,175,Project Tycho - https://zenodo.org/records/11452259,25.670250233599276
+South Dakota,1976,5,Project Tycho - https://zenodo.org/records/11452259,0.7277215329890725
+South Dakota,1977,60,Project Tycho - https://zenodo.org/records/11452259,8.70615002437722
+South Dakota,1978,0,https://stacks.cdc.gov/view/cdc/51063,0.0
+South Dakota,1979,2,Project Tycho - https://zenodo.org/records/11452259,0.2902660723952611
+South Dakota,1980,0,https://stacks.cdc.gov/view/cdc/1484,0.0
+South Dakota,1981,0,https://stacks.cdc.gov/view/cdc/1307,0.0
+South Dakota,1982,0,https://stacks.cdc.gov/view/cdc/35066,0.0
+South Dakota,1983,0,https://stacks.cdc.gov/view/cdc/35188,0.0
+South Dakota,1984,0,https://stacks.cdc.gov/view/cdc/35267,0.0
+South Dakota,1985,0,https://stacks.cdc.gov/view/cdc/35429,0.0
+South Dakota,1986,0,https://stacks.cdc.gov/view/cdc/35496,0.0
+South Dakota,1987,0,https://stacks.cdc.gov/view/cdc/35629,0.0
+South Dakota,1988,0,https://stacks.cdc.gov/view/cdc/35958,0.0
+South Dakota,1989,0,https://stacks.cdc.gov/view/cdc/35853,0.0
+South Dakota,1990,23,Project Tycho - https://zenodo.org/records/11452259,3.2981388459095196
+South Dakota,1991,0,https://stacks.cdc.gov/view/cdc/36010,0.0
+South Dakota,1992,0,https://stacks.cdc.gov/view/cdc/36063,0.0
+South Dakota,1993,0,https://stacks.cdc.gov/view/cdc/5650,0.0
+South Dakota,1994,0,https://stacks.cdc.gov/view/cdc/5648,0.0
+South Dakota,1995,0,https://stacks.cdc.gov/view/cdc/5644,0.0
+South Dakota,1996,0,https://stacks.cdc.gov/view/cdc/5642,0.0
+South Dakota,1997,8,Project Tycho - https://zenodo.org/records/11452259,1.0935161327801963
+South Dakota,1998,0,https://stacks.cdc.gov/view/cdc/5637,0.0
+South Dakota,1999,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.0
+South Dakota,2000,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4953a1.htm,0.0
+South Dakota,2001,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5053a1.htm,0.0
+South Dakota,2002,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.0
+South Dakota,2003,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.0
+South Dakota,2004,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0
+South Dakota,2005,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.0
+South Dakota,2006,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.0
+South Dakota,2007,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.0
+South Dakota,2008,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.0
+South Dakota,2009,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.0
+South Dakota,2010,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.0
+South Dakota,2011,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.0
+South Dakota,2012,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.0
+South Dakota,2013,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.0
+South Dakota,2014,8,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.9406021499813643
+South Dakota,2015,2,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.233776768901144
+South Dakota,2016,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+South Dakota,2017,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+South Dakota,2018,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+South Dakota,2019,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+South Dakota,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+South Dakota,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+South Dakota,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Tennessee,1889,1,Project Tycho - https://zenodo.org/records/11452259,
+Tennessee,1890,2,Project Tycho - https://zenodo.org/records/11452259,
+Tennessee,1891,24,Project Tycho - https://zenodo.org/records/11452259,
+Tennessee,1892,2,Project Tycho - https://zenodo.org/records/11452259,
+Tennessee,1894,21,Project Tycho - https://zenodo.org/records/11452259,
+Tennessee,1895,6,Project Tycho - https://zenodo.org/records/11452259,
+Tennessee,1896,57,Project Tycho - https://zenodo.org/records/11452259,
+Tennessee,1897,3,Project Tycho - https://zenodo.org/records/11452259,
+Tennessee,1898,3,Project Tycho - https://zenodo.org/records/11452259,
+Tennessee,1899,13,Project Tycho - https://zenodo.org/records/11452259,
+Tennessee,1900,7,Project Tycho - https://zenodo.org/records/11452259,0.3456750861595152
+Tennessee,1902,2,Project Tycho - https://zenodo.org/records/11452259,0.09699038825252417
+Tennessee,1903,15,Project Tycho - https://zenodo.org/records/11452259,0.7197413537471175
+Tennessee,1904,20,Project Tycho - https://zenodo.org/records/11452259,0.9578149558974104
+Tennessee,1906,5,Project Tycho - https://zenodo.org/records/11452259,0.23384854845529005
+Tennessee,1907,991,Project Tycho - https://zenodo.org/records/11452259,46.34878230383848
+Tennessee,1908,545,Project Tycho - https://zenodo.org/records/11452259,25.15968320034863
+Tennessee,1909,268,Project Tycho - https://zenodo.org/records/11452259,12.29822084208855
+Tennessee,1910,341,Project Tycho - https://zenodo.org/records/11452259,15.548121435843937
+Tennessee,1911,1255,Project Tycho - https://zenodo.org/records/11452259,57.06628373901929
+Tennessee,1912,103,Project Tycho - https://zenodo.org/records/11452259,4.639184080121861
+Tennessee,1913,968,Project Tycho - https://zenodo.org/records/11452259,42.84594448528875
+Tennessee,1914,324,Project Tycho - https://zenodo.org/records/11452259,14.14051217458819
+Tennessee,1915,51,Project Tycho - https://zenodo.org/records/11452259,2.2209699629054467
+Tennessee,1916,1237,Project Tycho - https://zenodo.org/records/11452259,53.63560051060051
+Tennessee,1917,2196,Project Tycho - https://zenodo.org/records/11452259,94.11437982866553
+Tennessee,1918,1340,Project Tycho - https://zenodo.org/records/11452259,58.50792564079277
+Tennessee,1919,1127,Project Tycho - https://zenodo.org/records/11452259,48.84486446308572
+Tennessee,1920,1151,Project Tycho - https://zenodo.org/records/11452259,49.37098110133748
+Tennessee,1921,415,Project Tycho - https://zenodo.org/records/11452259,17.500439619477188
+Tennessee,1922,430,Project Tycho - https://zenodo.org/records/11452259,17.721552375017723
+Tennessee,1923,5759,Project Tycho - https://zenodo.org/records/11452259,233.58695709487426
+Tennessee,1924,1044,Project Tycho - https://zenodo.org/records/11452259,41.68493377126471
+Tennessee,1925,540,Project Tycho - https://zenodo.org/records/11452259,21.314126410926097
+Tennessee,1926,3732,Project Tycho - https://zenodo.org/records/11452259,146.03492864362428
+Tennessee,1927,1426,Project Tycho - https://zenodo.org/records/11452259,54.62329081960984
+Tennessee,1928,10905,Project Tycho - https://zenodo.org/records/11452259,415.17171852537706
+Tennessee,1929,935,Project Tycho - https://zenodo.org/records/11452259,35.8704275754967
+Tennessee,1930,5170,Project Tycho - https://zenodo.org/records/11452259,197.2063827733931
+Tennessee,1931,6597,Project Tycho - https://zenodo.org/records/11452259,248.03950283814794
+Tennessee,1932,1943,Project Tycho - https://zenodo.org/records/11452259,71.59937075097532
+Tennessee,1933,5117,Project Tycho - https://zenodo.org/records/11452259,186.08984753870084
+Tennessee,1934,22216,Project Tycho - https://zenodo.org/records/11452259,797.1913144326938
+Tennessee,1935,1502,Project Tycho - https://zenodo.org/records/11452259,53.62757328447107
+Tennessee,1936,1953,Project Tycho - https://zenodo.org/records/11452259,69.90501436936407
+Tennessee,1937,4319,Project Tycho - https://zenodo.org/records/11452259,154.37156760949247
+Tennessee,1938,15192,Project Tycho - https://zenodo.org/records/11452259,537.9944408657631
+Tennessee,1939,2174,Project Tycho - https://zenodo.org/records/11452259,75.56813402324885
+Tennessee,1940,3618,Project Tycho - https://zenodo.org/records/11452259,123.14772110342808
+Tennessee,1941,12084,Project Tycho - https://zenodo.org/records/11452259,406.0520710369348
+Tennessee,1942,3436,Project Tycho - https://zenodo.org/records/11452259,116.7937200601372
+Tennessee,1943,9168,Project Tycho - https://zenodo.org/records/11452259,308.17096765952755
+Tennessee,1944,5916,Project Tycho - https://zenodo.org/records/11452259,206.07008054706802
+Tennessee,1945,2901,Project Tycho - https://zenodo.org/records/11452259,100.69846761994086
+Tennessee,1946,5871,Project Tycho - https://zenodo.org/records/11452259,190.79814135116672
+Tennessee,1947,2063,Project Tycho - https://zenodo.org/records/11452259,65.09599055398171
+Tennessee,1948,5852,Project Tycho - https://zenodo.org/records/11452259,181.78339073861463
+Tennessee,1949,8179,Project Tycho - https://zenodo.org/records/11452259,252.4978112122735
+Tennessee,1950,3628,Project Tycho - https://zenodo.org/records/11452259,109.33259802038083
+Tennessee,1951,2735,Project Tycho - https://zenodo.org/records/11452259,81.02810593913797
+Tennessee,1952,9920,Project Tycho - https://zenodo.org/records/11452259,295.6470736900331
+Tennessee,1953,3593,Project Tycho - https://zenodo.org/records/11452259,108.14735129287705
+Tennessee,1954,13987,Project Tycho - https://zenodo.org/records/11452259,415.9877038710025
+Tennessee,1955,5876,Project Tycho - https://zenodo.org/records/11452259,171.8925291399669
+Tennessee,1956,21735,Project Tycho - https://zenodo.org/records/11452259,635.8209872119096
+Tennessee,1957,15389,Project Tycho - https://zenodo.org/records/11452259,447.6885956210359
+Tennessee,1958,27150,Project Tycho - https://zenodo.org/records/11452259,781.4139188382921
+Tennessee,1959,9720,Project Tycho - https://zenodo.org/records/11452259,275.70385321663
+Tennessee,1960,19158,Project Tycho - https://zenodo.org/records/11452259,535.3527591289829
+Tennessee,1961,14891,Project Tycho - https://zenodo.org/records/11452259,410.7157337416863
+Tennessee,1962,24282,Project Tycho - https://zenodo.org/records/11452259,660.434039143541
+Tennessee,1963,6872,Project Tycho - https://zenodo.org/records/11452259,184.64590815317013
+Tennessee,1964,23588,Project Tycho - https://zenodo.org/records/11452259,624.8855890860664
+Tennessee,1965,9043,Project Tycho - https://zenodo.org/records/11452259,237.86113833507198
+Tennessee,1966,12718,Project Tycho - https://zenodo.org/records/11452259,332.42529317882537
+Tennessee,1967,2076,Project Tycho - https://zenodo.org/records/11452259,53.74257771251812
+Tennessee,1968,57,Project Tycho - https://zenodo.org/records/11452259,1.4683614477322575
+Tennessee,1969,19,Project Tycho - https://zenodo.org/records/11452259,0.4870674616633046
+Tennessee,1970,546,Project Tycho - https://zenodo.org/records/11452259,13.893327742074696
+Tennessee,1971,1012,Project Tycho - https://zenodo.org/records/11452259,25.18903599916468
+Tennessee,1972,195,Project Tycho - https://zenodo.org/records/11452259,4.757600266425615
+Tennessee,1973,165,Project Tycho - https://zenodo.org/records/11452259,3.974421107500142
+Tennessee,1974,56,Project Tycho - https://zenodo.org/records/11452259,1.3277309410150786
+Tennessee,1975,178,Project Tycho - https://zenodo.org/records/11452259,4.159033010805775
+Tennessee,1976,212,Project Tycho - https://zenodo.org/records/11452259,4.872136298472585
+Tennessee,1977,737,Project Tycho - https://zenodo.org/records/11452259,16.646553022885286
+Tennessee,1978,990,Project Tycho - https://zenodo.org/records/11452259,22.04506992072682
+Tennessee,1979,80,Project Tycho - https://zenodo.org/records/11452259,1.7524517347410196
+Tennessee,1980,179,Project Tycho - https://zenodo.org/records/11452259,3.8872041924474448
+Tennessee,1981,4,Project Tycho - https://zenodo.org/records/11452259,0.08635047282280775
+Tennessee,1982,6,Project Tycho - https://zenodo.org/records/11452259,0.12901319740502853
+Tennessee,1983,1,Project Tycho - https://zenodo.org/records/11452259,0.02143894787934503
+Tennessee,1984,2,https://stacks.cdc.gov/view/cdc/35267,0.04263098850817758
+Tennessee,1985,1,https://stacks.cdc.gov/view/cdc/35429,0.021186391302901626
+Tennessee,1986,58,Project Tycho - https://zenodo.org/records/11452259,1.2227397550219818
+Tennessee,1987,0,https://stacks.cdc.gov/view/cdc/35629,0.0
+Tennessee,1988,1,Project Tycho - https://zenodo.org/records/11452259,0.02071568979414612
+Tennessee,1989,138,Project Tycho - https://zenodo.org/records/11452259,2.8399163829837146
+Tennessee,1990,77,Project Tycho - https://zenodo.org/records/11452259,1.572867906059341
+Tennessee,1991,9,Project Tycho - https://zenodo.org/records/11452259,0.1817509156207238
+Tennessee,1992,1,Project Tycho - https://zenodo.org/records/11452259,0.019924240069559507
+Tennessee,1993,0,https://stacks.cdc.gov/view/cdc/5650,0.0
+Tennessee,1994,24,Project Tycho - https://zenodo.org/records/11452259,0.46438020045358336
+Tennessee,1995,0,https://stacks.cdc.gov/view/cdc/5644,0.0
+Tennessee,1996,1,Project Tycho - https://zenodo.org/records/11452259,0.018800918763298126
+Tennessee,1997,0,"https://www.cdc.gov/mmwr/preview/mmwrhtml/00056071.htm#:~:text=As%20of%20January%201%2C%201997,and%20control%20of%20the%20disease.",0.0
+Tennessee,1998,1,https://stacks.cdc.gov/view/cdc/5637,0.018388738295338217
+Tennessee,1999,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.0
+Tennessee,2000,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4953a1.htm,0.0
+Tennessee,2001,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5053a1.htm,0.0
+Tennessee,2002,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.0
+Tennessee,2003,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.0
+Tennessee,2004,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0
+Tennessee,2005,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.01667487070305257
+Tennessee,2006,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.0
+Tennessee,2007,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.0
+Tennessee,2008,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.0
+Tennessee,2009,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.015842023343221396
+Tennessee,2010,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.0
+Tennessee,2011,3,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.0468259936709987
+Tennessee,2012,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.0
+Tennessee,2013,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.0
+Tennessee,2014,4,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.061057879664383155
+Tennessee,2015,0,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.0
+Tennessee,2016,7,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.10513781464743988
+Tennessee,2017,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Tennessee,2018,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.014738484748173828
+Tennessee,2019,5,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.07312983251074459
+Tennessee,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Tennessee,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Tennessee,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Texas,1889,5,Project Tycho - https://zenodo.org/records/11452259,
+Texas,1890,4,Project Tycho - https://zenodo.org/records/11452259,
+Texas,1891,3,Project Tycho - https://zenodo.org/records/11452259,
+Texas,1895,31,Project Tycho - https://zenodo.org/records/11452259,
+Texas,1899,1,Project Tycho - https://zenodo.org/records/11452259,
+Texas,1900,1,Project Tycho - https://zenodo.org/records/11452259,0.032700523698887034
+Texas,1906,1,Project Tycho - https://zenodo.org/records/11452259,0.028172617005104317
+Texas,1907,114,Project Tycho - https://zenodo.org/records/11452259,3.1321813500031324
+Texas,1908,164,Project Tycho - https://zenodo.org/records/11452259,4.395926048729913
+Texas,1909,10,Project Tycho - https://zenodo.org/records/11452259,0.26145014367992647
+Texas,1910,49,Project Tycho - https://zenodo.org/records/11452259,1.2481144556616255
+Texas,1911,110,Project Tycho - https://zenodo.org/records/11452259,2.736307517184011
+Texas,1912,164,Project Tycho - https://zenodo.org/records/11452259,3.9891931783823678
+Texas,1913,41,Project Tycho - https://zenodo.org/records/11452259,0.9735926065852378
+Texas,1914,358,Project Tycho - https://zenodo.org/records/11452259,8.31726413121762
+Texas,1915,11,Project Tycho - https://zenodo.org/records/11452259,0.2515799219095922
+Texas,1916,35,Project Tycho - https://zenodo.org/records/11452259,0.7867919659098778
+Texas,1917,1428,Project Tycho - https://zenodo.org/records/11452259,31.26393658938038
+Texas,1918,1062,Project Tycho - https://zenodo.org/records/11452259,22.7376566853635
+Texas,1919,234,Project Tycho - https://zenodo.org/records/11452259,5.047856483831435
+Texas,1920,702,Project Tycho - https://zenodo.org/records/11452259,14.848585672214721
+Texas,1921,1927,Project Tycho - https://zenodo.org/records/11452259,39.667729756334744
+Texas,1922,1677,Project Tycho - https://zenodo.org/records/11452259,33.810790622092334
+Texas,1923,2704,Project Tycho - https://zenodo.org/records/11452259,53.20659250145167
+Texas,1924,4494,Project Tycho - https://zenodo.org/records/11452259,86.17102667006698
+Texas,1925,57,Project Tycho - https://zenodo.org/records/11452259,1.0679493050085698
+Texas,1926,102,Project Tycho - https://zenodo.org/records/11452259,1.8686613221731505
+Texas,1927,2050,Project Tycho - https://zenodo.org/records/11452259,36.721392288901704
+Texas,1928,7176,Project Tycho - https://zenodo.org/records/11452259,126.32301619085759
+Texas,1929,5182,Project Tycho - https://zenodo.org/records/11452259,89.84420647037794
+Texas,1930,7076,Project Tycho - https://zenodo.org/records/11452259,120.96049057034683
+Texas,1931,2942,Project Tycho - https://zenodo.org/records/11452259,49.755560166936505
+Texas,1932,4993,Project Tycho - https://zenodo.org/records/11452259,83.67743647059199
+Texas,1933,24553,Project Tycho - https://zenodo.org/records/11452259,407.85619435436524
+Texas,1934,29807,Project Tycho - https://zenodo.org/records/11452259,491.9415624850946
+Texas,1935,3949,Project Tycho - https://zenodo.org/records/11452259,64.43009872701201
+Texas,1936,9900,Project Tycho - https://zenodo.org/records/11452259,159.72399693329928
+Texas,1937,17185,Project Tycho - https://zenodo.org/records/11452259,274.68531468531467
+Texas,1938,5630,Project Tycho - https://zenodo.org/records/11452259,89.26163504801816
+Texas,1939,9465,Project Tycho - https://zenodo.org/records/11452259,148.6720826343468
+Texas,1940,23242,Project Tycho - https://zenodo.org/records/11452259,361.38180885262597
+Texas,1941,21854,Project Tycho - https://zenodo.org/records/11452259,331.54393063276893
+Texas,1942,39095,Project Tycho - https://zenodo.org/records/11452259,581.9690665466258
+Texas,1943,15325,Project Tycho - https://zenodo.org/records/11452259,218.33557201497877
+Texas,1944,43742,Project Tycho - https://zenodo.org/records/11452259,635.5192219066564
+Texas,1945,10984,Project Tycho - https://zenodo.org/records/11452259,160.75339837425977
+Texas,1946,32326,Project Tycho - https://zenodo.org/records/11452259,448.71066129923986
+Texas,1947,9732,Project Tycho - https://zenodo.org/records/11452259,131.59552953813917
+Texas,1948,47336,Project Tycho - https://zenodo.org/records/11452259,620.0984957869301
+Texas,1949,57133,Project Tycho - https://zenodo.org/records/11452259,748.7330982018113
+Texas,1950,15046,Project Tycho - https://zenodo.org/records/11452259,193.29949885505442
+Texas,1951,65137,Project Tycho - https://zenodo.org/records/11452259,802.2676374297629
+Texas,1952,19512,Project Tycho - https://zenodo.org/records/11452259,234.45402324401604
+Texas,1953,78974,Project Tycho - https://zenodo.org/records/11452259,946.4383984537535
+Texas,1954,75953,Project Tycho - https://zenodo.org/records/11452259,905.2388794693734
+Texas,1955,39466,Project Tycho - https://zenodo.org/records/11452259,455.2722104685153
+Texas,1956,67467,Project Tycho - https://zenodo.org/records/11452259,763.3023827814314
+Texas,1957,42381,Project Tycho - https://zenodo.org/records/11452259,466.7989122233885
+Texas,1958,81933,Project Tycho - https://zenodo.org/records/11452259,884.6860014175188
+Texas,1959,33917,Project Tycho - https://zenodo.org/records/11452259,360.26705883165215
+Texas,1960,49678,Project Tycho - https://zenodo.org/records/11452259,515.6730219074359
+Texas,1961,17044,Project Tycho - https://zenodo.org/records/11452259,173.39076402212856
+Texas,1962,66173,Project Tycho - https://zenodo.org/records/11452259,657.5837372614454
+Texas,1963,16506,Project Tycho - https://zenodo.org/records/11452259,162.31430740732839
+Texas,1964,39353,Project Tycho - https://zenodo.org/records/11452259,382.8012299287859
+Texas,1965,29509,Project Tycho - https://zenodo.org/records/11452259,284.0578192283723
+Texas,1966,25178,Project Tycho - https://zenodo.org/records/11452259,239.7335794209603
+Texas,1967,13329,Project Tycho - https://zenodo.org/records/11452259,125.63151538526574
+Texas,1968,5136,Project Tycho - https://zenodo.org/records/11452259,47.424615314438775
+Texas,1969,4921,Project Tycho - https://zenodo.org/records/11452259,44.50958728912554
+Texas,1970,8327,Project Tycho - https://zenodo.org/records/11452259,74.28286526148024
+Texas,1971,9093,Project Tycho - https://zenodo.org/records/11452259,78.92299492151835
+Texas,1972,1583,Project Tycho - https://zenodo.org/records/11452259,13.448411409588061
+Texas,1973,475,Project Tycho - https://zenodo.org/records/11452259,3.947949567977957
+Texas,1974,170,Project Tycho - https://zenodo.org/records/11452259,1.384263706470301
+Texas,1975,278,Project Tycho - https://zenodo.org/records/11452259,2.209609081207187
+Texas,1976,262,Project Tycho - https://zenodo.org/records/11452259,2.0283358518503496
+Texas,1977,2050,Project Tycho - https://zenodo.org/records/11452259,15.522961375161731
+Texas,1978,1067,Project Tycho - https://zenodo.org/records/11452259,7.8955572431970005
+Texas,1979,629,Project Tycho - https://zenodo.org/records/11452259,4.524444552500425
+Texas,1980,199,Project Tycho - https://zenodo.org/records/11452259,1.3865135844190988
+Texas,1981,924,Project Tycho - https://zenodo.org/records/11452259,6.25971135956053
+Texas,1982,174,Project Tycho - https://zenodo.org/records/11452259,1.1337908374843761
+Texas,1983,37,Project Tycho - https://zenodo.org/records/11452259,0.23466098812444164
+Texas,1984,540,Project Tycho - https://zenodo.org/records/11452259,3.370135840814255
+Texas,1985,412,Project Tycho - https://zenodo.org/records/11452259,2.5293133294935246
+Texas,1986,369,Project Tycho - https://zenodo.org/records/11452259,2.225885247833924
+Texas,1987,409,Project Tycho - https://zenodo.org/records/11452259,2.4581672818295397
+Texas,1988,14,Project Tycho - https://zenodo.org/records/11452259,0.08391429497397128
+Texas,1989,3129,Project Tycho - https://zenodo.org/records/11452259,18.59893823779429
+Texas,1990,4066,Project Tycho - https://zenodo.org/records/11452259,23.83107297618452
+Texas,1991,212,Project Tycho - https://zenodo.org/records/11452259,1.2213921300750354
+Texas,1992,887,Project Tycho - https://zenodo.org/records/11452259,5.02033916551096
+Texas,1993,9,Project Tycho - https://zenodo.org/records/11452259,0.04995903359245419
+Texas,1994,17,Project Tycho - https://zenodo.org/records/11452259,0.09260945497864889
+Texas,1995,8,Project Tycho - https://zenodo.org/records/11452259,0.04278444368323789
+Texas,1996,19,Project Tycho - https://zenodo.org/records/11452259,0.09986730263566632
+Texas,1997,4,Project Tycho - https://zenodo.org/records/11452259,0.020645393584299426
+Texas,1998,0,https://stacks.cdc.gov/view/cdc/5637,0.0
+Texas,1999,4,Project Tycho - https://zenodo.org/records/11452259,0.019936020326766325
+Texas,2000,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4953a1.htm,0.0
+Texas,2001,1,Project Tycho - https://zenodo.org/records/11452259,0.004685828989452714
+Texas,2002,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.004605744791535931
+Texas,2003,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.0
+Texas,2004,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0
+Texas,2005,3,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.013157374789706775
+Texas,2006,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.0
+Texas,2007,7,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.029342951785254527
+Texas,2008,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.0
+Texas,2009,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.0040279439416541045
+Texas,2010,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.0
+Texas,2011,6,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.023372541680935277
+Texas,2012,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.0
+Texas,2013,27,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.10186324858876956
+Texas,2014,10,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.0370506840389914
+Texas,2015,1,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.003636892771199184
+Texas,2016,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.003578844704551697
+Texas,2017,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.003531158857479427
+Texas,2018,9,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.03141011743614707
+Texas,2019,22,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.07582081198575395
+Texas,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Texas,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Texas,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Utah,1895,17,Project Tycho - https://zenodo.org/records/11452259,
+Utah,1897,1,Project Tycho - https://zenodo.org/records/11452259,
+Utah,1898,4,Project Tycho - https://zenodo.org/records/11452259,
+Utah,1899,1,Project Tycho - https://zenodo.org/records/11452259,
+Utah,1900,2,Project Tycho - https://zenodo.org/records/11452259,0.7213003602895299
+Utah,1902,4,Project Tycho - https://zenodo.org/records/11452259,1.3684945191794506
+Utah,1903,1,Project Tycho - https://zenodo.org/records/11452259,0.3341140464886284
+Utah,1910,85,Project Tycho - https://zenodo.org/records/11452259,22.523895202940295
+Utah,1911,548,Project Tycho - https://zenodo.org/records/11452259,141.46060657688565
+Utah,1915,53,Project Tycho - https://zenodo.org/records/11452259,12.313268127221615
+Utah,1916,4544,Project Tycho - https://zenodo.org/records/11452259,1041.1606741881972
+Utah,1917,1677,Project Tycho - https://zenodo.org/records/11452259,377.32537732537736
+Utah,1918,1189,Project Tycho - https://zenodo.org/records/11452259,271.81056929340684
+Utah,1919,45,Project Tycho - https://zenodo.org/records/11452259,10.079606492162547
+Utah,1920,2033,Project Tycho - https://zenodo.org/records/11452259,448.33753443024966
+Utah,1921,2072,Project Tycho - https://zenodo.org/records/11452259,452.93874615537635
+Utah,1922,32,Project Tycho - https://zenodo.org/records/11452259,6.84540299101327
+Utah,1923,284,Project Tycho - https://zenodo.org/records/11452259,59.855756058287696
+Utah,1924,4431,Project Tycho - https://zenodo.org/records/11452259,920.2855356701509
+Utah,1925,52,Project Tycho - https://zenodo.org/records/11452259,10.666951118696499
+Utah,1926,1982,Project Tycho - https://zenodo.org/records/11452259,400.81376113764776
+Utah,1927,1968,Project Tycho - https://zenodo.org/records/11452259,393.20679320679324
+Utah,1928,138,Project Tycho - https://zenodo.org/records/11452259,27.35359878217021
+Utah,1929,598,Project Tycho - https://zenodo.org/records/11452259,117.59893649657428
+Utah,1930,8700,Project Tycho - https://zenodo.org/records/11452259,1707.5262654830433
+Utah,1931,198,Project Tycho - https://zenodo.org/records/11452259,38.5579332947754
+Utah,1932,112,Project Tycho - https://zenodo.org/records/11452259,21.641801138899787
+Utah,1933,5026,Project Tycho - https://zenodo.org/records/11452259,965.5728886498117
+Utah,1934,17119,Project Tycho - https://zenodo.org/records/11452259,3276.2256900187936
+Utah,1935,425,Project Tycho - https://zenodo.org/records/11452259,80.71776132612635
+Utah,1936,1066,Project Tycho - https://zenodo.org/records/11452259,202.07496488331404
+Utah,1937,3002,Project Tycho - https://zenodo.org/records/11452259,566.9189034028353
+Utah,1938,10705,Project Tycho - https://zenodo.org/records/11452259,1998.9356437954568
+Utah,1939,3432,Project Tycho - https://zenodo.org/records/11452259,631.4127861089187
+Utah,1940,13312,Project Tycho - https://zenodo.org/records/11452259,2409.18501788067
+Utah,1941,1153,Project Tycho - https://zenodo.org/records/11452259,209.0468515150911
+Utah,1942,19567,Project Tycho - https://zenodo.org/records/11452259,3399.5569647743564
+Utah,1943,9366,Project Tycho - https://zenodo.org/records/11452259,1482.8277902762848
+Utah,1944,1525,Project Tycho - https://zenodo.org/records/11452259,251.81430140107827
+Utah,1945,6474,Project Tycho - https://zenodo.org/records/11452259,1094.337134946272
+Utah,1946,10217,Project Tycho - https://zenodo.org/records/11452259,1599.8108474597504
+Utah,1947,669,Project Tycho - https://zenodo.org/records/11452259,105.0835956496334
+Utah,1948,7641,Project Tycho - https://zenodo.org/records/11452259,1168.9688565645686
+Utah,1949,3533,Project Tycho - https://zenodo.org/records/11452259,526.0015692206453
+Utah,1950,6434,Project Tycho - https://zenodo.org/records/11452259,923.5017855707512
+Utah,1951,2341,Project Tycho - https://zenodo.org/records/11452259,331.2551471191698
+Utah,1952,6646,Project Tycho - https://zenodo.org/records/11452259,917.0387623426298
+Utah,1953,8366,Project Tycho - https://zenodo.org/records/11452259,1130.93942593266
+Utah,1954,7829,Project Tycho - https://zenodo.org/records/11452259,1042.8238428238428
+Utah,1955,791,Project Tycho - https://zenodo.org/records/11452259,100.92079057596298
+Utah,1956,2531,Project Tycho - https://zenodo.org/records/11452259,312.5428341744782
+Utah,1957,14239,Project Tycho - https://zenodo.org/records/11452259,1722.1277511834412
+Utah,1958,3860,Project Tycho - https://zenodo.org/records/11452259,456.3483853424682
+Utah,1959,5837,Project Tycho - https://zenodo.org/records/11452259,670.2492909389462
+Utah,1960,4966,Project Tycho - https://zenodo.org/records/11452259,551.2265512265512
+Utah,1961,1734,Project Tycho - https://zenodo.org/records/11452259,185.07133891749277
+Utah,1962,4176,Project Tycho - https://zenodo.org/records/11452259,435.4726692931286
+Utah,1963,2983,Project Tycho - https://zenodo.org/records/11452259,305.9568767987659
+Utah,1964,2543,Project Tycho - https://zenodo.org/records/11452259,259.760689208542
+Utah,1965,4422,Project Tycho - https://zenodo.org/records/11452259,444.4247905012492
+Utah,1966,688,Project Tycho - https://zenodo.org/records/11452259,68.11820488728318
+Utah,1967,385,Project Tycho - https://zenodo.org/records/11452259,37.74439495734884
+Utah,1968,21,Project Tycho - https://zenodo.org/records/11452259,2.038777548981631
+Utah,1969,11,Project Tycho - https://zenodo.org/records/11452259,1.049571250144316
+Utah,1970,39,Project Tycho - https://zenodo.org/records/11452259,3.6780932764454906
+Utah,1971,332,Project Tycho - https://zenodo.org/records/11452259,30.11903368705054
+Utah,1972,160,Project Tycho - https://zenodo.org/records/11452259,14.077270135775272
+Utah,1973,3,Project Tycho - https://zenodo.org/records/11452259,0.2561453539501883
+Utah,1974,15,Project Tycho - https://zenodo.org/records/11452259,1.248261795449836
+Utah,1975,355,Project Tycho - https://zenodo.org/records/11452259,28.692294138851306
+Utah,1976,2197,Project Tycho - https://zenodo.org/records/11452259,172.15143057290302
+Utah,1977,23,Project Tycho - https://zenodo.org/records/11452259,1.7413279972986704
+Utah,1978,44,Project Tycho - https://zenodo.org/records/11452259,3.2143136308083196
+Utah,1979,21,Project Tycho - https://zenodo.org/records/11452259,1.4771485125114479
+Utah,1980,45,Project Tycho - https://zenodo.org/records/11452259,3.052778469364011
+Utah,1981,0,https://stacks.cdc.gov/view/cdc/1307,0.0
+Utah,1982,3,Project Tycho - https://zenodo.org/records/11452259,0.1923234726951955
+Utah,1983,10,Project Tycho - https://zenodo.org/records/11452259,0.6263556685501181
+Utah,1984,25,Project Tycho - https://zenodo.org/records/11452259,1.5394429925786532
+Utah,1985,0,https://stacks.cdc.gov/view/cdc/35429,0.0
+Utah,1986,7,Project Tycho - https://zenodo.org/records/11452259,0.42054772135228924
+Utah,1987,1,Project Tycho - https://zenodo.org/records/11452259,0.05953100285332097
+Utah,1988,1,Project Tycho - https://zenodo.org/records/11452259,0.05913447238154034
+Utah,1989,115,Project Tycho - https://zenodo.org/records/11452259,6.7347205295949975
+Utah,1990,146,Project Tycho - https://zenodo.org/records/11452259,8.43223400488954
+Utah,1991,224,Project Tycho - https://zenodo.org/records/11452259,12.628882253714243
+Utah,1992,0,https://stacks.cdc.gov/view/cdc/36063,0.0
+Utah,1993,0,https://stacks.cdc.gov/view/cdc/5650,0.0
+Utah,1994,102,Project Tycho - https://zenodo.org/records/11452259,5.278503140709368
+Utah,1995,1,Project Tycho - https://zenodo.org/records/11452259,0.0505369551484523
+Utah,1996,137,Project Tycho - https://zenodo.org/records/11452259,6.767855158019538
+Utah,1997,2,Project Tycho - https://zenodo.org/records/11452259,0.09673696541943698
+Utah,1998,0,https://stacks.cdc.gov/view/cdc/5637,0.0
+Utah,1999,2,Project Tycho - https://zenodo.org/records/11452259,0.09381017042962712
+Utah,2000,2,Project Tycho - https://zenodo.org/records/11452259,0.08901762816090471
+Utah,2001,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5053a1.htm,0.0
+Utah,2002,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.0
+Utah,2003,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.0
+Utah,2004,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0
+Utah,2005,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.0
+Utah,2006,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.0
+Utah,2007,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.0
+Utah,2008,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.0
+Utah,2009,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.0
+Utah,2010,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.0
+Utah,2011,13,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.4613837751201284
+Utah,2012,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.03500175008750438
+Utah,2013,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.0
+Utah,2014,3,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.10199692989241023
+Utah,2015,1,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.03348278934403532
+Utah,2016,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.03281609695187684
+Utah,2017,3,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.09656725925701794
+Utah,2018,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Utah,2019,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Utah,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Utah,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Utah,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Vermont,1902,4,Project Tycho - https://zenodo.org/records/11452259,1.144986818339254
+Vermont,1906,1,Project Tycho - https://zenodo.org/records/11452259,0.28140873211295747
+Vermont,1907,5,Project Tycho - https://zenodo.org/records/11452259,1.4070436605647874
+Vermont,1908,10,Project Tycho - https://zenodo.org/records/11452259,2.822036720341805
+Vermont,1909,16,Project Tycho - https://zenodo.org/records/11452259,4.489892130341569
+Vermont,1911,45,Project Tycho - https://zenodo.org/records/11452259,12.557275127107529
+Vermont,1912,412,Project Tycho - https://zenodo.org/records/11452259,114.64858261515643
+Vermont,1913,706,Project Tycho - https://zenodo.org/records/11452259,195.37249454146962
+Vermont,1914,17,Project Tycho - https://zenodo.org/records/11452259,4.691441155529553
+Vermont,1915,5,Project Tycho - https://zenodo.org/records/11452259,1.3875013875013875
+Vermont,1916,244,Project Tycho - https://zenodo.org/records/11452259,67.7100677100677
+Vermont,1917,134,Project Tycho - https://zenodo.org/records/11452259,35.9855198564876
+Vermont,1918,53,Project Tycho - https://zenodo.org/records/11452259,15.041776405412769
+Vermont,1919,356,Project Tycho - https://zenodo.org/records/11452259,101.03532830805558
+Vermont,1920,653,Project Tycho - https://zenodo.org/records/11452259,184.8010346593916
+Vermont,1921,118,Project Tycho - https://zenodo.org/records/11452259,33.20623038932898
+Vermont,1922,21,Project Tycho - https://zenodo.org/records/11452259,5.926277112717791
+Vermont,1923,1014,Project Tycho - https://zenodo.org/records/11452259,286.154523442659
+Vermont,1924,101,Project Tycho - https://zenodo.org/records/11452259,28.422281943408702
+Vermont,1925,129,Project Tycho - https://zenodo.org/records/11452259,36.301726442571514
+Vermont,1926,188,Project Tycho - https://zenodo.org/records/11452259,52.756232531513426
+Vermont,1927,331,Project Tycho - https://zenodo.org/records/11452259,92.62446237236153
+Vermont,1928,1249,Project Tycho - https://zenodo.org/records/11452259,348.534147416829
+Vermont,1929,393,Project Tycho - https://zenodo.org/records/11452259,109.36139069843806
+Vermont,1930,1021,Project Tycho - https://zenodo.org/records/11452259,283.3277833277833
+Vermont,1931,1207,Project Tycho - https://zenodo.org/records/11452259,335.8758233410044
+Vermont,1932,4364,Project Tycho - https://zenodo.org/records/11452259,1217.7766367710503
+Vermont,1933,1527,Project Tycho - https://zenodo.org/records/11452259,427.3037886483265
+Vermont,1934,1393,Project Tycho - https://zenodo.org/records/11452259,389.80627215921334
+Vermont,1935,2124,Project Tycho - https://zenodo.org/records/11452259,594.3636195737037
+Vermont,1936,12146,Project Tycho - https://zenodo.org/records/11452259,3398.8420543042394
+Vermont,1937,1403,Project Tycho - https://zenodo.org/records/11452259,393.70741617932634
+Vermont,1938,4443,Project Tycho - https://zenodo.org/records/11452259,1246.7869209442242
+Vermont,1939,2241,Project Tycho - https://zenodo.org/records/11452259,625.3523013299549
+Vermont,1940,434,Project Tycho - https://zenodo.org/records/11452259,119.43978886127645
+Vermont,1941,1320,Project Tycho - https://zenodo.org/records/11452259,378.931413414172
+Vermont,1942,4208,Project Tycho - https://zenodo.org/records/11452259,1225.596560873529
+Vermont,1943,8039,Project Tycho - https://zenodo.org/records/11452259,2455.953832100621
+Vermont,1944,2219,Project Tycho - https://zenodo.org/records/11452259,705.981916172999
+Vermont,1945,592,Project Tycho - https://zenodo.org/records/11452259,187.7487591773306
+Vermont,1946,2806,Project Tycho - https://zenodo.org/records/11452259,819.6481880692406
+Vermont,1947,5118,Project Tycho - https://zenodo.org/records/11452259,1444.318393470936
+Vermont,1948,1471,Project Tycho - https://zenodo.org/records/11452259,409.33996365751244
+Vermont,1949,6315,Project Tycho - https://zenodo.org/records/11452259,1709.6724413797583
+Vermont,1950,695,Project Tycho - https://zenodo.org/records/11452259,183.19411459253146
+Vermont,1951,4386,Project Tycho - https://zenodo.org/records/11452259,1159.1583020154449
+Vermont,1952,4875,Project Tycho - https://zenodo.org/records/11452259,1298.7012987012988
+Vermont,1953,441,Project Tycho - https://zenodo.org/records/11452259,116.24259645367825
+Vermont,1954,2866,Project Tycho - https://zenodo.org/records/11452259,759.4527488426693
+Vermont,1955,7106,Project Tycho - https://zenodo.org/records/11452259,1893.0402930402931
+Vermont,1956,1349,Project Tycho - https://zenodo.org/records/11452259,357.4674662207819
+Vermont,1957,2802,Project Tycho - https://zenodo.org/records/11452259,744.468297659787
+Vermont,1958,2084,Project Tycho - https://zenodo.org/records/11452259,547.8731794521268
+Vermont,1959,2034,Project Tycho - https://zenodo.org/records/11452259,525.0563390098274
+Vermont,1960,3475,Project Tycho - https://zenodo.org/records/11452259,892.4237716011495
+Vermont,1961,1157,Project Tycho - https://zenodo.org/records/11452259,296.3702963702964
+Vermont,1962,2053,Project Tycho - https://zenodo.org/records/11452259,521.8699875188424
+Vermont,1963,1614,Project Tycho - https://zenodo.org/records/11452259,406.1429754124968
+Vermont,1964,2359,Project Tycho - https://zenodo.org/records/11452259,590.6374327426959
+Vermont,1965,1457,Project Tycho - https://zenodo.org/records/11452259,360.2832810753603
+Vermont,1966,327,Project Tycho - https://zenodo.org/records/11452259,79.09765779015174
+Vermont,1967,42,Project Tycho - https://zenodo.org/records/11452259,9.919158855329067
+Vermont,1968,8,Project Tycho - https://zenodo.org/records/11452259,1.8586065097693005
+Vermont,1969,3,Project Tycho - https://zenodo.org/records/11452259,0.6858130427924478
+Vermont,1970,9,Project Tycho - https://zenodo.org/records/11452259,2.0216723273491835
+Vermont,1971,123,Project Tycho - https://zenodo.org/records/11452259,27.046520014424814
+Vermont,1972,80,Project Tycho - https://zenodo.org/records/11452259,17.25603206170757
+Vermont,1973,121,Project Tycho - https://zenodo.org/records/11452259,25.805185776010987
+Vermont,1974,57,Project Tycho - https://zenodo.org/records/11452259,12.038650403928402
+Vermont,1975,45,Project Tycho - https://zenodo.org/records/11452259,9.37125149940024
+Vermont,1976,169,Project Tycho - https://zenodo.org/records/11452259,34.815785353472926
+Vermont,1977,285,Project Tycho - https://zenodo.org/records/11452259,57.877186640726855
+Vermont,1978,53,Project Tycho - https://zenodo.org/records/11452259,10.629614104896241
+Vermont,1979,118,Project Tycho - https://zenodo.org/records/11452259,23.32582821515902
+Vermont,1980,216,Project Tycho - https://zenodo.org/records/11452259,42.10230860992211
+Vermont,1981,2,Project Tycho - https://zenodo.org/records/11452259,0.3875150404275066
+Vermont,1982,2,Project Tycho - https://zenodo.org/records/11452259,0.38489072952188874
+Vermont,1983,0,https://stacks.cdc.gov/view/cdc/35188,0.0
+Vermont,1984,7,Project Tycho - https://zenodo.org/records/11452259,1.3278046078613621
+Vermont,1985,0,https://stacks.cdc.gov/view/cdc/35429,0.0
+Vermont,1986,0,https://stacks.cdc.gov/view/cdc/35496,0.0
+Vermont,1987,24,Project Tycho - https://zenodo.org/records/11452259,4.437812380387088
+Vermont,1988,0,https://stacks.cdc.gov/view/cdc/35958,0.0
+Vermont,1989,3,https://stacks.cdc.gov/view/cdc/35853,0.5373801642233782
+Vermont,1990,1,Project Tycho - https://zenodo.org/records/11452259,0.17696296165212622
+Vermont,1991,4,Project Tycho - https://zenodo.org/records/11452259,0.704587569666096
+Vermont,1992,0,https://stacks.cdc.gov/view/cdc/36063,0.0
+Vermont,1993,27,Project Tycho - https://zenodo.org/records/11452259,4.699100905360108
+Vermont,1994,3,https://stacks.cdc.gov/view/cdc/5648,0.51770731589465
+Vermont,1995,0,https://stacks.cdc.gov/view/cdc/5644,0.0
+Vermont,1996,1,Project Tycho - https://zenodo.org/records/11452259,0.1703757466717098
+Vermont,1997,0,"https://www.cdc.gov/mmwr/preview/mmwrhtml/00056071.htm#:~:text=As%20of%20January%201%2C%201997,and%20control%20of%20the%20disease.",0.0
+Vermont,1998,1,Project Tycho - https://zenodo.org/records/11452259,0.16915636645358603
+Vermont,1999,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.0
+Vermont,2000,2,Project Tycho - https://zenodo.org/records/11452259,0.3277468876336183
+Vermont,2001,2,Project Tycho - https://zenodo.org/records/11452259,0.3263521176173032
+Vermont,2002,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.0
+Vermont,2003,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.0
+Vermont,2004,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0
+Vermont,2005,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.0
+Vermont,2006,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.0
+Vermont,2007,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.0
+Vermont,2008,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.0
+Vermont,2009,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.0
+Vermont,2010,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.0
+Vermont,2011,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.15928030785697903
+Vermont,2012,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.0
+Vermont,2013,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.0
+Vermont,2014,0,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.0
+Vermont,2015,0,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.0
+Vermont,2016,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Vermont,2017,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Vermont,2018,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.15989101828193905
+Vermont,2019,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Vermont,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Vermont,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Vermont,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+"Virgin Islands, U.S.",1970,8,Project Tycho - https://zenodo.org/records/11452259,
+"Virgin Islands, U.S.",1971,14,Project Tycho - https://zenodo.org/records/11452259,
+"Virgin Islands, U.S.",1972,2,Project Tycho - https://zenodo.org/records/11452259,
+"Virgin Islands, U.S.",1973,8,Project Tycho - https://zenodo.org/records/11452259,
+"Virgin Islands, U.S.",1974,28,Project Tycho - https://zenodo.org/records/11452259,
+"Virgin Islands, U.S.",1975,53009,Project Tycho - https://zenodo.org/records/11452259,
+"Virgin Islands, U.S.",1976,14,Project Tycho - https://zenodo.org/records/11452259,
+"Virgin Islands, U.S.",1977,13,Project Tycho - https://zenodo.org/records/11452259,
+"Virgin Islands, U.S.",1978,15,Project Tycho - https://zenodo.org/records/11452259,
+"Virgin Islands, U.S.",1979,4,Project Tycho - https://zenodo.org/records/11452259,
+"Virgin Islands, U.S.",1980,4,Project Tycho - https://zenodo.org/records/11452259,
+"Virgin Islands, U.S.",1981,11,Project Tycho - https://zenodo.org/records/11452259,
+"Virgin Islands, U.S.",1983,4,Project Tycho - https://zenodo.org/records/11452259,
+"Virgin Islands, U.S.",1985,5,Project Tycho - https://zenodo.org/records/11452259,
+Virginia,1889,1,Project Tycho - https://zenodo.org/records/11452259,
+Virginia,1890,23,Project Tycho - https://zenodo.org/records/11452259,
+Virginia,1891,4,Project Tycho - https://zenodo.org/records/11452259,
+Virginia,1892,2,Project Tycho - https://zenodo.org/records/11452259,
+Virginia,1893,10,Project Tycho - https://zenodo.org/records/11452259,
+Virginia,1896,11,Project Tycho - https://zenodo.org/records/11452259,
+Virginia,1897,3,Project Tycho - https://zenodo.org/records/11452259,
+Virginia,1899,5,Project Tycho - https://zenodo.org/records/11452259,
+Virginia,1902,1,Project Tycho - https://zenodo.org/records/11452259,0.05274556488917629
+Virginia,1906,1,Project Tycho - https://zenodo.org/records/11452259,0.051441864006230645
+Virginia,1907,444,Project Tycho - https://zenodo.org/records/11452259,22.72317846088338
+Virginia,1908,331,Project Tycho - https://zenodo.org/records/11452259,16.58321618201257
+Virginia,1909,51,Project Tycho - https://zenodo.org/records/11452259,2.4999534322399874
+Virginia,1910,210,Project Tycho - https://zenodo.org/records/11452259,10.129899072438908
+Virginia,1911,817,Project Tycho - https://zenodo.org/records/11452259,39.01452276213271
+Virginia,1912,1668,Project Tycho - https://zenodo.org/records/11452259,78.52656297519634
+Virginia,1913,6182,Project Tycho - https://zenodo.org/records/11452259,283.8154492566257
+Virginia,1914,984,Project Tycho - https://zenodo.org/records/11452259,43.86510410606796
+Virginia,1915,426,Project Tycho - https://zenodo.org/records/11452259,18.55163145485726
+Virginia,1916,9403,Project Tycho - https://zenodo.org/records/11452259,405.596130984732
+Virginia,1917,3711,Project Tycho - https://zenodo.org/records/11452259,160.28070502778672
+Virginia,1918,2650,Project Tycho - https://zenodo.org/records/11452259,112.22351196916689
+Virginia,1919,1005,Project Tycho - https://zenodo.org/records/11452259,43.31302864521156
+Virginia,1920,3268,Project Tycho - https://zenodo.org/records/11452259,139.10248251961076
+Virginia,1921,4199,Project Tycho - https://zenodo.org/records/11452259,175.14844237182442
+Virginia,1922,1431,Project Tycho - https://zenodo.org/records/11452259,59.26908911983539
+Virginia,1923,9746,Project Tycho - https://zenodo.org/records/11452259,401.8268153637531
+Virginia,1924,2775,Project Tycho - https://zenodo.org/records/11452259,114.27154873156522
+Virginia,1925,577,Project Tycho - https://zenodo.org/records/11452259,23.789664730646983
+Virginia,1926,4221,Project Tycho - https://zenodo.org/records/11452259,174.31927312043064
+Virginia,1927,5545,Project Tycho - https://zenodo.org/records/11452259,227.6802523411648
+Virginia,1928,3809,Project Tycho - https://zenodo.org/records/11452259,156.2708338889037
+Virginia,1929,455,Project Tycho - https://zenodo.org/records/11452259,18.744142455482663
+Virginia,1930,4866,Project Tycho - https://zenodo.org/records/11452259,200.29414343382206
+Virginia,1931,6733,Project Tycho - https://zenodo.org/records/11452259,275.10321988849597
+Virginia,1932,1514,Project Tycho - https://zenodo.org/records/11452259,61.683830036195445
+Virginia,1933,11315,Project Tycho - https://zenodo.org/records/11452259,459.4998497437522
+Virginia,1934,34159,Project Tycho - https://zenodo.org/records/11452259,1373.2344114637879
+Virginia,1935,22867,Project Tycho - https://zenodo.org/records/11452259,906.5141207998352
+Virginia,1936,3429,Project Tycho - https://zenodo.org/records/11452259,134.23097278896654
+Virginia,1937,11060,Project Tycho - https://zenodo.org/records/11452259,426.6004266004266
+Virginia,1938,15254,Project Tycho - https://zenodo.org/records/11452259,577.663428307856
+Virginia,1939,16202,Project Tycho - https://zenodo.org/records/11452259,606.2102691316175
+Virginia,1940,4997,Project Tycho - https://zenodo.org/records/11452259,183.5297055885291
+Virginia,1941,35182,Project Tycho - https://zenodo.org/records/11452259,1231.063157507991
+Virginia,1942,4834,Project Tycho - https://zenodo.org/records/11452259,158.9588818028581
+Virginia,1943,13778,Project Tycho - https://zenodo.org/records/11452259,439.75194134938545
+Virginia,1944,19134,Project Tycho - https://zenodo.org/records/11452259,588.5124727489259
+Virginia,1945,1677,Project Tycho - https://zenodo.org/records/11452259,52.46867132241388
+Virginia,1946,14980,Project Tycho - https://zenodo.org/records/11452259,465.91017948427657
+Virginia,1947,9590,Project Tycho - https://zenodo.org/records/11452259,299.29458233113337
+Virginia,1948,6258,Project Tycho - https://zenodo.org/records/11452259,194.9407000856954
+Virginia,1949,21377,Project Tycho - https://zenodo.org/records/11452259,648.7133765384069
+Virginia,1950,3108,Project Tycho - https://zenodo.org/records/11452259,93.66199411448281
+Virginia,1951,14002,Project Tycho - https://zenodo.org/records/11452259,407.33872999452495
+Virginia,1952,13641,Project Tycho - https://zenodo.org/records/11452259,388.9090361693101
+Virginia,1953,5153,Project Tycho - https://zenodo.org/records/11452259,144.72454731099657
+Virginia,1954,23945,Project Tycho - https://zenodo.org/records/11452259,672.8854830120653
+Virginia,1955,4310,Project Tycho - https://zenodo.org/records/11452259,120.00262836383239
+Virginia,1956,23701,Project Tycho - https://zenodo.org/records/11452259,636.145155220921
+Virginia,1957,4965,Project Tycho - https://zenodo.org/records/11452259,129.0332976076993
+Virginia,1958,21429,Project Tycho - https://zenodo.org/records/11452259,546.9492183850897
+Virginia,1959,13801,Project Tycho - https://zenodo.org/records/11452259,348.9550186588911
+Virginia,1960,7396,Project Tycho - https://zenodo.org/records/11452259,185.36405892151
+Virginia,1961,12083,Project Tycho - https://zenodo.org/records/11452259,294.77238268447064
+Virginia,1962,9303,Project Tycho - https://zenodo.org/records/11452259,222.3374711412989
+Virginia,1963,7460,Project Tycho - https://zenodo.org/records/11452259,174.28782629905174
+Virginia,1964,11873,Project Tycho - https://zenodo.org/records/11452259,272.23178474039156
+Virginia,1965,4117,Project Tycho - https://zenodo.org/records/11452259,93.24160310331247
+Virginia,1966,2256,Project Tycho - https://zenodo.org/records/11452259,50.57778845929654
+Virginia,1967,2351,Project Tycho - https://zenodo.org/records/11452259,52.09963062669362
+Virginia,1968,362,Project Tycho - https://zenodo.org/records/11452259,7.934145713873665
+Virginia,1969,923,Project Tycho - https://zenodo.org/records/11452259,19.98435028344001
+Virginia,1970,2466,Project Tycho - https://zenodo.org/records/11452259,52.96279138394609
+Virginia,1971,1562,Project Tycho - https://zenodo.org/records/11452259,32.845570305922216
+Virginia,1972,77,Project Tycho - https://zenodo.org/records/11452259,1.594435296573248
+Virginia,1973,435,Project Tycho - https://zenodo.org/records/11452259,8.866345045944993
+Virginia,1974,43,Project Tycho - https://zenodo.org/records/11452259,0.8641409634970779
+Virginia,1975,43,Project Tycho - https://zenodo.org/records/11452259,0.8510735996573539
+Virginia,1976,856,Project Tycho - https://zenodo.org/records/11452259,16.695975645720758
+Virginia,1977,2757,Project Tycho - https://zenodo.org/records/11452259,53.036518634439496
+Virginia,1978,2650,Project Tycho - https://zenodo.org/records/11452259,50.2321102604298
+Virginia,1979,318,Project Tycho - https://zenodo.org/records/11452259,5.985035153612138
+Virginia,1980,358,Project Tycho - https://zenodo.org/records/11452259,6.662073929667108
+Virginia,1981,9,Project Tycho - https://zenodo.org/records/11452259,0.16515152377053408
+Virginia,1982,3,Project Tycho - https://zenodo.org/records/11452259,0.054562567350669076
+Virginia,1983,22,Project Tycho - https://zenodo.org/records/11452259,0.3949573993563271
+Virginia,1984,2,Project Tycho - https://zenodo.org/records/11452259,0.035401281490988694
+Virginia,1985,27,Project Tycho - https://zenodo.org/records/11452259,0.47195635347643045
+Virginia,1986,36,Project Tycho - https://zenodo.org/records/11452259,0.618821348167627
+Virginia,1987,1,Project Tycho - https://zenodo.org/records/11452259,0.0168401199016537
+Virginia,1988,211,Project Tycho - https://zenodo.org/records/11452259,3.4916750028338828
+Virginia,1989,23,Project Tycho - https://zenodo.org/records/11452259,0.37542647631564946
+Virginia,1990,75,Project Tycho - https://zenodo.org/records/11452259,1.205838380034918
+Virginia,1991,29,Project Tycho - https://zenodo.org/records/11452259,0.46103931616104965
+Virginia,1992,10,Project Tycho - https://zenodo.org/records/11452259,0.15650191918303494
+Virginia,1993,4,Project Tycho - https://zenodo.org/records/11452259,0.06181177418489973
+Virginia,1994,1,Project Tycho - https://zenodo.org/records/11452259,0.01528279201938714
+Virginia,1995,0,https://stacks.cdc.gov/view/cdc/5644,0.0
+Virginia,1996,3,https://stacks.cdc.gov/view/cdc/5642,0.044962977484339396
+Virginia,1997,1,Project Tycho - https://zenodo.org/records/11452259,0.014837653810828817
+Virginia,1998,2,Project Tycho - https://zenodo.org/records/11452259,0.029429015302205087
+Virginia,1999,17,Project Tycho - https://zenodo.org/records/11452259,0.24710078107103361
+Virginia,2000,2,Project Tycho - https://zenodo.org/records/11452259,0.028117839616405186
+Virginia,2001,2,Project Tycho - https://zenodo.org/records/11452259,0.027756343712355462
+Virginia,2002,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.0
+Virginia,2003,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.0
+Virginia,2004,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0
+Virginia,2005,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.0
+Virginia,2006,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.0
+Virginia,2007,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.0
+Virginia,2008,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.01275294022225059
+Virginia,2009,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.01260420208972629
+Virginia,2010,3,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.03735046740374909
+Virginia,2011,7,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.0863074574945019
+Virginia,2012,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.0
+Virginia,2013,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.0
+Virginia,2014,2,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.024027646209728915
+Virginia,2015,1,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.011939343359993887
+Virginia,2016,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Virginia,2017,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Virginia,2018,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.011737874482213011
+Virginia,2019,2,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.02335030667125267
+Virginia,2020,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.011565705001427208
+Virginia,2021,21,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.24228249492821977
+Virginia,2022,2,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.02300940728111985
+Washington,1896,1,Project Tycho - https://zenodo.org/records/11452259,
+Washington,1898,1,Project Tycho - https://zenodo.org/records/11452259,
+Washington,1899,4,Project Tycho - https://zenodo.org/records/11452259,
+Washington,1901,2,Project Tycho - https://zenodo.org/records/11452259,0.3427104627790734
+Washington,1902,2,Project Tycho - https://zenodo.org/records/11452259,0.30691274930906265
+Washington,1903,1,Project Tycho - https://zenodo.org/records/11452259,0.13894311529916537
+Washington,1905,1,Project Tycho - https://zenodo.org/records/11452259,0.11864619940629442
+Washington,1906,15,Project Tycho - https://zenodo.org/records/11452259,1.6576344009972328
+Washington,1907,808,Project Tycho - https://zenodo.org/records/11452259,83.47392008198626
+Washington,1908,203,Project Tycho - https://zenodo.org/records/11452259,19.727354357704552
+Washington,1909,916,Project Tycho - https://zenodo.org/records/11452259,83.87579423326444
+Washington,1910,1142,Project Tycho - https://zenodo.org/records/11452259,99.37797394243388
+Washington,1911,2611,Project Tycho - https://zenodo.org/records/11452259,223.51256284418238
+Washington,1912,967,Project Tycho - https://zenodo.org/records/11452259,81.59070659070659
+Washington,1913,497,Project Tycho - https://zenodo.org/records/11452259,41.06728672485496
+Washington,1914,694,Project Tycho - https://zenodo.org/records/11452259,56.32060871703439
+Washington,1915,246,Project Tycho - https://zenodo.org/records/11452259,19.83488666297383
+Washington,1916,4312,Project Tycho - https://zenodo.org/records/11452259,343.24241495556237
+Washington,1917,3193,Project Tycho - https://zenodo.org/records/11452259,247.84849959675134
+Washington,1918,2650,Project Tycho - https://zenodo.org/records/11452259,197.41630479885512
+Washington,1919,1142,Project Tycho - https://zenodo.org/records/11452259,85.58583202244118
+Washington,1920,5718,Project Tycho - https://zenodo.org/records/11452259,416.04426163785234
+Washington,1921,944,Project Tycho - https://zenodo.org/records/11452259,67.12149060903509
+Washington,1922,340,Project Tycho - https://zenodo.org/records/11452259,24.004264286949798
+Washington,1923,5741,Project Tycho - https://zenodo.org/records/11452259,400.2278252103793
+Washington,1924,11280,Project Tycho - https://zenodo.org/records/11452259,768.1480074118111
+Washington,1925,228,Project Tycho - https://zenodo.org/records/11452259,15.2457983783285
+Washington,1926,2117,Project Tycho - https://zenodo.org/records/11452259,139.5042951771184
+Washington,1927,6175,Project Tycho - https://zenodo.org/records/11452259,401.09435428031003
+Washington,1928,9030,Project Tycho - https://zenodo.org/records/11452259,581.6234056079318
+Washington,1929,5979,Project Tycho - https://zenodo.org/records/11452259,384.117490226815
+Washington,1930,15625,Project Tycho - https://zenodo.org/records/11452259,995.4968500886869
+Washington,1931,4068,Project Tycho - https://zenodo.org/records/11452259,257.0484543919079
+Washington,1932,17170,Project Tycho - https://zenodo.org/records/11452259,1082.8817646999466
+Washington,1933,4500,Project Tycho - https://zenodo.org/records/11452259,282.3809356472673
+Washington,1934,11016,Project Tycho - https://zenodo.org/records/11452259,683.54006242205
+Washington,1935,14481,Project Tycho - https://zenodo.org/records/11452259,888.0622140290649
+Washington,1936,11203,Project Tycho - https://zenodo.org/records/11452259,677.0603866792615
+Washington,1937,2398,Project Tycho - https://zenodo.org/records/11452259,142.51067195742985
+Washington,1938,1585,Project Tycho - https://zenodo.org/records/11452259,93.25186003631234
+Washington,1939,32404,Project Tycho - https://zenodo.org/records/11452259,1887.5585056343073
+Washington,1940,21928,Project Tycho - https://zenodo.org/records/11452259,1258.970914143328
+Washington,1941,1775,Project Tycho - https://zenodo.org/records/11452259,99.11832158897558
+Washington,1942,18213,Project Tycho - https://zenodo.org/records/11452259,957.1175799476695
+Washington,1943,22260,Project Tycho - https://zenodo.org/records/11452259,1097.0775647638006
+Washington,1944,8002,Project Tycho - https://zenodo.org/records/11452259,382.12265745726546
+Washington,1945,9254,Project Tycho - https://zenodo.org/records/11452259,419.0732205238098
+Washington,1946,16878,Project Tycho - https://zenodo.org/records/11452259,736.9378872875376
+Washington,1947,1765,Project Tycho - https://zenodo.org/records/11452259,79.74838368325477
+Washington,1948,14035,Project Tycho - https://zenodo.org/records/11452259,621.7729055866529
+Washington,1949,12644,Project Tycho - https://zenodo.org/records/11452259,550.6263570779699
+Washington,1950,3824,Project Tycho - https://zenodo.org/records/11452259,160.04104818516214
+Washington,1951,17572,Project Tycho - https://zenodo.org/records/11452259,724.1932984507242
+Washington,1952,5863,Project Tycho - https://zenodo.org/records/11452259,239.26237161531282
+Washington,1953,15003,Project Tycho - https://zenodo.org/records/11452259,607.7863742097319
+Washington,1954,21574,Project Tycho - https://zenodo.org/records/11452259,856.6155624979154
+Washington,1955,11068,Project Tycho - https://zenodo.org/records/11452259,424.6137886690882
+Washington,1956,13059,Project Tycho - https://zenodo.org/records/11452259,488.9787873296119
+Washington,1957,16618,Project Tycho - https://zenodo.org/records/11452259,609.4492878633848
+Washington,1958,10554,Project Tycho - https://zenodo.org/records/11452259,380.21841123175415
+Washington,1959,14457,Project Tycho - https://zenodo.org/records/11452259,511.96587885705225
+Washington,1960,13023,Project Tycho - https://zenodo.org/records/11452259,455.6914189138357
+Washington,1961,8900,Project Tycho - https://zenodo.org/records/11452259,308.5048192612384
+Washington,1962,20555,Project Tycho - https://zenodo.org/records/11452259,697.9763947812894
+Washington,1963,4976,Project Tycho - https://zenodo.org/records/11452259,168.22433066087888
+Washington,1964,19879,Project Tycho - https://zenodo.org/records/11452259,670.6903363438317
+Washington,1965,7587,Project Tycho - https://zenodo.org/records/11452259,255.45738386992178
+Washington,1966,4931,Project Tycho - https://zenodo.org/records/11452259,161.1407892075213
+Washington,1967,5694,Project Tycho - https://zenodo.org/records/11452259,179.2158691969656
+Washington,1968,583,Project Tycho - https://zenodo.org/records/11452259,17.810935242127904
+Washington,1969,56,Project Tycho - https://zenodo.org/records/11452259,1.6734686193256338
+Washington,1970,678,Project Tycho - https://zenodo.org/records/11452259,19.84395858290721
+Washington,1971,1136,Project Tycho - https://zenodo.org/records/11452259,32.917994784120545
+Washington,1972,1013,Project Tycho - https://zenodo.org/records/11452259,29.35098680741233
+Washington,1973,862,Project Tycho - https://zenodo.org/records/11452259,24.75403904360961
+Washington,1974,80,Project Tycho - https://zenodo.org/records/11452259,2.2513047014277494
+Washington,1975,299,Project Tycho - https://zenodo.org/records/11452259,8.248366878531073
+Washington,1976,367,Project Tycho - https://zenodo.org/records/11452259,9.92615428056613
+Washington,1977,539,Project Tycho - https://zenodo.org/records/11452259,14.259915668075728
+Washington,1978,452,Project Tycho - https://zenodo.org/records/11452259,11.610696431149341
+Washington,1979,1014,Project Tycho - https://zenodo.org/records/11452259,25.213538028803608
+Washington,1980,173,Project Tycho - https://zenodo.org/records/11452259,4.1598217961196795
+Washington,1981,2,Project Tycho - https://zenodo.org/records/11452259,0.047170189572274875
+Washington,1982,32,Project Tycho - https://zenodo.org/records/11452259,0.7475189379250929
+Washington,1983,28,Project Tycho - https://zenodo.org/records/11452259,0.6504720801121414
+Washington,1984,172,Project Tycho - https://zenodo.org/records/11452259,3.95584267613677
+Washington,1985,45,Project Tycho - https://zenodo.org/records/11452259,1.021682834229917
+Washington,1986,215,Project Tycho - https://zenodo.org/records/11452259,4.823686409229889
+Washington,1987,47,Project Tycho - https://zenodo.org/records/11452259,1.0360565307713199
+Washington,1988,7,Project Tycho - https://zenodo.org/records/11452259,0.150714862121738
+Washington,1989,16,Project Tycho - https://zenodo.org/records/11452259,0.3367668112939802
+Washington,1990,75,Project Tycho - https://zenodo.org/records/11452259,1.528840038486
+Washington,1991,65,Project Tycho - https://zenodo.org/records/11452259,1.29521908730494
+Washington,1992,11,Project Tycho - https://zenodo.org/records/11452259,0.21383513311237035
+Washington,1993,0,https://stacks.cdc.gov/view/cdc/5650,0.0
+Washington,1994,4,https://stacks.cdc.gov/view/cdc/5648,0.07490314087595479
+Washington,1995,21,Project Tycho - https://zenodo.org/records/11452259,0.386281133569578
+Washington,1996,45,Project Tycho - https://zenodo.org/records/11452259,0.8158866548502105
+Washington,1997,1,Project Tycho - https://zenodo.org/records/11452259,0.017826236619403964
+Washington,1998,1,https://stacks.cdc.gov/view/cdc/5637,0.017563830032006567
+Washington,1999,5,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.08677366322134729
+Washington,2000,3,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4953a1.htm,0.050706322165660254
+Washington,2001,13,Project Tycho - https://zenodo.org/records/11452259,0.21696655060068856
+Washington,2002,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.016506005462497447
+Washington,2003,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.0
+Washington,2004,7,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.11318028017940045
+Washington,2005,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.03193071290744787
+Washington,2006,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.0313621048237583
+Washington,2007,3,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.046381845032689925
+Washington,2008,19,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.2892464414695363
+Washington,2009,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.014983309342557859
+Washington,2010,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.014815359142084034
+Washington,2011,4,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.058528254368475745
+Washington,2012,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.0
+Washington,2013,4,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.05736232539983692
+Washington,2014,33,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.4671185354333473
+Washington,2015,10,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.13938342903864184
+Washington,2016,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Washington,2017,3,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.040347646077980165
+Washington,2018,8,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.10618079749477026
+Washington,2019,90,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,1.1808485262616777
+Washington,2020,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.012928355192596294
+Washington,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Washington,2022,1,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.012817362707139795
+West Virginia,1899,1,Project Tycho - https://zenodo.org/records/11452259,
+West Virginia,1900,3,Project Tycho - https://zenodo.org/records/11452259,0.3125133469241916
+West Virginia,1901,3,Project Tycho - https://zenodo.org/records/11452259,0.308333641666975
+West Virginia,1907,30,Project Tycho - https://zenodo.org/records/11452259,2.608357699741512
+West Virginia,1909,171,Project Tycho - https://zenodo.org/records/11452259,14.20026357682218
+West Virginia,1910,90,Project Tycho - https://zenodo.org/records/11452259,7.303825337943941
+West Virginia,1911,401,Project Tycho - https://zenodo.org/records/11452259,31.6429226381833
+West Virginia,1912,211,Project Tycho - https://zenodo.org/records/11452259,16.327591850442353
+West Virginia,1913,419,Project Tycho - https://zenodo.org/records/11452259,31.782947500487364
+West Virginia,1914,97,Project Tycho - https://zenodo.org/records/11452259,7.114764824015925
+West Virginia,1915,63,Project Tycho - https://zenodo.org/records/11452259,4.537639721489758
+West Virginia,1916,1317,Project Tycho - https://zenodo.org/records/11452259,93.04698130723591
+West Virginia,1917,97,Project Tycho - https://zenodo.org/records/11452259,6.734058158658575
+West Virginia,1918,356,Project Tycho - https://zenodo.org/records/11452259,24.731874523251438
+West Virginia,1919,306,Project Tycho - https://zenodo.org/records/11452259,20.880758585676617
+West Virginia,1920,1865,Project Tycho - https://zenodo.org/records/11452259,126.7440042950247
+West Virginia,1921,1218,Project Tycho - https://zenodo.org/records/11452259,81.93826375644558
+West Virginia,1922,900,Project Tycho - https://zenodo.org/records/11452259,60.02008672235642
+West Virginia,1923,4374,Project Tycho - https://zenodo.org/records/11452259,286.34537153541083
+West Virginia,1924,377,Project Tycho - https://zenodo.org/records/11452259,23.882268650816524
+West Virginia,1925,622,Project Tycho - https://zenodo.org/records/11452259,39.00681866783562
+West Virginia,1926,2314,Project Tycho - https://zenodo.org/records/11452259,142.43304446631618
+West Virginia,1927,520,Project Tycho - https://zenodo.org/records/11452259,31.08800236268818
+West Virginia,1928,3618,Project Tycho - https://zenodo.org/records/11452259,213.11235933877444
+West Virginia,1929,8991,Project Tycho - https://zenodo.org/records/11452259,523.1227712299349
+West Virginia,1930,2924,Project Tycho - https://zenodo.org/records/11452259,168.5561985619689
+West Virginia,1931,5144,Project Tycho - https://zenodo.org/records/11452259,295.33684706098495
+West Virginia,1932,12871,Project Tycho - https://zenodo.org/records/11452259,736.0126993784693
+West Virginia,1933,6882,Project Tycho - https://zenodo.org/records/11452259,392.41580337470754
+West Virginia,1934,4960,Project Tycho - https://zenodo.org/records/11452259,279.7879703582696
+West Virginia,1935,12559,Project Tycho - https://zenodo.org/records/11452259,699.356384975114
+West Virginia,1936,1615,Project Tycho - https://zenodo.org/records/11452259,89.23598525368436
+West Virginia,1937,2187,Project Tycho - https://zenodo.org/records/11452259,120.5082837735899
+West Virginia,1938,13024,Project Tycho - https://zenodo.org/records/11452259,711.7608868155914
+West Virginia,1939,507,Project Tycho - https://zenodo.org/records/11452259,27.11421340971662
+West Virginia,1940,657,Project Tycho - https://zenodo.org/records/11452259,34.41760127654202
+West Virginia,1941,13366,Project Tycho - https://zenodo.org/records/11452259,708.3632547823529
+West Virginia,1942,5763,Project Tycho - https://zenodo.org/records/11452259,314.4316088062675
+West Virginia,1943,2337,Project Tycho - https://zenodo.org/records/11452259,134.09910021053042
+West Virginia,1944,9357,Project Tycho - https://zenodo.org/records/11452259,547.9280391355421
+West Virginia,1945,1242,Project Tycho - https://zenodo.org/records/11452259,72.6439836510094
+West Virginia,1946,2656,Project Tycho - https://zenodo.org/records/11452259,145.30923621832713
+West Virginia,1947,2933,Project Tycho - https://zenodo.org/records/11452259,155.60647530907752
+West Virginia,1948,6160,Project Tycho - https://zenodo.org/records/11452259,324.0571960951108
+West Virginia,1949,3637,Project Tycho - https://zenodo.org/records/11452259,188.25733851640587
+West Virginia,1950,6148,Project Tycho - https://zenodo.org/records/11452259,306.1743839410839
+West Virginia,1951,4633,Project Tycho - https://zenodo.org/records/11452259,233.28486030098935
+West Virginia,1952,5397,Project Tycho - https://zenodo.org/records/11452259,275.5037502099331
+West Virginia,1953,5963,Project Tycho - https://zenodo.org/records/11452259,308.8150833096401
+West Virginia,1954,9755,Project Tycho - https://zenodo.org/records/11452259,511.5619288847635
+West Virginia,1955,3839,Project Tycho - https://zenodo.org/records/11452259,203.99812953004445
+West Virginia,1956,10985,Project Tycho - https://zenodo.org/records/11452259,590.954548951318
+West Virginia,1957,3771,Project Tycho - https://zenodo.org/records/11452259,204.40763793992227
+West Virginia,1958,11683,Project Tycho - https://zenodo.org/records/11452259,632.5923399094131
+West Virginia,1959,7538,Project Tycho - https://zenodo.org/records/11452259,405.95523075307443
+West Virginia,1960,3528,Project Tycho - https://zenodo.org/records/11452259,190.20375199544114
+West Virginia,1961,8050,Project Tycho - https://zenodo.org/records/11452259,439.93205918807666
+West Virginia,1962,10173,Project Tycho - https://zenodo.org/records/11452259,561.7930991065319
+West Virginia,1963,12268,Project Tycho - https://zenodo.org/records/11452259,682.391105553689
+West Virginia,1964,9147,Project Tycho - https://zenodo.org/records/11452259,508.50651852321306
+West Virginia,1965,14872,Project Tycho - https://zenodo.org/records/11452259,831.8669012957927
+West Virginia,1966,5564,Project Tycho - https://zenodo.org/records/11452259,313.15163709529907
+West Virginia,1967,1509,Project Tycho - https://zenodo.org/records/11452259,85.2172135382989
+West Virginia,1968,355,Project Tycho - https://zenodo.org/records/11452259,20.116015578295784
+West Virginia,1969,236,Project Tycho - https://zenodo.org/records/11452259,13.503106286611441
+West Virginia,1970,349,Project Tycho - https://zenodo.org/records/11452259,19.988762764314156
+West Virginia,1971,568,Project Tycho - https://zenodo.org/records/11452259,32.04645381727992
+West Virginia,1972,279,Project Tycho - https://zenodo.org/records/11452259,15.504780640697549
+West Virginia,1973,224,Project Tycho - https://zenodo.org/records/11452259,12.388243114846755
+West Virginia,1974,235,Project Tycho - https://zenodo.org/records/11452259,12.931542067131762
+West Virginia,1975,218,Project Tycho - https://zenodo.org/records/11452259,11.821536018810342
+West Virginia,1976,212,Project Tycho - https://zenodo.org/records/11452259,11.268312336356997
+West Virginia,1977,275,Project Tycho - https://zenodo.org/records/11452259,14.397935911907668
+West Virginia,1978,889,Project Tycho - https://zenodo.org/records/11452259,46.174190445422525
+West Virginia,1979,65,Project Tycho - https://zenodo.org/records/11452259,3.343470048680924
+West Virginia,1980,30,Project Tycho - https://zenodo.org/records/11452259,1.5358623867301489
+West Virginia,1981,4,Project Tycho - https://zenodo.org/records/11452259,0.20449082296309246
+West Virginia,1982,1,Project Tycho - https://zenodo.org/records/11452259,0.05124124223118716
+West Virginia,1983,1,Project Tycho - https://zenodo.org/records/11452259,0.05136091003314833
+West Virginia,1984,0,https://stacks.cdc.gov/view/cdc/35267,0.0
+West Virginia,1985,35,Project Tycho - https://zenodo.org/records/11452259,1.8336732614288924
+West Virginia,1986,2,Project Tycho - https://zenodo.org/records/11452259,0.10614404171036264
+West Virginia,1987,0,https://stacks.cdc.gov/view/cdc/35629,0.0
+West Virginia,1988,4,Project Tycho - https://zenodo.org/records/11452259,0.2183352483154071
+West Virginia,1989,53,Project Tycho - https://zenodo.org/records/11452259,2.9308096665844565
+West Virginia,1990,6,Project Tycho - https://zenodo.org/records/11452259,0.3343972739934224
+West Virginia,1991,0,https://stacks.cdc.gov/view/cdc/36010,0.0
+West Virginia,1992,0,https://stacks.cdc.gov/view/cdc/36063,0.0
+West Virginia,1993,0,https://stacks.cdc.gov/view/cdc/5650,0.0
+West Virginia,1994,36,Project Tycho - https://zenodo.org/records/11452259,1.9776872924801736
+West Virginia,1995,0,https://stacks.cdc.gov/view/cdc/5644,0.0
+West Virginia,1996,0,https://stacks.cdc.gov/view/cdc/5642,0.0
+West Virginia,1997,1,"https://www.cdc.gov/mmwr/preview/mmwrhtml/00056071.htm#:~:text=As%20of%20January%201%2C%201997,and%20control%20of%20the%20disease.",0.05502356934592933
+West Virginia,1998,0,https://stacks.cdc.gov/view/cdc/5637,0.0
+West Virginia,1999,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.0
+West Virginia,2000,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4953a1.htm,0.0
+West Virginia,2001,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5053a1.htm,0.0
+West Virginia,2002,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.0
+West Virginia,2003,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.0
+West Virginia,2004,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0
+West Virginia,2005,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.0
+West Virginia,2006,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.0
+West Virginia,2007,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.0
+West Virginia,2008,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.0
+West Virginia,2009,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.05406510086925869
+West Virginia,2010,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.0
+West Virginia,2011,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.0
+West Virginia,2012,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.0
+West Virginia,2013,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.0
+West Virginia,2014,0,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.0
+West Virginia,2015,0,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.0
+West Virginia,2016,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+West Virginia,2017,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+West Virginia,2018,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+West Virginia,2019,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+West Virginia,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+West Virginia,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+West Virginia,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Wisconsin,1888,3,Project Tycho - https://zenodo.org/records/11452259,
+Wisconsin,1889,4,Project Tycho - https://zenodo.org/records/11452259,
+Wisconsin,1890,23,Project Tycho - https://zenodo.org/records/11452259,
+Wisconsin,1891,38,Project Tycho - https://zenodo.org/records/11452259,
+Wisconsin,1892,21,Project Tycho - https://zenodo.org/records/11452259,
+Wisconsin,1893,32,Project Tycho - https://zenodo.org/records/11452259,
+Wisconsin,1894,52,Project Tycho - https://zenodo.org/records/11452259,
+Wisconsin,1895,6,Project Tycho - https://zenodo.org/records/11452259,
+Wisconsin,1896,29,Project Tycho - https://zenodo.org/records/11452259,
+Wisconsin,1897,31,Project Tycho - https://zenodo.org/records/11452259,
+Wisconsin,1898,3,Project Tycho - https://zenodo.org/records/11452259,
+Wisconsin,1899,29,Project Tycho - https://zenodo.org/records/11452259,
+Wisconsin,1900,45,Project Tycho - https://zenodo.org/records/11452259,2.169645026787884
+Wisconsin,1901,16,Project Tycho - https://zenodo.org/records/11452259,0.7578954947376
+Wisconsin,1902,35,Project Tycho - https://zenodo.org/records/11452259,1.6331169997680974
+Wisconsin,1903,1,Project Tycho - https://zenodo.org/records/11452259,0.04601570700142787
+Wisconsin,1906,55,Project Tycho - https://zenodo.org/records/11452259,2.442002442002442
+Wisconsin,1907,243,Project Tycho - https://zenodo.org/records/11452259,10.703582132153562
+Wisconsin,1908,751,Project Tycho - https://zenodo.org/records/11452259,32.73340969676048
+Wisconsin,1909,1886,Project Tycho - https://zenodo.org/records/11452259,81.31704290530358
+Wisconsin,1910,2008,Project Tycho - https://zenodo.org/records/11452259,85.54345441339045
+Wisconsin,1911,972,Project Tycho - https://zenodo.org/records/11452259,40.988981470197174
+Wisconsin,1912,2470,Project Tycho - https://zenodo.org/records/11452259,102.51485116462267
+Wisconsin,1913,1524,Project Tycho - https://zenodo.org/records/11452259,62.44780650030855
+Wisconsin,1914,1399,Project Tycho - https://zenodo.org/records/11452259,56.12861034547782
+Wisconsin,1915,2067,Project Tycho - https://zenodo.org/records/11452259,81.4570045339276
+Wisconsin,1916,6675,Project Tycho - https://zenodo.org/records/11452259,260.27836332285983
+Wisconsin,1917,2593,Project Tycho - https://zenodo.org/records/11452259,100.13179707806688
+Wisconsin,1918,8491,Project Tycho - https://zenodo.org/records/11452259,326.6275503472269
+Wisconsin,1919,2115,Project Tycho - https://zenodo.org/records/11452259,81.26488895719665
+Wisconsin,1920,10706,Project Tycho - https://zenodo.org/records/11452259,399.2274988915526
+Wisconsin,1921,679,Project Tycho - https://zenodo.org/records/11452259,24.919973487203467
+Wisconsin,1922,8038,Project Tycho - https://zenodo.org/records/11452259,290.835567909092
+Wisconsin,1923,14866,Project Tycho - https://zenodo.org/records/11452259,529.8304977220424
+Wisconsin,1924,1632,Project Tycho - https://zenodo.org/records/11452259,57.549228039873995
+Wisconsin,1925,7211,Project Tycho - https://zenodo.org/records/11452259,251.6170521759065
+Wisconsin,1926,10205,Project Tycho - https://zenodo.org/records/11452259,352.5174687000413
+Wisconsin,1927,5688,Project Tycho - https://zenodo.org/records/11452259,194.8668615335282
+Wisconsin,1928,4868,Project Tycho - https://zenodo.org/records/11452259,166.37484991915372
+Wisconsin,1929,45670,Project Tycho - https://zenodo.org/records/11452259,1555.0230274156654
+Wisconsin,1930,24073,Project Tycho - https://zenodo.org/records/11452259,815.2186796254592
+Wisconsin,1931,20070,Project Tycho - https://zenodo.org/records/11452259,670.5668913026773
+Wisconsin,1932,47664,Project Tycho - https://zenodo.org/records/11452259,1576.1795304992922
+Wisconsin,1933,11699,Project Tycho - https://zenodo.org/records/11452259,384.4510752405489
+Wisconsin,1934,44463,Project Tycho - https://zenodo.org/records/11452259,1454.4394701565625
+Wisconsin,1935,59225,Project Tycho - https://zenodo.org/records/11452259,1927.2258685939469
+Wisconsin,1936,4328,Project Tycho - https://zenodo.org/records/11452259,140.28800531071784
+Wisconsin,1937,3205,Project Tycho - https://zenodo.org/records/11452259,103.68517492869823
+Wisconsin,1938,104450,Project Tycho - https://zenodo.org/records/11452259,3368.1618575098237
+Wisconsin,1939,20081,Project Tycho - https://zenodo.org/records/11452259,642.7727991329401
+Wisconsin,1940,25020,Project Tycho - https://zenodo.org/records/11452259,795.259465319917
+Wisconsin,1941,40482,Project Tycho - https://zenodo.org/records/11452259,1287.9477210687403
+Wisconsin,1942,31836,Project Tycho - https://zenodo.org/records/11452259,1041.735859947455
+Wisconsin,1943,53013,Project Tycho - https://zenodo.org/records/11452259,1757.134703385533
+Wisconsin,1944,50308,Project Tycho - https://zenodo.org/records/11452259,1686.5014180450423
+Wisconsin,1945,2851,Project Tycho - https://zenodo.org/records/11452259,96.18884998824208
+Wisconsin,1946,69538,Project Tycho - https://zenodo.org/records/11452259,2193.51220298489
+Wisconsin,1947,13399,Project Tycho - https://zenodo.org/records/11452259,411.86505801890416
+Wisconsin,1948,40111,Project Tycho - https://zenodo.org/records/11452259,1209.1408892857294
+Wisconsin,1949,39712,Project Tycho - https://zenodo.org/records/11452259,1169.9300404697042
+Wisconsin,1950,19856,Project Tycho - https://zenodo.org/records/11452259,576.9681162351319
+Wisconsin,1951,32680,Project Tycho - https://zenodo.org/records/11452259,949.3269161777449
+Wisconsin,1952,51921,Project Tycho - https://zenodo.org/records/11452259,1495.218531828506
+Wisconsin,1953,49161,Project Tycho - https://zenodo.org/records/11452259,1400.7954395860843
+Wisconsin,1954,10448,Project Tycho - https://zenodo.org/records/11452259,289.28942454441346
+Wisconsin,1955,51103,Project Tycho - https://zenodo.org/records/11452259,1387.658278117642
+Wisconsin,1956,27007,Project Tycho - https://zenodo.org/records/11452259,721.0053442014961
+Wisconsin,1957,38072,Project Tycho - https://zenodo.org/records/11452259,1003.2700088094443
+Wisconsin,1958,62884,Project Tycho - https://zenodo.org/records/11452259,1634.69109604941
+Wisconsin,1959,14972,Project Tycho - https://zenodo.org/records/11452259,384.4010012090197
+Wisconsin,1960,43191,Project Tycho - https://zenodo.org/records/11452259,1089.0422046403874
+Wisconsin,1961,37495,Project Tycho - https://zenodo.org/records/11452259,934.3363047528674
+Wisconsin,1962,15797,Project Tycho - https://zenodo.org/records/11452259,389.7559590323236
+Wisconsin,1963,57073,Project Tycho - https://zenodo.org/records/11452259,1386.5754867700393
+Wisconsin,1964,15361,Project Tycho - https://zenodo.org/records/11452259,368.44308152831564
+Wisconsin,1965,20407,Project Tycho - https://zenodo.org/records/11452259,481.7252690598626
+Wisconsin,1966,31459,Project Tycho - https://zenodo.org/records/11452259,735.319897697062
+Wisconsin,1967,2143,Project Tycho - https://zenodo.org/records/11452259,49.75271068694262
+Wisconsin,1968,1375,Project Tycho - https://zenodo.org/records/11452259,31.613955664588573
+Wisconsin,1969,668,Project Tycho - https://zenodo.org/records/11452259,15.242865859585825
+Wisconsin,1970,1384,Project Tycho - https://zenodo.org/records/11452259,31.296370751642044
+Wisconsin,1971,3874,Project Tycho - https://zenodo.org/records/11452259,86.73230769506317
+Wisconsin,1972,3454,Project Tycho - https://zenodo.org/records/11452259,76.637805824562
+Wisconsin,1973,1350,Project Tycho - https://zenodo.org/records/11452259,29.80943161583901
+Wisconsin,1974,634,Project Tycho - https://zenodo.org/records/11452259,13.9330645907426
+Wisconsin,1975,1468,Project Tycho - https://zenodo.org/records/11452259,32.02747905341782
+Wisconsin,1976,4096,Project Tycho - https://zenodo.org/records/11452259,89.03382002691447
+Wisconsin,1977,2327,Project Tycho - https://zenodo.org/records/11452259,50.24680748152723
+Wisconsin,1978,1558,Project Tycho - https://zenodo.org/records/11452259,33.49994431010542
+Wisconsin,1979,654,Project Tycho - https://zenodo.org/records/11452259,13.952020835017782
+Wisconsin,1980,1467,Project Tycho - https://zenodo.org/records/11452259,31.101877836827292
+Wisconsin,1981,5,Project Tycho - https://zenodo.org/records/11452259,0.10568436013087106
+Wisconsin,1982,1,Project Tycho - https://zenodo.org/records/11452259,0.0211255793161988
+Wisconsin,1983,1,https://stacks.cdc.gov/view/cdc/35188,0.02115883109307156
+Wisconsin,1984,3,Project Tycho - https://zenodo.org/records/11452259,0.0632871604274668
+Wisconsin,1985,59,https://stacks.cdc.gov/view/cdc/35429,1.241448210357718
+Wisconsin,1986,286,https://stacks.cdc.gov/view/cdc/35496,6.007932571670329
+Wisconsin,1987,3,Project Tycho - https://zenodo.org/records/11452259,0.06272612769032361
+Wisconsin,1988,1,Project Tycho - https://zenodo.org/records/11452259,0.0207159000747844
+Wisconsin,1989,869,https://stacks.cdc.gov/view/cdc/35853,17.87539880240999
+Wisconsin,1990,1,Project Tycho - https://zenodo.org/records/11452259,0.02037835679935083
+Wisconsin,1991,9,https://stacks.cdc.gov/view/cdc/36010,0.18153846588297184
+Wisconsin,1992,4,https://stacks.cdc.gov/view/cdc/36063,0.07984605680248481
+Wisconsin,1993,6,https://stacks.cdc.gov/view/cdc/5650,0.11856833478480737
+Wisconsin,1994,3,https://stacks.cdc.gov/view/cdc/5648,0.05881662134192474
+Wisconsin,1995,6,https://stacks.cdc.gov/view/cdc/5644,0.11668291476254734
+Wisconsin,1996,9,https://stacks.cdc.gov/view/cdc/5642,0.17377868820647072
+Wisconsin,1997,1,"https://www.cdc.gov/mmwr/preview/mmwrhtml/00056071.htm#:~:text=As%20of%20January%201%2C%201997,and%20control%20of%20the%20disease.",0.019210690364974303
+Wisconsin,1998,1,https://stacks.cdc.gov/view/cdc/5637,0.019130166627577362
+Wisconsin,1999,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.0
+Wisconsin,2000,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4953a1.htm,0.018589530525124492
+Wisconsin,2001,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5053a1.htm,0.0
+Wisconsin,2002,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.018346580481770194
+Wisconsin,2003,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.018232597623709084
+Wisconsin,2004,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0
+Wisconsin,2005,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.03602492348306252
+Wisconsin,2006,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.0
+Wisconsin,2007,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.0
+Wisconsin,2008,6,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.10625795606446033
+Wisconsin,2009,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.0
+Wisconsin,2010,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.0
+Wisconsin,2011,2,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.03501679493026843
+Wisconsin,2012,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.0
+Wisconsin,2013,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.0
+Wisconsin,2014,2,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.03472854088730033
+Wisconsin,2015,0,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.0
+Wisconsin,2016,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Wisconsin,2017,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Wisconsin,2018,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Wisconsin,2019,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Wisconsin,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Wisconsin,2021,22,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.3736737342524122
+Wisconsin,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Wyoming,1899,2,Project Tycho - https://zenodo.org/records/11452259,
+Wyoming,1918,1,Project Tycho - https://zenodo.org/records/11452259,0.5519342535917121
+Wyoming,1919,65,Project Tycho - https://zenodo.org/records/11452259,33.99741619636908
+Wyoming,1920,98,Project Tycho - https://zenodo.org/records/11452259,49.69649639700401
+Wyoming,1921,4,Project Tycho - https://zenodo.org/records/11452259,1.9684748748788157
+Wyoming,1922,22,Project Tycho - https://zenodo.org/records/11452259,10.566356720202874
+Wyoming,1923,10,Project Tycho - https://zenodo.org/records/11452259,4.734601890999995
+Wyoming,1924,2454,https://www.jstor.org/stable/4577735?seq=13,1140.2550937434657
+Wyoming,1925,129,https://www.jstor.org/stable/4578131,59.662559662559666
+Wyoming,1927,32,Project Tycho - https://zenodo.org/records/11452259,14.597274871247475
+Wyoming,1928,503,Project Tycho - https://zenodo.org/records/11452259,228.40795568068293
+Wyoming,1929,697,Project Tycho - https://zenodo.org/records/11452259,312.24381000165755
+Wyoming,1930,768,Project Tycho - https://zenodo.org/records/11452259,339.4835253242333
+Wyoming,1931,139,Project Tycho - https://zenodo.org/records/11452259,60.63805190442745
+Wyoming,1932,557,Project Tycho - https://zenodo.org/records/11452259,241.93198106241587
+Wyoming,1933,618,Project Tycho - https://zenodo.org/records/11452259,268.42722494896407
+Wyoming,1934,2216,Project Tycho - https://zenodo.org/records/11452259,950.1228385348558
+Wyoming,1935,2212,Project Tycho - https://zenodo.org/records/11452259,932.4009324009324
+Wyoming,1936,139,Project Tycho - https://zenodo.org/records/11452259,57.858807858807864
+Wyoming,1937,170,Project Tycho - https://zenodo.org/records/11452259,69.88895877784766
+Wyoming,1938,613,Project Tycho - https://zenodo.org/records/11452259,248.9380538161026
+Wyoming,1939,1973,Project Tycho - https://zenodo.org/records/11452259,794.7697463826496
+Wyoming,1940,644,Project Tycho - https://zenodo.org/records/11452259,257.34265734265733
+Wyoming,1941,815,Project Tycho - https://zenodo.org/records/11452259,329.6298842857547
+Wyoming,1942,1639,Project Tycho - https://zenodo.org/records/11452259,652.3357120966682
+Wyoming,1943,2824,Project Tycho - https://zenodo.org/records/11452259,1142.177660396284
+Wyoming,1944,1739,Project Tycho - https://zenodo.org/records/11452259,717.8771641581559
+Wyoming,1945,258,Project Tycho - https://zenodo.org/records/11452259,107.84194884613295
+Wyoming,1946,1066,Project Tycho - https://zenodo.org/records/11452259,419.2657735964823
+Wyoming,1947,444,Project Tycho - https://zenodo.org/records/11452259,171.9211021536603
+Wyoming,1948,2172,Project Tycho - https://zenodo.org/records/11452259,806.6283159219962
+Wyoming,1949,558,Project Tycho - https://zenodo.org/records/11452259,201.24280052077887
+Wyoming,1950,655,Project Tycho - https://zenodo.org/records/11452259,225.6364325329843
+Wyoming,1951,2192,Project Tycho - https://zenodo.org/records/11452259,752.5120927182783
+Wyoming,1952,404,Project Tycho - https://zenodo.org/records/11452259,137.74621283153706
+Wyoming,1953,1440,Project Tycho - https://zenodo.org/records/11452259,496.0556684694616
+Wyoming,1954,1148,Project Tycho - https://zenodo.org/records/11452259,391.4174562638727
+Wyoming,1955,555,Project Tycho - https://zenodo.org/records/11452259,180.60115779985486
+Wyoming,1956,2004,Project Tycho - https://zenodo.org/records/11452259,641.666026281411
+Wyoming,1957,216,Project Tycho - https://zenodo.org/records/11452259,68.72108782936809
+Wyoming,1958,1362,Project Tycho - https://zenodo.org/records/11452259,431.94900337757485
+Wyoming,1959,900,Project Tycho - https://zenodo.org/records/11452259,280.96903096903094
+Wyoming,1960,694,Project Tycho - https://zenodo.org/records/11452259,209.45821550051159
+Wyoming,1961,519,Project Tycho - https://zenodo.org/records/11452259,153.85208263546542
+Wyoming,1962,441,Project Tycho - https://zenodo.org/records/11452259,132.3001323001323
+Wyoming,1963,329,Project Tycho - https://zenodo.org/records/11452259,97.81884781884783
+Wyoming,1964,286,Project Tycho - https://zenodo.org/records/11452259,84.28150021070375
+Wyoming,1965,751,Project Tycho - https://zenodo.org/records/11452259,225.97884043667176
+Wyoming,1966,225,Project Tycho - https://zenodo.org/records/11452259,69.58985287158661
+Wyoming,1967,114,Project Tycho - https://zenodo.org/records/11452259,35.36835834972481
+Wyoming,1968,48,Project Tycho - https://zenodo.org/records/11452259,14.800014800014798
+Wyoming,1969,8,Project Tycho - https://zenodo.org/records/11452259,2.4291817604887513
+Wyoming,1970,11,Project Tycho - https://zenodo.org/records/11452259,3.305804993568707
+Wyoming,1971,85,Project Tycho - https://zenodo.org/records/11452259,24.954128440366972
+Wyoming,1972,51,Project Tycho - https://zenodo.org/records/11452259,14.668154573588117
+Wyoming,1973,66,Project Tycho - https://zenodo.org/records/11452259,18.62223664348292
+Wyoming,1974,17,Project Tycho - https://zenodo.org/records/11452259,4.646509924398551
+Wyoming,1975,3,Project Tycho - https://zenodo.org/records/11452259,0.7851840994985291
+Wyoming,1976,4,Project Tycho - https://zenodo.org/records/11452259,1.006674250279352
+Wyoming,1977,19,Project Tycho - https://zenodo.org/records/11452259,4.5919563425792775
+Wyoming,1978,0,https://stacks.cdc.gov/view/cdc/51063,0.0
+Wyoming,1979,36,https://stacks.cdc.gov/view/cdc/1577,7.915010377458051
+Wyoming,1980,0,https://stacks.cdc.gov/view/cdc/1484,0.0
+Wyoming,1981,1,Project Tycho - https://zenodo.org/records/11452259,0.20316820498859212
+Wyoming,1982,1,https://stacks.cdc.gov/view/cdc/35066,0.19727523446161618
+Wyoming,1983,1,https://stacks.cdc.gov/view/cdc/35188,0.19575026181597519
+Wyoming,1984,0,https://stacks.cdc.gov/view/cdc/35267,0.0
+Wyoming,1985,5,Project Tycho - https://zenodo.org/records/11452259,0.9996121504856116
+Wyoming,1986,0,https://stacks.cdc.gov/view/cdc/35496,0.0
+Wyoming,1987,2,Project Tycho - https://zenodo.org/records/11452259,0.4188999269019627
+Wyoming,1988,0,https://stacks.cdc.gov/view/cdc/35958,0.0
+Wyoming,1989,0,https://stacks.cdc.gov/view/cdc/35853,0.0
+Wyoming,1990,2,Project Tycho - https://zenodo.org/records/11452259,0.44067034773297137
+Wyoming,1991,3,Project Tycho - https://zenodo.org/records/11452259,0.6547416389492706
+Wyoming,1992,1,Project Tycho - https://zenodo.org/records/11452259,0.2155386094311074
+Wyoming,1993,0,https://stacks.cdc.gov/view/cdc/5650,0.0
+Wyoming,1994,0,https://stacks.cdc.gov/view/cdc/5648,0.0
+Wyoming,1995,0,https://stacks.cdc.gov/view/cdc/5644,0.0
+Wyoming,1996,1,Project Tycho - https://zenodo.org/records/11452259,0.20808839595059983
+Wyoming,1997,0,"https://www.cdc.gov/mmwr/preview/mmwrhtml/00056071.htm#:~:text=As%20of%20January%201%2C%201997,and%20control%20of%20the%20disease.",0.0
+Wyoming,1998,0,https://stacks.cdc.gov/view/cdc/5637,0.0
+Wyoming,1999,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4853a1.htm,0.0
+Wyoming,2000,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm4953a1.htm,0.0
+Wyoming,2001,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5053a1.htm,0.0
+Wyoming,2002,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5153a1.htm,0.0
+Wyoming,2003,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5254a1.htm,0.0
+Wyoming,2004,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5353a1.htm,0.0
+Wyoming,2005,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5453a1.htm,0.0
+Wyoming,2006,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5553a1.htm,0.0
+Wyoming,2007,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5653a1.htm,0.0
+Wyoming,2008,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5754a1.htm,0.0
+Wyoming,2009,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5853a1.htm,0.0
+Wyoming,2010,1,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5953a1.htm,0.17696139587149065
+Wyoming,2011,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6053a1.htm,0.0
+Wyoming,2012,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6153a1.htm,0.0
+Wyoming,2013,0,https://www.cdc.gov/mmwr/preview/mmwrhtml/mm6253a1.htm,0.0
+Wyoming,2014,0,https://www.cdc.gov/mmwr/volumes/63/wr/mm6354a1.htm?s_cid=mm6354a1_w,0.0
+Wyoming,2015,0,https://www.cdc.gov/mmwr/volumes/64/wr/mm6453a1.htm?s_cid=mm6453a1_w,0.0
+Wyoming,2016,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Wyoming,2017,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Wyoming,2018,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Wyoming,2019,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Wyoming,2020,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Wyoming,2021,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0
+Wyoming,2022,0,CDC WONDER - https://wonder.cdc.gov/controller/datarequest/D130,0.0

--- a/samples/highcharts/website/industry-finance-demos/demo.js
+++ b/samples/highcharts/website/industry-finance-demos/demo.js
@@ -1243,7 +1243,7 @@ function customization() {
                     },
                     chartOptions: {
                         chart: {
-                            height: '100%'
+                            height: '70%'
                         },
                         plotOptions: {
                             variablepie: {

--- a/samples/highcharts/website/industry-healthcare-demos/demo.css
+++ b/samples/highcharts/website/industry-healthcare-demos/demo.css
@@ -471,6 +471,11 @@ highcharts-tooltip-box {
     display: none;
 }
 
+.heatmap .highcharts-title,
+.heatmap .highcharts-subtitle {
+    display: block;
+}
+
 @media (min-width: 400px) {
     #made-with {
         justify-content: start;

--- a/samples/highcharts/website/industry-healthcare-demos/demo.js
+++ b/samples/highcharts/website/industry-healthcare-demos/demo.js
@@ -1188,9 +1188,13 @@ function heatmap() {
             csv: csv,
 
             parsed: function (columns) {
-                const countries = [...new Set(columns[0].slice(1))];
+                const states = [...new Set(columns[0].slice(1))];
 
-                const data = columns[0].slice(1).map((country, i) => {
+                const stateIndex = new Map(
+                    states.map((state, index) => [state, index])
+                );
+
+                const data = columns[0].slice(1).map((state, i) => {
                     const year = Number(columns[1][i + 1]);
                     const rawRate = columns[4][i + 1] === '' ?
                         null :
@@ -1206,7 +1210,7 @@ function heatmap() {
 
                     return {
                         x: year,
-                        y: countries.indexOf(country),
+                        y: stateIndex.get(state),
                         // Log-style color value so smaller outbreaks still show
                         value: Math.log10(rawRate + 1),
                         rawRate: rawRate
@@ -1384,7 +1388,7 @@ function heatmap() {
                         outside: true,
                         formatter: function () {
                             return (
-                                '<b>' + countries[this.point.y] + '</b><br/>' +
+                                '<b>' + states[this.point.y] + '</b><br/>' +
                                 'Year: ' + this.point.x + '<br/>' +
                                 'Case rate: <b>' +
                                 Highcharts.numberFormat(this.point.rawRate, 2) +

--- a/samples/highcharts/website/industry-healthcare-demos/demo.js
+++ b/samples/highcharts/website/industry-healthcare-demos/demo.js
@@ -1319,7 +1319,7 @@ function heatmap() {
 
                     yAxis: [
                         {
-                            categories: countries,
+                            categories: states,
                             visible: true,
                             title: {
                                 text: null

--- a/samples/highcharts/website/industry-healthcare-demos/demo.js
+++ b/samples/highcharts/website/industry-healthcare-demos/demo.js
@@ -1181,98 +1181,230 @@ function scatter() {
 function heatmap() {
     (async () => {
         const csv = await fetch(
-            'https://cdn.jsdelivr.net/gh/highcharts/highcharts@35bdee4/samples/data/large-heatmap.csv'
+            'https://cdn.jsdelivr.net/gh/highcharts/highcharts@b61efc3e897e9ea3c0e6a268d44b70f3ea004d7b/samples/data/measles.csv'
         ).then(res => res.text());
 
-        Highcharts.chart('container', {
+        Highcharts.data({
+            csv: csv,
 
-            data: {
-                csv: csv
-            },
+            parsed: function (columns) {
+                const countries = [...new Set(columns[0].slice(1))];
 
-            chart: {
-                type: 'heatmap'
-            },
+                const data = columns[0].slice(1).map((country, i) => {
+                    const year = Number(columns[1][i + 1]);
+                    const rawRate = columns[4][i + 1] === '' ?
+                        null :
+                        Number(columns[4][i + 1]);
 
-            boost: {
-                useGPUTranslations: true
-            },
+                    if (
+                        Number.isNaN(year) ||
+                        rawRate === null ||
+                        Number.isNaN(rawRate)
+                    ) {
+                        return null;
+                    }
 
-            title: {
-                text: 'Large heatmap',
-                align: 'left',
-                x: 40
-            },
+                    return {
+                        x: year,
+                        y: countries.indexOf(country),
+                        // Log-style color value so smaller outbreaks still show
+                        value: Math.log10(rawRate + 1),
+                        rawRate: rawRate
+                    };
+                }).filter(Boolean);
 
-            subtitle: {
-                text: 'Temperature variation by day and hour through 2023',
-                align: 'left',
-                x: 40
-            },
+                Highcharts.chart('container', {
+                    chart: {
+                        type: 'heatmap',
+                        margin: [70, 100, 40, 80],
+                        className: 'heatmap'
+                    },
 
-            xAxis: {
-                type: 'datetime',
-                min: '2023-01-01',
-                max: '2023-12-31 23:59:59',
-                labels: {
-                    align: 'left',
-                    x: 5,
-                    y: 14,
-                    format: '{value:%B}' // long month
-                },
-                showLastLabel: false,
-                tickLength: 16
-            },
+                    title: {
+                        // eslint-disable-next-line max-len
+                        text: 'The effectiveness of the measles vaccines across US states',
+                        align: 'left',
+                        y: 0,
+                        style: {
+                            fontSize: '14px'
+                        }
+                    },
 
-            yAxis: {
-                title: {
-                    text: null
-                },
-                labels: {
-                    format: '{value}:00'
-                },
-                minPadding: 0,
-                maxPadding: 0,
-                startOnTick: false,
-                endOnTick: false,
-                tickPositions: [0, 6, 12, 18, 24],
-                tickWidth: 1,
-                min: 0,
-                max: 23,
-                reversed: true
-            },
+                    subtitle: {
+                        useHTML: true,
+                        text: 'Source: <a href="https://ourworldindata.org/vaccination" target="_blank">Our World in Data</a>',
+                        align: 'left',
+                        y: 15,
+                        style: {
+                            fontSize: '10px'
+                        }
+                    },
 
-            colorAxis: {
-                stops: [
-                    [0, '#3060cf'],
-                    [0.5, '#fffbbc'],
-                    [0.9, '#c4463a'],
-                    [1, '#c4463a']
-                ],
-                min: -15,
-                max: 25,
-                startOnTick: false,
-                endOnTick: false,
-                labels: {
-                    format: '{value}℃'
-                }
-            },
+                    xAxis: [
+                        {
+                            min: 1929,
+                            title: {
+                                text: ''
+                            },
+                            tickInterval: 10,
+                            plotLines: [{
+                                color: '#000',
+                                dashStyle: 'dash',
+                                width: 2,
+                                value: 1963,
+                                zIndex: 5,
+                                label: {
+                                    useHTML: true,
+                                    rotation: -15,
+                                    text:
+                                    'First vaccine',
+                                    align: 'left',
+                                    y: -6,
+                                    x: 0,
+                                    style: {
+                                        // eslint-disable-next-line max-len
+                                        color: 'var(--highcharts-neutral-color-80)',
+                                        fontSize: '11px'
+                                    }
+                                }
+                            }, {
+                                color: '#000',
+                                dashStyle: 'dash',
+                                width: 2,
+                                value: 1971,
+                                zIndex: 5,
+                                label: {
+                                    useHTML: true,
+                                    text:
+                                    'First MMR vaccine',
+                                    rotation: -15,
+                                    align: 'left',
+                                    y: -2,
+                                    x: 0,
+                                    style: {
+                                        // eslint-disable-next-line max-len
+                                        color: 'var(--highcharts-neutral-color-80)',
+                                        fontSize: '11px'
+                                    }
+                                }
+                            },
+                            {
+                                color: '#000',
+                                dashStyle: 'dash',
+                                width: 2,
+                                value: 1980,
+                                zIndex: 5,
+                                label: {
+                                    useHTML: true,
+                                    // eslint-disable-next-line max-len
+                                    text: 'Required for kindergarten',
+                                    align: 'left',
+                                    rotation: -15,
+                                    y: -2,
+                                    x: 5,
+                                    style: {
+                                        // eslint-disable-next-line max-len
+                                        color: 'var(--highcharts-neutral-color-80)',
+                                        fontSize: '11px'
+                                    }
+                                }
+                            }
+                            ]
+                        }
+                    ],
 
-            series: [{
-                boostThreshold: 100,
-                borderWidth: 0,
-                nullColor: '#EFEFEF',
-                colsize: 24 * 36e5, // one day
-                tooltip: {
-                    headerFormat: 'Temperature<br/>',
-                    // eslint-disable-next-line max-len
-                    pointFormat: '{point.x:%e %b, %Y} {point.y}:00: <b>{point.value} ' +
-                '℃</b>'
-                }
-            }]
+                    yAxis: [
+                        {
+                            categories: countries,
+                            visible: true,
+                            title: {
+                                text: null
+                            },
+                            labels: {
+                                step: 2,
+                                style: {
+                                    color: 'var(--highcharts-neutral-color-40)'
+                                }
 
+                            },
+                            reversed: true,
+                            startOnTick: false,
+                            endOnTick: false
+                        }
+                    ],
+
+                    legend: {
+                        enabled: true,
+                        align: 'right',
+                        layout: 'vertical',
+                        verticalAlign: 'top',
+                        y: 60
+                    },
+
+                    colorAxis: {
+                        min: 0,
+                        max: 3,
+                        title: {
+                            rotation: 90,
+                            text: 'Cases per 100,000 (log scale)',
+                            style: {
+                                fontSize: '10px'
+                            }
+                        },
+                        tickPositions: [
+                            Math.log10(1),
+                            Math.log10(2),
+                            Math.log10(4),
+                            Math.log10(11),
+                            Math.log10(31),
+                            Math.log10(101),
+                            Math.log10(301),
+                            Math.log10(1001)
+
+                        ],
+                        height: '70%',
+                        stops: [
+                            [0, '#FEF3C7'],
+                            [0.25, '#FDE68A'],
+                            [0.5, '#A7F3D0'],
+                            [0.75, '#34D399'],
+                            [1, '#10B981']
+                        ],
+                        labels: {
+                            formatter: function () {
+                                return Highcharts.numberFormat(
+                                    Math.pow(10, this.value) - 1,
+                                    0
+                                );
+                            }
+                        }
+                    },
+                    tooltip: {
+                        useHTML: true,
+                        outside: true,
+                        formatter: function () {
+                            return (
+                                '<b>' + countries[this.point.y] + '</b><br/>' +
+                                'Year: ' + this.point.x + '<br/>' +
+                                'Case rate: <b>' +
+                                Highcharts.numberFormat(this.point.rawRate, 2) +
+                                '</b> per 100,000'
+                            );
+                        }
+                    },
+
+                    series: [
+                        {
+                            name: 'Measles rate',
+                            data: data,
+                            borderWidth: 0,
+                            nullColor: '#ffffff',
+                            colsize: 1
+                        }
+                    ]
+                });
+            }
         });
-
     })();
 }
 
@@ -1778,9 +1910,9 @@ const charts = {
     heatmap: {
         run: heatmap,
         demoCardLabel: 'Highcharts Heatmap demo',
-        demoName: 'Large Heatmap',
+        demoName: 'Heatmap',
         // eslint-disable-next-line max-len
-        demoDescription: 'The demo uses 8,000 points to visualize the temperature over a year.',
+        demoDescription: 'Heatmaps visualize hot spots within data sets, and to show patterns or correlations.',
         chartDescription: `A purely decorative chart demonstrating 
        the use of the heatmap series type.`,
         madeWith: ['core']

--- a/samples/highcharts/website/industry-healthcare-demos/demo.js
+++ b/samples/highcharts/website/industry-healthcare-demos/demo.js
@@ -1236,7 +1236,7 @@ function heatmap() {
 
                     subtitle: {
                         useHTML: true,
-                        text: 'Source: <a href="https://ourworldindata.org/vaccination" target="_blank">Our World in Data</a>',
+                        text: 'Source: <a href="https://ourworldindata.org/vaccination" target="_blank" rel="noopener noreferrer">Our World in Data</a>',
                         align: 'left',
                         y: 15,
                         style: {
@@ -1347,7 +1347,7 @@ function heatmap() {
 
                     colorAxis: {
                         min: 0,
-                        max: 3,
+                        max: Math.log10(1001),
                         title: {
                             rotation: 90,
                             text: 'Cases per 100,000 (log scale)',

--- a/samples/highcharts/website/industry-software-demos/demo.details
+++ b/samples/highcharts/website/industry-software-demos/demo.details
@@ -3,5 +3,6 @@
  authors:
    - Nancy Dillon
  requiresManualTesting: true
+ applyCSP: false
  js_wrap: b
 ...

--- a/samples/highcharts/website/industry-software-demos/demo.js
+++ b/samples/highcharts/website/industry-software-demos/demo.js
@@ -153,12 +153,6 @@ function hero() {
             enabled: false
         },
         columns: [{
-            id: 'instanceId',
-            header: {
-                format: 'Instance ID'
-            },
-            width: 120
-        }, {
             id: 'running',
             header: {
                 format: 'Status'
@@ -242,12 +236,6 @@ function hero() {
                     }
                 }
             }
-        }, {
-            id: 'publicIP',
-            header: {
-                format: 'Public IP'
-            },
-            width: 150
         }, {
             id: 'diskOperationsIn',
             header: {
@@ -1595,7 +1583,7 @@ function activity() {
 
     (async () => {
         const weeks = await fetch(
-            'https://cdn.jsdelivr.net/gh/highcharts/highcharts@4dc715c/samples/data/github-commit-activity.json'
+            'https://cdn.jsdelivr.net/gh/highcharts/highcharts@35bdee444990708fba78f8eec2bc72b9f0a6c81e/samples/data/github-commit-activity.json'
 
 
         ).then(res => res.json());


### PR DESCRIPTION
Hi, here are some fixes for the industry page demos:

- fixed the height of the variable pie (the gold chart) so it's no longer cut off
- created the heatmap demo using the measles vaccine data
- fixed the column issue on the sparklines grid

The issue where the dashboards are cut off will be fixed by the web team since it's an html issue.