### PR TITLE
enhancement/24313-dark-gray-canvas-esri-tiledwebmap

### DIFF
--- a/docs/maps/tiledwebmap.md
+++ b/docs/maps/tiledwebmap.md
@@ -80,7 +80,7 @@ Available providers
     Available properties:
 
     ```js
-    theme: ‘WorldStreetMap’, ‘DeLorme’, ‘WorldTopoMap’, ‘WorldImagery’, ‘WorldTerrain’, ‘WorldShadedRelief’, ‘WorldPhysical’, ‘NatGeoWorldMap’, ‘WorldGrayCanvas’
+    theme: ‘WorldStreetMap’, ‘DeLorme’, ‘WorldTopoMap’, ‘WorldImagery’, ‘WorldTerrain’, ‘WorldShadedRelief’, ‘WorldPhysical’, ‘NatGeoWorldMap’, ‘WorldGrayCanvas’, ’WorldDarkGrayCanvas’
     ```
 * `Stamen`
 

--- a/ts/Maps/TilesProviders/Esri.ts
+++ b/ts/Maps/TilesProviders/Esri.ts
@@ -112,6 +112,12 @@ class Esri implements ProviderDefinition {
             minZoom: 0,
             maxZoom: 16,
             credits: 'Tiles &copy; Esri &mdash; Esri, DeLorme, NAVTEQ'
+        },
+        WorldDarkGrayCanvas: {
+            url: 'https://server.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/{z}/{y}/{x}',
+            minZoom: 0,
+            maxZoom: 16,
+            credits: 'Tiles &copy; Esri &mdash; Esri, DeLorme, NAVTEQ'
         }
     };
 


### PR DESCRIPTION
Added new theme `WorldDarkGrayCanvas` to TiledWebMap Esri provider, closes #24313.