### PR TITLE
Fixed #24626, performance degradation with data-label-heavy charts

### DIFF
--- a/samples/unit-tests/series-treemap/zooming/demo.js
+++ b/samples/unit-tests/series-treemap/zooming/demo.js
@@ -134,3 +134,77 @@ QUnit.test(
         );
     }
 );
+
+QUnit.test(
+    'Traversing treemap should not init data labels per point (#24626)',
+    function (assert) {
+        const data = [
+                { id: 'tech', name: 'Technology' },
+                { id: 'finance', name: 'Finance' }
+            ],
+            pointsCount = 300;
+
+        for (let i = 0; i < pointsCount; i++) {
+            data.push({
+                id: `id-${i}`,
+                name: `Point ${i}`,
+                parent: i % 2 ? 'tech' : 'finance',
+                value: i + 1
+            });
+        }
+
+        const chart = Highcharts.chart('container', {
+                chart: {
+                    animation: false
+                },
+                series: [{
+                    type: 'treemap',
+                    allowTraversingTree: true,
+                    dataLabels: {
+                        animation: false,
+                        defer: false,
+                        enabled: true,
+                        headers: true
+                    },
+                    data
+                }]
+            }),
+            series = chart.series[0],
+            allPointsCount = series.points.length;
+
+        let drawDataLabelsCalls = 0,
+            initDataLabelsCalls = 0;
+
+        const originalDrawDataLabels = series.drawDataLabels,
+            originalInitDataLabels = series.initDataLabels;
+
+        series.drawDataLabels = function () {
+            drawDataLabelsCalls++;
+            return originalDrawDataLabels.apply(this, arguments);
+        };
+
+        series.initDataLabels = function () {
+            initDataLabelsCalls++;
+            return originalInitDataLabels.apply(this, arguments);
+        };
+
+        series.setRootNode('tech');
+        series.setRootNode('');
+        series.setRootNode('finance');
+        series.setRootNode('');
+
+        series.drawDataLabels = originalDrawDataLabels;
+        series.initDataLabels = originalInitDataLabels;
+
+        assert.ok(
+            drawDataLabelsCalls > 0,
+            'Sanity check: traversing should trigger data labels redraw.'
+        );
+
+        assert.ok(
+            initDataLabelsCalls < allPointsCount,
+            'initDataLabels should not scale with number of points on ' +
+            'treemap traversing.'
+        );
+    }
+);

--- a/ts/Core/Series/DataLabel.ts
+++ b/ts/Core/Series/DataLabel.ts
@@ -588,7 +588,7 @@ namespace DataLabel {
             'initDataLabelsGroup',
             {
                 index,
-                zIndex: dataLabelsOptions?.zIndex ?? 6
+                zIndex: dataLabelsOptions?.zIndex
             }
         );
 
@@ -675,10 +675,8 @@ namespace DataLabel {
                 (isString(backgroundColor) && backgroundColor) ||
                 Palette.neutralColor100
             ),
+            groupByIndex: SVGElement[] = [],
             seriesDlOptions = mergedDataLabelOptions(series);
-
-        let pointOptions: Array<DataLabelOptions>,
-            dataLabelsGroup: SVGElement;
 
         // Resolve the animation
         const { animation, defer } = seriesDlOptions[0],
@@ -694,25 +692,22 @@ namespace DataLabel {
             points.forEach((point): void => {
 
                 const dataLabels = point.dataLabels || [],
-                    pointColor = point.color || series.color;
+                    pointColor = point.color || series.color,
 
-                // Merge in series options for the point.
-                // @note dataLabelAttribs (like pointAttribs) would eradicate
-                // the need for dlOptions, and simplify the section below.
-                pointOptions = splat(
-                    mergeArrays(
-                        seriesDlOptions,
-                        // The dlOptions prop is used in treemap
-                        point.dlOptions || point.options?.dataLabels
-                    )
-                );
+                    // Merge in series options for the point.
+                    // @note
+                    // dataLabelAttribs (like pointAttribs) would eradicate the
+                    // need for dlOptions, and simplify the section below.
+                    pointOptions = splat(
+                        mergeArrays(
+                            seriesDlOptions,
+                            // The dlOptions prop is used in treemap
+                            point.dlOptions || point.options?.dataLabels
+                        )
+                    );
 
                 // Handle each individual data label for this point
                 pointOptions.forEach((labelOptions, i): void => {
-                    // Create dataLabelsGroup for each data labels config
-                    // (can be multiple)
-                    dataLabelsGroup =
-                        this.initDataLabels(i, animationConfig, labelOptions);
 
                     // Options for one dataLabel
                     const labelEnabled = (
@@ -919,6 +914,16 @@ namespace DataLabel {
                                 dataLabel,
                                 'beforeAddingDataLabel',
                                 { labelOptions, point }
+                            );
+
+                            // On the first occurrence, create a dataLabelsGroup
+                            // for each data labels config (#24626)
+                            const dataLabelsGroup = groupByIndex[i] = (
+                                groupByIndex[i] || this.initDataLabels(
+                                    i,
+                                    animationConfig,
+                                    labelOptions
+                                )
                             );
 
                             if (!dataLabel.added) {

--- a/ts/Extensions/NonCartesianSeriesZoom/NonCartesianSeriesZoom.ts
+++ b/ts/Extensions/NonCartesianSeriesZoom/NonCartesianSeriesZoom.ts
@@ -433,7 +433,7 @@ function onAfterSetChartSize(
  */
 function onInitDataLabelsGroup(
     this: Series,
-    { index, zIndex }: { index: number, zIndex: number }
+    { index, zIndex = 6 }: { index: number, zIndex?: number }
 ): void {
     if (this.hasDataLabels?.()) {
         this.dataLabelsParentGroups ||= [];


### PR DESCRIPTION
Fixed #24626, performance degradation with data-label-heavy charts, primarily the treemap demo in Safari