### PR TITLE
React sample generation: wrapper mapping + react/<product> output path

### DIFF
--- a/samples/highcharts/react/agents.md
+++ b/samples/highcharts/react/agents.md
@@ -7,7 +7,7 @@ Example import pattern for a simple stock demo:
 ```js
 import { Chart, SeriesLine, Title } from '@highcharts/react';
 import StockChart from '@highcharts/react/Stock';
-import Accessibility from '@highcharts/react/options/Accessibility';
+import Accessibility from '@highcharts/react/modules/Accessibility';
 ```
 
 - Use the `@highcharts/react` package for all React samples.
@@ -15,6 +15,7 @@ import Accessibility from '@highcharts/react/options/Accessibility';
 - `@highcharts/react` exports the core `Chart`, `Series`, `Title`, `Subtitle`, axes, and other components.
 - `@highcharts/react/Stock`, `/Gantt`, and `/Maps` provide the root chart components for the product variants. Import only what the sample needs.
 - Individual series live under `@highcharts/react/series/*` and `@highcharts/react/indicators/*` (for technical indicators). Prefer these imports over generic ones.
-- Highcharts modules or helpers that extend the base library (e.g., accessibility, exporting) live in the `@highcharts/react/options/*` tree. Import them when you need to enable a module explicitly.
-- Always add Accessibility from `@highcharts/react/options/Accessibility` in new samples, unless there is a specific reason not to.
+- Highcharts modules that extend the base library (e.g., accessibility, exporting) live in the `@highcharts/react/modules/*` tree. Available wrappers: `Accessibility`, `Boost`, `BrokenAxis`, `Data`, `DraggablePoints`, `Drilldown`, `Exporting`, `StockTools`. Import them when you need to enable a module explicitly — they handle registration automatically via `getHighcharts()`.
+- For modules without a `@highcharts/react/modules/*` wrapper (e.g. `highcharts-more`, `solid-gauge`), use the `setHighcharts` fallback: import `setHighcharts` from `@highcharts/react`, import the Highcharts instance and the side-effect module from `highcharts/esm/`, then call `setHighcharts(Highcharts)`.
+- Always add Accessibility from `@highcharts/react/modules/Accessibility` in new samples, unless there is a specific reason not to.
 - When using new import paths, make sure `tools/gulptasks/prepare-react-samples.js` maps them to CDN URLs so the generated `.html` preview works. Add entries to the `"imports"` object inside the `<script type="importmap">` block so the new alias resolves when the HTML is produced.

--- a/tools/gulptasks-tests/generate-samples.test.mjs
+++ b/tools/gulptasks-tests/generate-samples.test.mjs
@@ -1,0 +1,77 @@
+import { describe, it } from 'node:test';
+import { strictEqual } from 'node:assert';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { getOutputDir } = require('../gulptasks/generate-samples.js');
+
+describe('getOutputDir', () => {
+
+    describe('classic mode', () => {
+        it('returns the sample dir unchanged', () => {
+            strictEqual(
+                getOutputDir('samples/highcharts/yaxis/labels-distance/config.ts', 'classic'),
+                'highcharts/yaxis/labels-distance'
+            );
+        });
+
+        it('handles top-level (no subdirectory)', () => {
+            strictEqual(
+                getOutputDir('samples/highcharts/basic/config.ts', 'classic'),
+                'highcharts/basic'
+            );
+        });
+
+        it('preserves react segment in path (no stripping in classic mode)', () => {
+            strictEqual(
+                getOutputDir('samples/highcharts/react/basic/config.ts', 'classic'),
+                'highcharts/react/basic'
+            );
+        });
+    });
+
+    describe('react mode — output path is react/<product>/<flattened>', () => {
+        it('non-react source sample', () => {
+            strictEqual(
+                getOutputDir('samples/highcharts/yaxis/labels-distance/config.ts', 'react'),
+                'react/highcharts/yaxis-labels-distance'
+            );
+        });
+
+        it('source sample already under react/ segment is normalized (segment stripped)', () => {
+            strictEqual(
+                getOutputDir('samples/highcharts/react/basic/config.ts', 'react'),
+                'react/highcharts/basic'
+            );
+        });
+
+        it('stock product', () => {
+            strictEqual(
+                getOutputDir('samples/stock/navigator/enabled/config.ts', 'react'),
+                'react/stock/navigator-enabled'
+            );
+        });
+
+        it('maps product', () => {
+            strictEqual(
+                getOutputDir('samples/maps/demo/basic/config.ts', 'react'),
+                'react/maps/demo-basic'
+            );
+        });
+
+        it('gantt product', () => {
+            strictEqual(
+                getOutputDir('samples/gantt/gantt/simple/config.ts', 'react'),
+                'react/gantt/gantt-simple'
+            );
+        });
+
+        it('single-segment path (no subdirectory after product)', () => {
+            strictEqual(
+                getOutputDir('samples/highcharts/basic/config.ts', 'react'),
+                'react/highcharts/basic'
+            );
+        });
+    });
+
+});

--- a/tools/gulptasks/generate-samples.js
+++ b/tools/gulptasks/generate-samples.js
@@ -44,8 +44,8 @@ function getOutputDir(configFile, outputMode) {
     const flattenedPath = normalizedRest.join('-');
 
     return flattenedPath ?
-        `${product}/react/${flattenedPath}` :
-        `${product}/react`;
+        `react/${product}/${flattenedPath}` :
+        `react/${product}`;
 }
 
 /* *
@@ -268,3 +268,5 @@ async function task() {
 }
 
 gulp.task('generate-samples', task);
+
+module.exports = { getOutputDir };

--- a/tools/gulptasks/test.js
+++ b/tools/gulptasks/test.js
@@ -98,8 +98,8 @@ async function checkSamplesConsistency() {
         return path.join(
             process.cwd(),
             'samples',
-            product,
             'react',
+            product,
             flattenedPath
         );
     }

--- a/tools/sample-generator/index.ts
+++ b/tools/sample-generator/index.ts
@@ -40,6 +40,17 @@ import * as selectHandler from './type-handlers/select.ts';
 import * as colorHandler from './type-handlers/color.ts';
 import * as textHandler from './type-handlers/text.ts';
 import * as separatorHandler from './type-handlers/separator.ts';
+const REACT_MODULE_WRAPPERS: Record<string, string> = {
+    'accessibility': 'Accessibility',
+    'boost': 'Boost',
+    'broken-axis': 'BrokenAxis',
+    'data': 'Data',
+    'draggable-points': 'DraggablePoints',
+    'drilldown': 'Drilldown',
+    'exporting': 'Exporting',
+    'stock-tools': 'StockTools'
+};
+
 interface MetaData {
     controlOptions?: ControlOptions;
     path?: string;
@@ -981,8 +992,12 @@ function getReactFactoryConfig(factory: SampleGeneratorConfig['factory'] = 'char
     };
 }
 
-function getReactModuleImports(config: SampleGeneratorConfig): string[] {
-    const moduleImports: string[] = [];
+function getReactModuleImports(config: SampleGeneratorConfig): {
+    sideEffectImports: string[];
+    wrapperImports: string[];
+} {
+    const sideEffectImports: string[] = [];
+    const wrapperImports: string[] = [];
     const modules = config.modules || [];
 
     for (const moduleName of modules) {
@@ -997,16 +1012,26 @@ function getReactModuleImports(config: SampleGeneratorConfig): string[] {
             continue;
         }
 
-        const importPath = normalized.startsWith('esm/') ?
-            `highcharts/${normalized}${normalized.endsWith('.js') ? '' : '.js'}` :
-            `highcharts/esm/${normalized}.src.js`;
+        // Extract the last segment after '/' for wrapper lookup
+        const lastSegment = normalized.split('/').pop() || '';
+        const wrapperName = REACT_MODULE_WRAPPERS[lastSegment];
 
-        if (!moduleImports.includes(importPath)) {
-            moduleImports.push(importPath);
+        if (wrapperName) {
+            if (!wrapperImports.includes(wrapperName)) {
+                wrapperImports.push(wrapperName);
+            }
+        } else {
+            const importPath = normalized.startsWith('esm/') ?
+                `highcharts/${normalized}${normalized.endsWith('.js') ? '' : '.js'}` :
+                `highcharts/esm/${normalized}.src.js`;
+
+            if (!sideEffectImports.includes(importPath)) {
+                sideEffectImports.push(importPath);
+            }
         }
     }
 
-    return moduleImports;
+    return { sideEffectImports, wrapperImports };
 }
 
 // Function to get TS (one listener per path)
@@ -1060,8 +1085,8 @@ export async function getDemoJSX(
         componentName,
         highchartsImportPath
     } = getReactFactoryConfig(factory);
-    const moduleImports = getReactModuleImports(config);
-    const shouldSetupHighcharts = moduleImports.length > 0;
+    const { sideEffectImports, wrapperImports } = getReactModuleImports(config);
+    const shouldSetupHighcharts = sideEffectImports.length > 0;
     const chartOptions = await getChartOptionsLiteral(
         config,
         metaList,
@@ -1082,10 +1107,17 @@ export async function getDemoJSX(
         ];
     const highchartsSetup = shouldSetupHighcharts ? [
         `import Highcharts from '${highchartsImportPath}';`,
-        ...moduleImports.map(moduleImport => `import '${moduleImport}';`),
+        ...sideEffectImports.map(moduleImport => `import '${moduleImport}';`),
         '',
         'setHighcharts(Highcharts);'
     ].join('\n') : '';
+
+    // Add wrapper module imports (e.g. Accessibility, Drilldown)
+    for (const wrapperName of wrapperImports) {
+        reactImports.push(
+            `import ${wrapperName} from '@highcharts/react/modules/${wrapperName}';`
+        );
+    }
 
     const dataStateBlock = dataFile ? [
         '    const [data, setData] = React.useState([]);',
@@ -1108,6 +1140,8 @@ export async function getDemoJSX(
         .replace('__CHART_OPTIONS__', indentBlock(chartOptions, 8).trimStart())
         .replace('__DEPENDENCIES__', dependencies)
         .replace(/__COMPONENT_NAME__/gu, componentName);
+
+    // TODO: render wrapper components (e.g. <Accessibility />) as siblings of chart component once template supports multiple JSX children
 
     return jsx;
 }

--- a/tools/sample-generator/index.ts
+++ b/tools/sample-generator/index.ts
@@ -1112,10 +1112,12 @@ export async function getDemoJSX(
         'setHighcharts(Highcharts);'
     ].join('\n') : '';
 
-    // Add wrapper module imports (e.g. Accessibility, Drilldown)
+    // Add wrapper module imports as side effects.
+    // We do not yet render wrapper JSX components in the template,
+    // so bound imports would be unused and may be tree-shaken.
     for (const wrapperName of wrapperImports) {
         reactImports.push(
-            `import ${wrapperName} from '@highcharts/react/modules/${wrapperName}';`
+            `import '@highcharts/react/modules/${wrapperName}';`
         );
     }
 

--- a/tools/sample-generator/tests/get-demo-jsx.test.ts
+++ b/tools/sample-generator/tests/get-demo-jsx.test.ts
@@ -68,8 +68,8 @@ describe('sample-generator getDemoJSX', () => {
         );
 
         ok(
-            jsx.includes("import Accessibility from '@highcharts/react/modules/Accessibility';"),
-            'should import the Accessibility wrapper component'
+            jsx.includes("import '@highcharts/react/modules/Accessibility';"),
+            'should import Accessibility module wrapper as a side-effect import'
         );
         ok(
             !jsx.includes('setHighcharts('),
@@ -110,8 +110,8 @@ describe('sample-generator getDemoJSX', () => {
         );
 
         ok(
-            jsx.includes("import Accessibility from '@highcharts/react/modules/Accessibility';"),
-            'should import Accessibility wrapper component'
+            jsx.includes("import '@highcharts/react/modules/Accessibility';"),
+            'should import Accessibility module wrapper as a side-effect import'
         );
         ok(
             jsx.includes('setHighcharts(Highcharts);'),

--- a/tools/sample-generator/tests/get-demo-jsx.test.ts
+++ b/tools/sample-generator/tests/get-demo-jsx.test.ts
@@ -57,4 +57,65 @@ describe('sample-generator getDemoJSX', () => {
             'should call setHighcharts when modules are used'
         );
     });
+
+    it('uses @highcharts/react wrapper import for known wrapper modules (no setHighcharts)', async () => {
+        const jsx = await getDemoJSX(
+            {
+                modules: ['modules/accessibility'],
+                output: 'highcharts/react/unit-test/wrapper-module'
+            },
+            metaList
+        );
+
+        ok(
+            jsx.includes("import Accessibility from '@highcharts/react/modules/Accessibility';"),
+            'should import the Accessibility wrapper component'
+        );
+        ok(
+            !jsx.includes('setHighcharts('),
+            'should not call setHighcharts when all modules have wrappers'
+        );
+        ok(
+            !jsx.includes("import { Chart, setHighcharts }"),
+            'should not import setHighcharts from @highcharts/react'
+        );
+    });
+
+    it('uses setHighcharts fallback for modules without wrappers (highcharts-more)', async () => {
+        const jsx = await getDemoJSX(
+            {
+                modules: ['highcharts-more'],
+                output: 'highcharts/react/unit-test/no-wrapper-module'
+            },
+            metaList
+        );
+
+        ok(
+            jsx.includes('setHighcharts(Highcharts);'),
+            'should call setHighcharts for modules without wrappers'
+        );
+        ok(
+            !jsx.includes("@highcharts/react/modules"),
+            'should not use wrapper imports for highcharts-more'
+        );
+    });
+
+    it('supports mixed: wrapper module + non-wrapper module coexist', async () => {
+        const jsx = await getDemoJSX(
+            {
+                modules: ['modules/accessibility', 'highcharts-more'],
+                output: 'highcharts/react/unit-test/mixed-modules'
+            },
+            metaList
+        );
+
+        ok(
+            jsx.includes("import Accessibility from '@highcharts/react/modules/Accessibility';"),
+            'should import Accessibility wrapper component'
+        );
+        ok(
+            jsx.includes('setHighcharts(Highcharts);'),
+            'should call setHighcharts for the non-wrapper module'
+        );
+    });
 });


### PR DESCRIPTION
## Summary
- add wrapper-first module mapping in the sample generator for supported @highcharts/react/modules/* modules
- keep setHighcharts fallback for modules without wrappers (e.g. highcharts-more)
- switch React output path to samples/react/<product>/<flattened-path>
- align gulptask test output-dir resolver with the new path layout
- add table-driven output-dir tests, including classic-mode react-segment preservation

## Validation
- node --import tsx --test tools/sample-generator/tests/*.test.ts
- node --test tools/gulptasks-tests/generate-samples.test.mjs
- npx gulp generate-samples --samples "stock/xaxis/showfirstlabel,highcharts/yaxis/labels-distance" --outputMode react
- npx gulp prepare-react-samples

## Notes
- "Controls(?)" TODO is intentionally deferred for this first version.
