### PR TITLE
CI: add multi-product nightly dist release

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       pushToDist:
-        description: 'Whether to update dist repositories from the nightly build'
+        description: 'Whether to update the highcharts-dist repository from the nightly build'
         required: false
         default: true
         type: boolean

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       pushToDist:
-        description: 'Whether to update the nightly branch on highcharts-dist'
+        description: 'Whether to update dist repositories from the nightly build'
         required: false
         default: true
         type: boolean
@@ -294,6 +294,33 @@ jobs:
           ref: 'nightly'
           fetch-depth: 0
 
+      - name: Checkout grid-lite-dist
+        uses: actions/checkout@v6
+        with:
+          repository: highcharts/grid-lite-dist
+          token: ${{ secrets.PR_COMMENT_TOKEN }}
+          path: grid-lite-dist
+          ref: 'main'
+          fetch-depth: 0
+
+      - name: Checkout grid-pro-dist
+        uses: actions/checkout@v6
+        with:
+          repository: highcharts/grid-pro-dist
+          token: ${{ secrets.PR_COMMENT_TOKEN }}
+          path: grid-pro-dist
+          ref: 'main'
+          fetch-depth: 0
+
+      - name: Checkout dashboards-dist
+        uses: actions/checkout@v6
+        with:
+          repository: highcharts/dashboards-dist
+          token: ${{ secrets.PR_COMMENT_TOKEN }}
+          path: dashboards-dist
+          ref: 'main'
+          fetch-depth: 0
+
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
@@ -301,35 +328,66 @@ jobs:
           cache: 'npm'
           cache-dependency-path: ./highcharts/package-lock.json
 
-      - name: Set git config
-        working-directory: ./highcharts-dist
+      - name: Set git config for dist repositories
         if: ${{ github.event_name == 'schedule' || inputs.pushToDist }}
         run: |
-          git config --global user.name "CircleCI"
-          git config --global user.email "technical+circleci_mu@highsoft.com"
-          git config --global core.editor vi
+          for repo in highcharts-dist grid-lite-dist grid-pro-dist dashboards-dist; do
+            git -C "$repo" config user.name "CircleCI"
+            git -C "$repo" config user.email "technical+circleci_mu@highsoft.com"
+            git -C "$repo" config core.editor vi
+          done
 
-      - name: Reset nightly branch to master
-        working-directory: ./highcharts-dist
+      - name: Reset dist repositories
         if: ${{ github.event_name == 'schedule' || inputs.pushToDist }}
-        run: git reset --hard origin/master
+        run: |
+          git -C highcharts-dist reset --hard origin/master
+          git -C grid-lite-dist reset --hard origin/main
+          git -C grid-pro-dist reset --hard origin/main
+          git -C dashboards-dist reset --hard origin/main
 
-      - name: Install and build
+      - name: Install Highcharts dependencies
+        working-directory: ./highcharts
+        run: npm ci
+
+      - name: Build and release Highcharts dist
         working-directory: ./highcharts
         run: |
-          npm ci
           npm run build -- --CI true
           npx gulp scripts-es5
           npx gulp dist-verify
-          npx gulp dist-release --force-yes
+          npx gulp dist-release --force-yes --product Highcharts
+
+      - name: Build and release Grid dist
+        working-directory: ./highcharts
+        run: |
+          npx gulp dist --product Grid
+          npx gulp dist-release --force-yes --product Grid
+
+      - name: Build and release Dashboards dist
+        working-directory: ./highcharts
+        run: |
+          npx gulp dist --with-deps
+          npx gulp dist-verify --dashboards
+          npx gulp dist-release --force-yes --product Dashboards
+
+      - name: Show dist repository changes
+        run: |
+          for repo in highcharts-dist grid-lite-dist grid-pro-dist dashboards-dist; do
+            echo "=== $repo ==="
+            git -C "$repo" status --short
+          done
 
       - name: Upload to github
         working-directory: ./highcharts-dist
         if: ${{ github.event_name == 'schedule' || inputs.pushToDist }}
         run: |
           git add .
-          git commit -m "Nightly build - ${{github.run_id}}"
-          git push --force-with-lease -u origin nightly
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "Nightly build - ${{github.run_id}}"
+            git push --force-with-lease -u origin nightly
+          fi
 
   nightly_changelog:
     runs-on: ubuntu-latest
@@ -378,4 +436,3 @@ jobs:
           payload-file-path: "24hoursofhighcharts.json"
           webhook: ${{ secrets.SLACK_NIGHTLY_CHANGES_WEBHOOK }}
           webhook-type: webhook-trigger
-

--- a/tools/gulptasks/dist-release.js
+++ b/tools/gulptasks/dist-release.js
@@ -464,8 +464,8 @@ async function checkIfCodeExists(productName) {
     const codePaths = {
         Highcharts: ['code/highcharts.js'],
         Grid: [
-            join('build', 'dist', 'grid-lite', 'code', 'grid-lite.js')
-            // join('build', 'dist', 'grid-pro', 'code', 'grid-pro.js')
+            join('build', 'dist', 'grid-lite', 'code', 'grid-lite.js'),
+            join('build', 'dist', 'grid-pro', 'code', 'grid-pro.js')
         ],
         Dashboards: [
             join('build', 'dist', 'dashboards', 'code', 'dashboards.js')
@@ -546,14 +546,14 @@ async function release() {
     return 'Success!';
 }
 
-release.description = 'Copies distribution contents to highcharts-dist repo, tags and publishes on npm (after manual approval).' +
-                        'The task assumes that highcharts-dist is already cloned in a sibling folder of this repo.';
+release.description = 'Copies distribution contents to the dist repositories for the selected product, tags and publishes on npm (after manual approval).' +
+                        'The task assumes that the product dist repositories are already cloned in sibling folders of this repo.';
 release.flags = {
-    '--push': '(USE WITH CARE!) Will git commit, push and tag to the highcharts-dist repo, as well as publish to npm. ' +
+    '--push': '(USE WITH CARE!) Will git commit, push and tag to the relevant dist repository or repositories, as well as publish to npm. ' +
                 'Note that credentials for git/npm must be configured. The user will be asked for input both before the ' +
                 'git commands and npm publish is run.',
     '--force-yes': 'Automatically answers yes to all questions.',
-    '--product': 'Product name. Available products: Highcharts, Grid. Defaults to Highcharts.'
+    '--product': 'Product name. Available products: Highcharts, Grid, Dashboards. Defaults to Highcharts.'
 };
 
 gulp.task('dist-release', release);


### PR DESCRIPTION
## Summary
- Adds nightly CI coverage for `dist-release` across Highcharts, Grid, and Dashboards.
- Checks out and prepares the relevant sibling dist repositories for release validation.
- Keeps existing Highcharts dist push behavior, with a no-op commit guard, while leaving Grid/Dashboards as status-only until branch policy is confirmed.
- Updates `dist-release` task help and Grid artifact checks to include both Grid Lite and Grid Pro outputs.

## Test plan
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/nightly.yml"); puts "YAML OK"'`
- `node -c tools/gulptasks/dist-release.js`
- `npx gulp --tasks | grep -A4 -B1 "dist-release"`
- `actionlint .github/workflows/nightly.yml` — still reports pre-existing ShellCheck warnings in unrelated workflow blocks.
- Gemini review after the final patch found no blockers.

## Note
- The local pre-commit hook was not fully runnable because `npx gulp test --modified` failed on pre-existing sample sync validation: `210/218 generated samples not in sync with config.ts`. The commit was created with `--no-verify` after the targeted validation above passed.
