### PR TITLE
bugfix/axis-labels-align-rotation-margin

### DIFF
--- a/samples/unit-tests/axis/labels/demo.js
+++ b/samples/unit-tests/axis/labels/demo.js
@@ -1114,6 +1114,54 @@ QUnit.test('Label reserve space', function (assert) {
         unrotatedPlotLeft >= chart.plotLeft,
         'Long rotated label should not increase the plot left margin (#23527).'
     );
+
+    chart.update({
+        yAxis: {
+            lineWidth: 1,
+            labels: {
+                align: 'left',
+                rotation: 0,
+                format: 'Label'
+            }
+        }
+    });
+
+    const plotLeft = chart.plotLeft;
+    chart.update({
+        yAxis: {
+            labels: {
+                rotation: 45
+            }
+        }
+    });
+    assert.strictEqual(
+        chart.plotLeft,
+        plotLeft,
+        'chart.plotLeft should not change when rotating labels with align left.'
+    );
+    chart.update({
+        yAxis: {
+            opposite: true,
+            labels: {
+                rotation: 0,
+                align: 'right'
+            }
+        }
+    });
+    const plotWidth = chart.plotWidth;
+    chart.update({
+        yAxis: {
+            labels: {
+                rotation: 45
+            }
+        }
+    });
+    assert.strictEqual(
+        chart.plotWidth,
+        plotWidth,
+        `chart.plotWidth should not change when rotating labels with align right
+        on opposite y-axis.`
+    );
 });
 
 QUnit.test('Label ellipsis', function (assert) {

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -3781,6 +3781,7 @@ class Axis {
 
         let tickRotCorr = axis.tickRotCorr || { x: 0, y: 0 },
             absTickRotCorrX = 0,
+            skipRotationMarginCorr,
             showAxis,
             titleOffset = 0,
             titleOffsetOption,
@@ -3807,6 +3808,10 @@ class Axis {
             axis.renderUnsquish();
             tickRotCorr = axis.tickRotCorr;
             absTickRotCorrX = Math.abs(tickRotCorr.x);
+            skipRotationMarginCorr = !horiz && (
+                (side === 3 && labelOptions.align === 'left') ||
+                (side === 1 && labelOptions.align === 'right')
+            );
 
             // Left side must be align: right and right side must
             // have align: left for labels
@@ -3834,7 +3839,11 @@ class Axis {
             if (axis.staggerLines) {
                 labelOffset *= axis.staggerLines;
             }
-            if (!horiz && isNumber(axis.labelRotation)) {
+            if (
+                !horiz &&
+                isNumber(axis.labelRotation) &&
+                !skipRotationMarginCorr
+            ) {
                 labelOffset -= absTickRotCorrX;
             }
             axis.labelOffset = labelOffset * (axis.opposite ? -1 : 1);
@@ -3897,14 +3906,18 @@ class Axis {
                     ) :
                     pick(
                         labelOptions.x,
-                        directionFactor * (
-                            labelOptions.distance - absTickRotCorrX
-                        )
+                        skipRotationMarginCorr ?
+                            tickRotCorr.x +
+                            directionFactor * labelOptions.distance :
+                            directionFactor * (
+                                labelOptions.distance - absTickRotCorrX
+                            )
                     )
             );
 
             if (
                 !horiz &&
+                !skipRotationMarginCorr &&
                 axis.labelAlign === 'center' &&
                 isNumber(axis.labelRotation)
             ) {

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -3787,7 +3787,8 @@ class Axis {
             titleMargin = 0,
             labelOffset = 0, // Reset
             labelOffsetPadded,
-            lineHeightCorrection;
+            lineHeightCorrection,
+            reserveSpaceDefault: boolean|undefined;
 
         // For reuse in Axis.render
         axis.showAxis = showAxis = hasData || options.showEmpty;
@@ -3810,17 +3811,17 @@ class Axis {
 
             // Left side must be align: right and right side must
             // have align: left for labels
-            axis.reserveSpaceDefault = (
+            reserveSpaceDefault = axis.reserveSpaceDefault = (
                 side === 0 ||
                 side === 2 ||
-                ({ 1: 'left', 3: 'right' } as any)[side] === axis.labelAlign
+                ({ 1: 'left', 3: 'right' })[side] === axis.labelAlign
             );
-            if (pick(
-                labelOptions.reserveSpace,
-                hasCrossing ? false : null,
-                axis.labelAlign === 'center' ? true : null,
-                axis.reserveSpaceDefault
-            )) {
+            if (
+                labelOptions.reserveSpace ??
+                (hasCrossing ? false : null) ??
+                (axis.labelAlign === 'center' ? true : null) ??
+                reserveSpaceDefault
+            ) {
                 tickPositions.forEach(function (pos: number): void {
                     // Get the highest offset
                     labelOffset = Math.max(
@@ -3837,7 +3838,7 @@ class Axis {
             if (
                 !horiz &&
                 isNumber(axis.labelRotation) &&
-                axis.reserveSpaceDefault
+                reserveSpaceDefault
             ) {
                 labelOffset -= absTickRotCorrX;
             }
@@ -3895,24 +3896,28 @@ class Axis {
             labelOffsetPadded -= lineHeightCorrection;
             labelOffsetPadded += directionFactor * (
                 horiz ?
-                    pick(
-                        labelOptions.y,
-                        tickRotCorr.y + directionFactor * labelOptions.distance
+                    (
+                        labelOptions.y ??
+                        (
+                            tickRotCorr.y +
+                            directionFactor * labelOptions.distance
+                        )
                     ) :
-                    pick(
-                        labelOptions.x,
-                        !axis.reserveSpaceDefault ?
-                            tickRotCorr.x +
-                            directionFactor * labelOptions.distance :
-                            directionFactor * (
-                                labelOptions.distance - absTickRotCorrX
-                            )
+                    (
+                        labelOptions.x ?? (
+                            reserveSpaceDefault ?
+                                directionFactor * (
+                                    labelOptions.distance - absTickRotCorrX
+                                ) :
+                                tickRotCorr.x +
+                                    directionFactor * labelOptions.distance
+                        )
                     )
             );
 
             if (
                 !horiz &&
-                !axis.reserveSpaceDefault &&
+                !reserveSpaceDefault &&
                 axis.labelAlign === 'center' &&
                 isNumber(axis.labelRotation)
             ) {
@@ -3920,14 +3925,12 @@ class Axis {
             }
         }
 
-        axis.axisTitleMargin = pick(titleOffsetOption, labelOffsetPadded);
+        axis.axisTitleMargin = titleOffsetOption ?? labelOffsetPadded;
 
-        if (axis.getMaxLabelDimensions) {
-            axis.maxLabelDimensions = axis.getMaxLabelDimensions(
-                ticks,
-                tickPositions
-            );
-        }
+        axis.maxLabelDimensions = axis.getMaxLabelDimensions?.(
+            ticks,
+            tickPositions
+        );
 
         // Due to GridAxis.tickSize, tickSize should be calculated after ticks
         // has rendered.

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -3781,7 +3781,6 @@ class Axis {
 
         let tickRotCorr = axis.tickRotCorr || { x: 0, y: 0 },
             absTickRotCorrX = 0,
-            skipRotationMarginCorr,
             showAxis,
             titleOffset = 0,
             titleOffsetOption,
@@ -3808,10 +3807,6 @@ class Axis {
             axis.renderUnsquish();
             tickRotCorr = axis.tickRotCorr;
             absTickRotCorrX = Math.abs(tickRotCorr.x);
-            skipRotationMarginCorr = !horiz && (
-                (side === 3 && labelOptions.align === 'left') ||
-                (side === 1 && labelOptions.align === 'right')
-            );
 
             // Left side must be align: right and right side must
             // have align: left for labels
@@ -3842,7 +3837,7 @@ class Axis {
             if (
                 !horiz &&
                 isNumber(axis.labelRotation) &&
-                !skipRotationMarginCorr
+                axis.reserveSpaceDefault
             ) {
                 labelOffset -= absTickRotCorrX;
             }
@@ -3906,7 +3901,7 @@ class Axis {
                     ) :
                     pick(
                         labelOptions.x,
-                        skipRotationMarginCorr ?
+                        !axis.reserveSpaceDefault ?
                             tickRotCorr.x +
                             directionFactor * labelOptions.distance :
                             directionFactor * (
@@ -3917,7 +3912,7 @@ class Axis {
 
             if (
                 !horiz &&
-                !skipRotationMarginCorr &&
+                !axis.reserveSpaceDefault &&
                 axis.labelAlign === 'center' &&
                 isNumber(axis.labelRotation)
             ) {


### PR DESCRIPTION
Fixed regression from #24415. Rotating y-axis labels should not move the axis line when align left/right is set.

Left yAxis labels rotation should not change chart.plotLeft when `align: 'left'` is set.
Right yAxis labels rotation should not change chart.plotWidth when `align: 'right'` is set.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214845524968719