### PR TITLE
bugfix/24274-viewfullscreen-label

### DIFF
--- a/samples/unit-tests/fullscreen/toggle/demo.details
+++ b/samples/unit-tests/fullscreen/toggle/demo.details
@@ -2,5 +2,4 @@
  resources:
    - https://code.jquery.com/qunit/qunit-2.4.0.js
    - https://code.jquery.com/qunit/qunit-2.4.0.css
- js_wrap: b
 ...

--- a/samples/unit-tests/fullscreen/toggle/demo.details
+++ b/samples/unit-tests/fullscreen/toggle/demo.details
@@ -2,4 +2,5 @@
  resources:
    - https://code.jquery.com/qunit/qunit-2.4.0.js
    - https://code.jquery.com/qunit/qunit-2.4.0.css
+ js_wrap: b
 ...

--- a/samples/unit-tests/fullscreen/toggle/demo.html
+++ b/samples/unit-tests/fullscreen/toggle/demo.html
@@ -1,4 +1,5 @@
 <script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/exporting.js"></script>
 <script src="https://code.highcharts.com/modules/full-screen.js"></script>
 
 

--- a/samples/unit-tests/fullscreen/toggle/demo.js
+++ b/samples/unit-tests/fullscreen/toggle/demo.js
@@ -1,8 +1,36 @@
 // Automated fullscreen tests disabled.
 // See samples\highcharts\members\chart-togglefullscreen-test\test-notes.md
 
+QUnit.test(
+    '#24274, viewFullscreen button label after exiting fullscreen.',
+    function (assert) {
+        const chart = Highcharts.chart('container', {
+            series: [{ data: [1, 2, 3] }]
+        });
+
+        const controller = new TestController(chart),
+            alignAttr = chart.exporting.svgElements[0].alignAttr;
+        controller.click(alignAttr.translateX + 5, alignAttr.translateY + 5);
+
+        chart.fullscreen.isOpen = false;
+        chart.fullscreen.setButtonText();
+
+        const menuItems =
+            chart.options.exporting.buttons.contextButton.menuItems;
+        const buttonElement =
+            chart.exporting.divElements[menuItems.indexOf('viewFullscreen')];
+
+        assert.strictEqual(
+            buttonElement.innerHTML,
+            chart.options.lang.viewFullscreen,
+            '#24274: after exiting fullscreen the viewFullscreen button ' +
+            'label works correctly.'
+        );
+    }
+);
+
 QUnit.skip('Fullscreen module.', function (assert) {
-    var chart = Highcharts.chart('container', {
+    const chart = Highcharts.chart('container', {
         series: [
             {
                 data: [5, 3, 4, 2, 4, 3]

--- a/samples/unit-tests/fullscreen/toggle/demo.js
+++ b/samples/unit-tests/fullscreen/toggle/demo.js
@@ -8,9 +8,7 @@ QUnit.test(
             series: [{ data: [1, 2, 3] }]
         });
 
-        const controller = new TestController(chart),
-            alignAttr = chart.exporting.svgElements[0].alignAttr;
-        controller.click(alignAttr.translateX + 5, alignAttr.translateY + 5);
+        Highcharts.fireEvent(chart.exporting.svgElements[0].element, 'click');
 
         chart.fullscreen.isOpen = false;
         chart.fullscreen.setButtonText();

--- a/ts/Extensions/Exporting/Fullscreen.ts
+++ b/ts/Extensions/Exporting/Fullscreen.ts
@@ -439,7 +439,7 @@ class Fullscreen {
                     !this.isOpen ?
                         (
                             exportingOptions.menuItemDefinitions.viewFullscreen
-                                ?.textKey ||
+                                ?.text ||
                             lang.viewFullscreen
                         ) : lang.exitFullscreen
                 );


### PR DESCRIPTION
Fixed #24274, in the exporting menu, the 'View in fullscreen" label was broken after being used

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213529287818812