### PR TITLE
bugfix/24544-zones-clipped-at-axis-max

### DIFF
--- a/samples/unit-tests/series/zones/demo.js
+++ b/samples/unit-tests/series/zones/demo.js
@@ -352,6 +352,40 @@ QUnit.test('Adding and removing zones', function (assert) {
         'Series line should be hidden after adding zones back (#10569).'
     );
 
+    chart.update({
+        yAxis: {
+            min: -10,
+            max: 5
+        },
+        series: [
+            {
+                data: [
+                    -10, -5, 0, 5, 5, 5, 5, 5, 5, 0, -5, -10, -10,
+                    -10, -5
+                ],
+                dashStyle: 'Dash',
+                zones: [
+                    {
+                        value: 4.9,
+                        dashStyle: 'Solid'
+                    }
+                ]
+            }
+        ]
+    });
+
+    const maxPoint = chart.series[0].points[3],
+        maxClip = chart.series[0].zones[1].lineClip.find(
+            clip => clip[1] === maxPoint.plotX
+        ),
+        halfWidth = chart.series[0].graph.strokeWidth() / 2 + 1;
+
+    assert.deepEqual(
+        maxClip,
+        ['L', maxPoint.plotX, maxPoint.plotY - halfWidth],
+        'Clip path should not clip a line drawn at axis max, #24544.'
+    );
+
     const clip = chart.series[0].zones[0].clip;
     chart.series[0].destroy();
 

--- a/samples/unit-tests/series/zones/demo.js
+++ b/samples/unit-tests/series/zones/demo.js
@@ -354,36 +354,57 @@ QUnit.test('Adding and removing zones', function (assert) {
 
     chart.update({
         yAxis: {
-            min: -10,
-            max: 5
+            min: -15,
+            max: 20
         },
         series: [
             {
                 data: [
-                    -10, -5, 0, 5, 5, 5, 5, 5, 5, 0, -5, -10, -10,
-                    -10, -5
+                    -10, -5, 0, 5, 10, 20, 10, 10, 5, 0, -5, -10,
+                    -10, -10, -5
                 ],
                 dashStyle: 'Dash',
                 zones: [
                     {
-                        value: 4.9,
-                        dashStyle: 'Solid'
+                        value: 0,
+                        color: '#f7a35c'
+                    },
+                    {
+                        value: 10,
+                        color: '#7cb5ec'
+                    },
+                    {
+                        value: 19.9,
+                        color: '#90ed7d'
                     }
                 ]
             }
         ]
     });
 
-    const maxPoint = chart.series[0].points[3],
-        maxClip = chart.series[0].zones[1].lineClip.find(
+    const maxPoint = chart.series[0].points[5],
+        maxClip = chart.series[0].zones[3].lineClip.find(
             clip => clip[1] === maxPoint.plotX
         ),
-        halfWidth = chart.series[0].graph.strokeWidth() / 2 + 1;
+        maxHalfWidth = chart.series[0].graph.strokeWidth() / 2 + 1;
 
     assert.deepEqual(
         maxClip,
-        ['L', maxPoint.plotX, maxPoint.plotY - halfWidth],
+        ['L', maxPoint.plotX, maxPoint.plotY - maxHalfWidth],
         'Clip path should not clip a line drawn at axis max, #24544.'
+    );
+
+    const boundaryPoint = chart.series[0].points[6],
+        boundaryClip = chart.series[0].zones[1].lineClip.find(
+            clip => clip[1] === boundaryPoint.plotX
+        ),
+        boundaryHalfWidth = chart.series[0].graph.strokeWidth() / 2 + 1;
+
+    assert.deepEqual(
+        boundaryClip,
+        ['L', boundaryPoint.plotX, boundaryPoint.plotY + boundaryHalfWidth],
+        'Clip path should preserve horizontal lines on internal zone ' +
+        'boundaries.'
     );
 
     const clip = chart.series[0].zones[0].clip;

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -3293,14 +3293,19 @@ class Series {
                 if (inverted) {
                     plotY = len - plotY;
                 }
-                const { translated = 0, lineClip } = zone,
+                const { translated = 0, lineClip, value } = zone,
                     distance = plotY - translated;
 
                 lineClip?.push([
                     'L',
                     plotX,
                     Math.abs(distance) < halfWidth ?
-                        plotY - halfWidth * (distance < 0 ? -1 : 1) :
+                        plotY - halfWidth * (
+                            distance < 0 ||
+                            (distance === 0 && defined(value)) ?
+                                -1 :
+                                1
+                        ) :
                         translated
                 ]);
             };

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -3300,7 +3300,7 @@ class Series {
                     'L',
                     plotX,
                     Math.abs(distance) < halfWidth ?
-                        plotY - halfWidth * (distance <= 0 ? -1 : 1) :
+                        plotY - halfWidth * (distance < 0 ? -1 : 1) :
                         translated
                 ]);
             };


### PR DESCRIPTION
Fixed #24544, regression with zones set below max value and axis max set, line on max was clipped.