### PR TITLE
bugfix/fix-requires-doclets-for-tree-json

### DIFF
--- a/ts/Series/Contour/ContourSeriesDefaults.ts
+++ b/ts/Series/Contour/ContourSeriesDefaults.ts
@@ -44,6 +44,8 @@ import type ContourSeriesOptions from './ContourSeriesOptions';
  *               softThreshold, stacking, step, threshold
  *
  * @product      highcharts highmaps
+ * @requires     modules/coloraxis
+ * @requires     modules/contour
  * @optionparent plotOptions.contour
  */
 const ContourSeriesDefaults: ContourSeriesOptions = {
@@ -177,6 +179,8 @@ const ContourSeriesDefaults: ContourSeriesOptions = {
  *
  *
  * @product      highcharts highmaps
+ * @requires     modules/coloraxis
+ * @requires     modules/contour
  * @apioption    series.contour
  */
 

--- a/ts/Series/Cylinder/CylinderSeriesDefaults.ts
+++ b/ts/Series/Cylinder/CylinderSeriesDefaults.ts
@@ -41,6 +41,7 @@ import type CylinderSeriesOptions from './CylinderSeriesOptions';
  * @product      highcharts
  * @excluding    allAreas, boostThreshold, colorAxis, compare, compareBase,
  *               dragDrop, boostBlending
+ * @requires     highcharts-3d
  * @requires     modules/cylinder
  * @optionparent plotOptions.cylinder
  */
@@ -55,6 +56,7 @@ const CylinderSeriesDefaults: CylinderSeriesOptions = {};
  * @product   highcharts
  * @excluding allAreas, boostThreshold, colorAxis, compare, compareBase,
  *            boostBlending
+ * @requires  highcharts-3d
  * @requires  modules/cylinder
  * @apioption series.cylinder
  */

--- a/ts/masters/modules/contour.src.ts
+++ b/ts/masters/modules/contour.src.ts
@@ -2,6 +2,7 @@
  * @license Highmaps JS v@product.version@ (@product.date@)
  * @module highcharts/modules/contour
  * @requires highcharts
+ * @requires highcharts/modules/coloraxis
  *
  * (c) 2009-2025 Highsoft AS
  *


### PR DESCRIPTION
Fixed doclets for contour and cylinder.

This is so the integration can resolve these modules with the help of tree.json.