### PR TITLE
fix: guard Point.getZone() against series without zones

### DIFF
--- a/samples/unit-tests/series/zones/demo.js
+++ b/samples/unit-tests/series/zones/demo.js
@@ -124,6 +124,20 @@ QUnit.test('Point colors within color zones(#4430)', function (assert) {
     );
 });
 
+QUnit.test('Point.getZone without zones (#24633)', function (assert) {
+    const chart = Highcharts.chart('container', {
+        series: [{
+            data: [1]
+        }]
+    });
+
+    assert.strictEqual(
+        chart.series[0].data[0].getZone(),
+        void 0,
+        'Point.getZone should return undefined when no zones are defined.'
+    );
+});
+
 // Highcharts 4.1.1, Issue #3898
 // negativeColor not rendered correctly when threshold is out of range
 QUnit.test('Spline zones out of range', function (assert) {

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -951,6 +951,10 @@ class Point {
             i = 0;
 
         zone = zones[i];
+        if (!zones.length) {
+            return zone;
+        }
+
         while ((this as any)[zoneAxis] >= (zone.value as any)) {
             zone = zones[++i];
         }


### PR DESCRIPTION
## Summary

`Point.getZone()` walks `series.zones` to find the active zone for a point. If a series has no zones configured, the lookup walked into undefined and the reproducer in #24633 threw. Adds a single-line guard that short-circuits when zones is missing or empty so the method returns the default zone rather than throwing.

## Why this matters

The bug fires in real configs that mix zone-aware and non-zone-aware series in the same chart: any code path that calls `getZone()` indirectly (tooltip rendering, point coloring) breaks for the non-zone series. Reproducible from the JSFiddle linked on #24633.

## Changes

- `ts/Core/Series/Point.ts` - guard `getZone()` when `series.zones` is empty/missing.
- `samples/unit-tests/series/zones/demo.js` - add a unit test that constructs a chart with a zone-less series and confirms `getZone()` returns the default zone without throwing.

## Testing

Unit test added covers the no-zones case. Existing zone tests still pass locally.

Fixes #24633
