### PR TITLE
bugfix/22949-clipPath-height

### DIFF
--- a/samples/unit-tests/boost/general/demo.js
+++ b/samples/unit-tests/boost/general/demo.js
@@ -602,6 +602,44 @@ QUnit[Highcharts.hasWebGLSupport() ? 'test' : 'skip'](
             `Clip rect 'x' should take into account opposite navigator boosted
             series on inverted charts, #20936.`
         );
+
+    }
+);
+
+QUnit[Highcharts.hasWebGLSupport() ? 'test' : 'skip'](
+    'The boost clip-path should have appropriate size, #22949.',
+    function (assert) {
+        const chart = Highcharts.chart('container', {
+            chart: {
+                inverted: false
+            },
+            navigator: {
+                enabled: false
+            },
+            plotOptions: {
+                series: {
+                    boostThreshold: 1
+                }
+            },
+            yAxis: [
+                { lineWidth: 1 },
+                { opposite: true, lineWidth: 1 }
+            ],
+            series: [{
+                data: [[4, 3], [5, 4]]
+            }, {
+                data: [[3, 5], [4, 6]]
+            }]
+        });
+
+        chart.setSize(600, 500);
+
+        assert.strictEqual(
+            chart.boost.clipRect.attr('width'),
+            chart.clipBox.width,
+            'Clip rect width should take into account opposing y-axis ' +
+            'line widths after resize, #22949.'
+        );
     }
 );
 

--- a/ts/Extensions/Boost/BoostChart.ts
+++ b/ts/Extensions/Boost/BoostChart.ts
@@ -134,6 +134,14 @@ function getBoostClipRect(
         const verticalAxes =
             chart.inverted ? chart.xAxis : chart.yAxis; // #14444
 
+        // Use chart.clipBox dimensions to match what createAndAttachRenderer
+        // compares against. Fractional clipOffset shrinks chart.clipBox below
+        // plotWidth/Height, breaking that check. #22949
+        if (!chart.inverted && !navigator && chart.clipBox) {
+            clipBox.width = chart.clipBox.width;
+            clipBox.height = chart.clipBox.height;
+        }
+
         if (verticalAxes.length <= 1) {
             clipBox.y = Math.min(verticalAxes[0].pos, clipBox.y);
             clipBox.height = (


### PR DESCRIPTION
Fixed #22949, `clipPath` height was cut after chart resize in boost mode.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210012185285342