### PR TITLE
bugfix/20412-setdata-ignore-nulls

### DIFF
--- a/samples/unit-tests/point/point-update/demo.js
+++ b/samples/unit-tests/point/point-update/demo.js
@@ -264,7 +264,7 @@ QUnit.test(
 QUnit.test(
     'Preserve point config initial array type in options.data',
     function (assert) {
-        var chart = $('#container')
+        const chart = $('#container')
             .highcharts({
                 accessibility: {
                     enabled: false // Forces markers
@@ -368,6 +368,15 @@ QUnit.test(
             [2, 4, 6],
             '#15117: pointStart/pointInterval should work with turboed ' +
                 'pointArrayMap series'
+        );
+
+        chart.series[0].setData([3, null, 1]);
+
+        assert.deepEqual(
+            chart.series[0].getColumn('y'),
+            chart.options.series[0].data,
+            'Values of null should be reflected correctly in' +
+            'options.series.data after setData call (#20412).'
         );
 
         Highcharts.Series.types.line.prototype.pointArrayMap = map;

--- a/samples/unit-tests/point/point-update/demo.js
+++ b/samples/unit-tests/point/point-update/demo.js
@@ -264,23 +264,21 @@ QUnit.test(
 QUnit.test(
     'Preserve point config initial array type in options.data',
     function (assert) {
-        const chart = $('#container')
-            .highcharts({
-                accessibility: {
-                    enabled: false // Forces markers
-                },
-                series: [
-                    {
-                        data: [
-                            [0, 1],
-                            [1, 2],
-                            [2, 3]
-                        ],
-                        turboThreshold: 2
-                    }
-                ]
-            })
-            .highcharts();
+        const chart = Highcharts.chart('container', {
+            accessibility: {
+                enabled: false // Forces markers
+            },
+            series: [
+                {
+                    data: [
+                        [0, 1],
+                        [1, 2],
+                        [2, 3]
+                    ],
+                    turboThreshold: 2
+                }
+            ]
+        });
 
         assert.strictEqual(
             chart.series[0].options.data

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -1368,7 +1368,7 @@ class Point {
             if (data && !series.processedData) {
                 data[i] = (isObject(data[i], true) || isObject(options, true)) ?
                     point.options :
-                    (options ?? data[i]);
+                    (options === void 0 ? data[i] : options); // #20412
             }
 
             // Redraw


### PR DESCRIPTION
Fixed #20412, exported charts did not have correct data after updating it with `null` values.