### PR TITLE
Throw error on JS errors in Exporting, relevant when esbuild

### DIFF
--- a/ts/Extensions/Exporting/Exporting.ts
+++ b/ts/Extensions/Exporting/Exporting.ts
@@ -1815,6 +1815,10 @@ export class Exporting {
 
             // Allow fallback to server only for PDFs that failed locally
             await this.exportChart(exportingOptions);
+
+        } else {
+            // General unknown error
+            throw err;
         }
     }
 

--- a/ts/Extensions/Exporting/Exporting.ts
+++ b/ts/Extensions/Exporting/Exporting.ts
@@ -1817,8 +1817,7 @@ export class Exporting {
             await this.exportChart(exportingOptions);
 
         } else {
-            // General unknown error
-            throw err;
+            error(err.message, false);
         }
     }
 


### PR DESCRIPTION
Throw error on JS errors in Exporting. Without it, basic JavaScript errors would silently fail.