### PR TITLE
bugfix/externalize-shared-utils

### DIFF
--- a/.github/workflows/highcharts-headless.yml
+++ b/.github/workflows/highcharts-headless.yml
@@ -21,6 +21,11 @@ jobs:
       - name: Build Highcharts
         run: npx gulp scripts
 
+      - name: Verify webpack bundles
+        run: |
+          node tools/webpacks/check-duplicates.mjs
+          node tools/webpacks/check-namespace-exposure.mjs
+
       - name: Run unit tests
         run: npm run test-node
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test": "npx playwright test --project=setup-highcharts --project=setup-dashboards --project=setup-grid-lite --project=setup-grid-pro --project=highcharts --project=dashboards --project=grid-lite --project=grid-pro --project=grid-shared --project=qunit",
     "test-node": "tsx ./test/ts-node-unit-tests/index.ts",
     "test-node:watch": "tsx ./test/ts-node-unit-tests/index.ts --watch",
+    "test:webpack": "node tools/webpacks/check-duplicates.mjs && node tools/webpacks/check-namespace-exposure.mjs",
     "test:precommit": "npx gulp test --modified && npm run test-node",
     "test:pw": "playwright test --project=setup-highcharts --project=highcharts",
     "test:pw:all": "playwright test",

--- a/tools/webpacks/AGENTS.md
+++ b/tools/webpacks/AGENTS.md
@@ -1,0 +1,97 @@
+# Agent Instructions for Highcharts Webpack Build
+
+This document gives AI agents context for working under `tools/webpacks/`.
+
+## Webpack externals system
+
+The externals system prevents utility code from being duplicated across secondary
+bundles (modules like `exporting.js`, `data.js`, etc.). It works at the
+**module level**, not per-export.
+
+### Key files
+
+- `externals.json` — Configuration of which modules to externalize and how.
+- `externals.mjs` — Runtime logic that resolves externals during webpack builds.
+- `highcharts.webpack.mjs` — Webpack config for Highcharts product bundles.
+- `highcharts-es5.webpack.mjs` — Webpack config for Highcharts ES5 product bundles.
+- `dashboards.webpack.mjs` — Webpack config for Dashboards product bundles.
+- `grid.webpack.mjs` — Webpack config for Grid product bundles.
+
+### How `externals.json` works
+
+Each entry has three fields:
+
+- **`files`**: Module paths (relative to `code/es-modules/`, no extension) to
+  externalize.
+- **`included`**: Bundle names where the file should be **bundled** (included),
+  NOT externalized. If a bundle is absent from this list, the module IS
+  externalized for that bundle.
+- **`namespacePath`**: How to resolve the external on the global object.
+  - `""` (empty) → root namespace (e.g., `Highcharts` or `Dashboards`).
+  - `".{name}"` → `Namespace.FileName` (e.g., `Highcharts.Chart`).
+
+### Critical rule: namespace exposure
+
+When a module is externalized with `namespacePath: ""`, **every named export**
+from that module must be attached to the product namespace object. Otherwise
+secondary bundles will fail at runtime with `xxx is not a function`.
+
+The namespace attachments live in the master files:
+
+- `ts/masters/highcharts.src.ts` — `G.xxx = xxx` for Highcharts
+- `ts/masters-dashboards/dashboards.src.ts` — `G.xxx = xxx` for Dashboards
+
+If you add a new export to `Shared/Utilities.ts`, you **must** also add
+`G.xxx = xxx` to every master file that externalizes `Shared/Utilities`.
+
+### Multi-product impact
+
+`externals.json` is shared across **all** products (Highcharts, Dashboards,
+Grid). A change to externals affects every product's webpack build. When
+modifying `externals.json`:
+
+1. Check which products use the affected module.
+2. Verify the namespace object in each product's master file exposes all
+   required exports.
+3. Rebuild and test each affected product.
+
+### Build pipeline order
+
+Always run `scripts-ts` before `scripts-webpack`. The webpack step reads
+compiled JS from `code/es-modules/`, so stale compiled output causes confusing
+failures.
+
+```bash
+# Highcharts
+npx gulp scripts-ts
+npx gulp scripts-webpack
+
+# Dashboards
+npx gulp scripts-ts --product Dashboards
+npx gulp scripts-webpack --product Dashboards
+
+# Grid
+npx gulp scripts-ts --product Grid
+npx gulp scripts-webpack --product Grid
+```
+
+### Testing
+
+```bash
+# Highcharts module tests
+node --import tsx --test test/ts-node-unit-tests/tests/modules.test.ts
+
+# Dashboards tests
+node --import tsx --test "test/ts-node-unit-tests/tests/Dashboards/**"
+```
+
+### Common mistakes
+
+- **Adding a file to `externals.json` without exposing its exports on the
+  namespace** → runtime errors in secondary bundles.
+- **Running `scripts-webpack` without `scripts-ts` first** → stale compiled
+  output, misleading test failures.
+- **Assuming externals work per-export** → they don't. Webpack externalizes
+  entire modules. If even one export is missing from the namespace, it breaks.
+- **Forgetting Dashboards/Grid** → `externals.json` is shared. A change for
+  Highcharts affects all products.

--- a/tools/webpacks/AGENTS.md
+++ b/tools/webpacks/AGENTS.md
@@ -95,3 +95,51 @@ node --import tsx --test "test/ts-node-unit-tests/tests/Dashboards/**"
   entire modules. If even one export is missing from the namespace, it breaks.
 - **Forgetting Dashboards/Grid** → `externals.json` is shared. A change for
   Highcharts affects all products.
+
+## Validation scripts
+
+Two scripts validate the externals configuration against actual build output
+and source code.
+
+### check-duplicates.mjs
+
+Detects when an externalized module has been accidentally inlined into a
+secondary webpack bundle.
+
+```bash
+node tools/webpacks/check-duplicates.mjs
+```
+
+**Prerequisites:** Build must have been run (`npx gulp scripts`) so that
+`code/` contains `.js` bundles.
+
+**What it does:** Reads `externals.json` and `externals-dashboards.json`, then
+scans all secondary bundles (excluding masters) for module path strings that
+indicate the module was inlined rather than externalized.
+
+**Exit codes:** 0 = no duplicates found (or no build output); 1 = violations
+detected.
+
+### check-namespace-exposure.mjs
+
+Verifies that all named exports from modules with `namespacePath: ""` are
+exposed on the global namespace in the corresponding masters file.
+
+```bash
+node tools/webpacks/check-namespace-exposure.mjs
+```
+
+**Prerequisites:** None (reads TypeScript source directly).
+
+**What it does:** For each externalized module with `namespacePath: ""`, parses
+the TS source for named exports, then checks the masters file for matching
+`G.xxx = xxx` assignments.
+
+**Exit codes:** 0 = all exports exposed; 1 = missing exposures found.
+
+### When to run
+
+Run both scripts after:
+- Adding or removing entries in `externals.json` / `externals-dashboards.json`
+- Adding new exports to an externalized module
+- Modifying masters files

--- a/tools/webpacks/README.md
+++ b/tools/webpacks/README.md
@@ -166,7 +166,7 @@ Each entry is an object with the following properties:
   - It reflects the namespace assignment that happens in the masters files (the ones in `included`).
   - A leading dot will be replaced with the shared product namespace.
   - A `{name}` pattern will be replaced with the imports file name (without file extension).
-  - If the export of a file is merged into the namespace root itself, then you can keep the namespace empty.
+   - If the export of a file is merged into the namespace root itself, then you can keep the namespacePath empty.
 
 **Examples:**
 
@@ -179,21 +179,14 @@ Each entry is an object with the following properties:
         "included": [
             "module/stock"
         ],
-        "namespace": ".Series.types.sma"
-    },
-    {
-        "files": [
-            "Shared/TimeBase",
-        ],
-        "included": [], // = highcharts
-        "namespace": ".Time"
+        "namespacePath": ".Series.types.sma"
     },
     {
         "files": [
             "Core/Utilities"
         ],
         "included": [],
-        "namespace": "" // Utilities properties are part of the namespace itself.
+        "namespacePath": "" // Utilities properties are part of the namespace itself.
     }
 ]
 ```

--- a/tools/webpacks/README.md
+++ b/tools/webpacks/README.md
@@ -82,7 +82,7 @@ In our example the `example.src.ts` module requires the Highcharts namespace fro
 
 ### Adding a module with shared code
 
-If you module provides shared code required by other modules, you have to define the relationship in `externals.json`.
+If your module provides shared code required by other modules, you have to define the relationship in `externals.json`.
 This helps Webpack to make the correct decision when to bundle the code and when to expect the code on the product namespace.
 
 **Example:**
@@ -149,7 +149,7 @@ Now an entry in `externals.json` is needed, to inform Webpack about the namespac
 Updating a module with shared code
 ----------------------------------
 
-Webpack provides an callback option where one can define dynamically, whether a file for the current bundle should be included.
+Webpack provides a callback option where one can define dynamically, whether a file for the current bundle should be included.
 Our callback system can be found in `externals.mjs` with the related definitions in `externals.json`.
 
 In `externals.json` you define which code files should go into which bundle and otherwise be accessible under a certain namespace path.
@@ -162,11 +162,11 @@ Each entry is an object with the following properties:
 * `included`: Defines the masters files that should bundle the covered file matches.
   An empty array defaults to the default product master (`highcharts`).
 
-* `namespacePath`: This point to the namespace property when the files are not bundled.
-  - It reflects the namespace assignment that happens in the masters files (the ones in `included`).
-  - A leading dot will be replaced with the shared product namespace.
-  - A `{name}` pattern will be replaced with the imports file name (without file extension).
-  - If the export of a file is merged into the namespace root itself, then you can keep the namespacePath empty.
+* `namespacePath`: This points to the namespace property when the files are not bundled.
+   - It reflects the namespace assignment that happens in the masters files (the ones in `included`).
+   - A leading dot will be replaced with the shared product namespace.
+   - A `{name}` pattern will be replaced with the imports file name (without file extension).
+   - If the export of a file is merged into the namespace root itself, then you can keep the namespacePath empty.
 
 **Examples:**
 
@@ -177,7 +177,7 @@ Each entry is an object with the following properties:
             "Stock/Indicators/SMA/SMAIndicator"
         ],
         "included": [
-            "module/stock"
+            "modules/stock"
         ],
         "namespacePath": ".Series.types.sma"
     },
@@ -214,7 +214,7 @@ const masterName = masterPath.replace(/(?:\.src)?\.js$/u, '');
 export default [{
     entry: masterFile,
     experiments: { outputModule: true },
-    externals = [(info) => {
+    externals: [(info) => {
         const contextPath = FSLib.path([info.context, info.request], true);
         if (contextPath.includes('masters')) {
             return makeExternals(

--- a/tools/webpacks/README.md
+++ b/tools/webpacks/README.md
@@ -166,7 +166,7 @@ Each entry is an object with the following properties:
   - It reflects the namespace assignment that happens in the masters files (the ones in `included`).
   - A leading dot will be replaced with the shared product namespace.
   - A `{name}` pattern will be replaced with the imports file name (without file extension).
-   - If the export of a file is merged into the namespace root itself, then you can keep the namespacePath empty.
+  - If the export of a file is merged into the namespace root itself, then you can keep the namespacePath empty.
 
 **Examples:**
 

--- a/tools/webpacks/check-duplicates.mjs
+++ b/tools/webpacks/check-duplicates.mjs
@@ -47,7 +47,7 @@ function collectJsFiles(directory) {
     for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
         const entryPath = path.join(directory, entry.name);
 
-        if (entryPath.includes('/es-modules/')) {
+        if (entryPath.replace(/\\/g, '/').includes('/es-modules/')) {
             continue;
         }
 
@@ -78,9 +78,9 @@ for (const externalsFile of externalsFiles) {
 
 const jsFiles = collectJsFiles(codeRoot).filter((filePath) => {
     return !masterBundleBasenames.has(path.basename(filePath)) &&
-        !filePath.includes('/es-modules/') &&
-        !filePath.includes('/es5/') &&
-        !filePath.includes('/esm/');
+        !filePath.replace(/\\/g, '/').includes('/es-modules/') &&
+        !filePath.replace(/\\/g, '/').includes('/es5/') &&
+        !filePath.replace(/\\/g, '/').includes('/esm/');
 });
 
 if (!fs.existsSync(codeRoot) || jsFiles.length === 0) {

--- a/tools/webpacks/check-duplicates.mjs
+++ b/tools/webpacks/check-duplicates.mjs
@@ -1,0 +1,111 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+const codeRoot = path.join(repoRoot, 'code');
+const externalsFiles = [
+    path.join(repoRoot, 'tools/webpacks/externals.json'),
+    path.join(repoRoot, 'tools/webpacks/externals-dashboards.json')
+];
+const masterBundleBasenames = new Set([
+    'highcharts.src.js',
+    'highstock.src.js',
+    'highmaps.src.js',
+    'highcharts-gantt.src.js',
+    'dashboards.src.js',
+    'datagrid.src.js',
+    'highcharts.js',
+    'highstock.js',
+    'highmaps.js',
+    'highcharts-gantt.js',
+    'dashboards.js',
+    'datagrid.js',
+    'standalone-navigator.src.js',
+    'standalone-navigator.js',
+    'grid-lite.src.js',
+    'grid-lite.js',
+    'grid-pro.src.js',
+    'grid-pro.js'
+]);
+
+function readJsonArray(filePath) {
+    if (!fs.existsSync(filePath)) {
+        return [];
+    }
+
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    return Array.isArray(parsed) ? parsed : [];
+}
+
+function collectJsFiles(directory) {
+    if (!fs.existsSync(directory)) {
+        return [];
+    }
+
+    const files = [];
+
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+        const entryPath = path.join(directory, entry.name);
+
+        if (entryPath.includes('/es-modules/')) {
+            continue;
+        }
+
+        if (entry.isDirectory()) {
+            files.push(...collectJsFiles(entryPath));
+            continue;
+        }
+
+        if (entry.isFile() && entry.name.endsWith('.js')) {
+            files.push(entryPath);
+        }
+    }
+
+    return files;
+}
+
+const externalModuleKeys = [];
+
+for (const externalsFile of externalsFiles) {
+    for (const entry of readJsonArray(externalsFile)) {
+        if (!entry || !Array.isArray(entry.files)) {
+            continue;
+        }
+
+        externalModuleKeys.push(...entry.files);
+    }
+}
+
+const jsFiles = collectJsFiles(codeRoot).filter((filePath) => {
+    return !masterBundleBasenames.has(path.basename(filePath)) &&
+        !filePath.includes('/es-modules/') &&
+        !filePath.includes('/es5/') &&
+        !filePath.includes('/esm/');
+});
+
+if (!fs.existsSync(codeRoot) || jsFiles.length === 0) {
+    console.log('Warning: code/ has no .js files yet; build may not have been run.');
+    process.exit(0);
+}
+
+const violations = [];
+
+for (const filePath of jsFiles) {
+    const content = fs.readFileSync(filePath, 'utf8');
+
+    for (const moduleKey of externalModuleKeys) {
+        if (content.includes(`'/${moduleKey}.js'`) || content.includes(`"/${moduleKey}.js"`)) {
+            violations.push({ filePath, moduleKey });
+        }
+    }
+}
+
+if (violations.length > 0) {
+    for (const violation of violations) {
+        console.log(`${path.relative(repoRoot, violation.filePath)}: inlined external ${violation.moduleKey}`);
+    }
+    process.exit(1);
+}
+
+console.log('Success: no externalized modules were inlined into secondary bundles.');
+process.exit(0);

--- a/tools/webpacks/check-namespace-exposure.mjs
+++ b/tools/webpacks/check-namespace-exposure.mjs
@@ -1,0 +1,167 @@
+import FS from 'node:fs';
+import Path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = Path.resolve(Path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const CONFIGS = [
+    {
+        configPath: Path.join(ROOT, 'tools/webpacks/externals.json'),
+        mastersPath: Path.join(ROOT, 'ts/masters/highcharts.src.ts'),
+        label: 'Highcharts'
+    },
+    {
+        configPath: Path.join(ROOT, 'tools/webpacks/externals-dashboards.json'),
+        mastersPath: Path.join(ROOT, 'ts/masters-dashboards/dashboards.src.ts'),
+        label: 'Dashboards'
+    }
+];
+
+/**
+ * Exports that are intentionally not exposed on the global namespace.
+ * These are internal implementation details accessed only by the core,
+ * not by externalized secondary bundles.
+ */
+const ALLOWLIST = new Set([
+    // Core/Globals - internal state
+    'SVG_NS',
+    'charts',
+    'composed',
+    'dateFormats',
+    'seriesTypes',
+    'symbolSizes',
+    'chartCount',
+    // Core/Utilities - internal
+    'messages',
+    // Shared/Utilities - keyword/type collision
+    'enum',
+    // Dashboards/Globals - internal constants
+    'classNamePrefix',
+    'version',
+    'classNames',
+    'guiElementType',
+    'boards',
+    'doc',
+    'noop',
+    'isMS',
+    'supportsPassiveEvents'
+]);
+
+const exportPatterns = [
+    /export\s+(?:async\s+)?(?:function|class|const|let|var|enum)\s+([A-Za-z_$][\w$]*)/gu,
+    /export\s+\{([^}]+)\}/gu
+];
+
+const missing = [];
+
+for (const { configPath, mastersPath, label } of CONFIGS) {
+    if (!FS.existsSync(configPath)) {
+        continue;
+    }
+
+    const entries = readJson(configPath);
+    const mastersSource = readOptionalText(mastersPath);
+    if (mastersSource === null) {
+        console.warn(`[warn] Missing masters file: ${relative(mastersPath)}`);
+    }
+
+    for (const entry of entries) {
+        if (entry.namespacePath !== '') {
+            continue;
+        }
+
+        for (const fileKey of entry.files || []) {
+            const sourcePath = Path.join(ROOT, 'ts', `${fileKey}.ts`);
+            const source = readOptionalText(sourcePath);
+            if (source === null) {
+                console.warn(`[warn] Missing source file: ${relative(sourcePath)}`);
+                continue;
+            }
+
+            const exportNames = collectNamedExports(source);
+            for (const name of exportNames) {
+                if (ALLOWLIST.has(name)) {
+                    continue;
+                }
+
+                if (hasNamespaceExposure(mastersSource, name)) {
+                    continue;
+                }
+
+                missing.push({
+                    label,
+                    module: fileKey,
+                    exportName: name,
+                    masters: relative(mastersPath)
+                });
+            }
+        }
+    }
+}
+
+for (const item of missing) {
+    console.warn(`[warn] ${item.label} missing namespace exposure: ${item.module} -> ${item.exportName} (${item.masters})`);
+}
+
+process.exit(missing.length > 0 ? 1 : 0);
+
+function readJson(filePath) {
+    return JSON.parse(FS.readFileSync(filePath, 'utf8'));
+}
+
+function readOptionalText(filePath) {
+    if (!FS.existsSync(filePath)) {
+        return null;
+    }
+
+    return FS.readFileSync(filePath, 'utf8');
+}
+
+function collectNamedExports(source) {
+    const names = new Set();
+
+    // Single-declaration exports (function, class, const, let, var, enum, async function)
+    for (const match of source.matchAll(exportPatterns[0])) {
+        names.add(match[1]);
+    }
+
+    // Braced export lists: export { A, B as C }
+    for (const match of source.matchAll(exportPatterns[1])) {
+        for (const specifier of match[1].split(',')) {
+            const piece = specifier.trim();
+            if (!piece) {
+                continue;
+            }
+
+            if (piece.startsWith('type ')) {
+                continue;
+            }
+
+            const aliasMatch = piece.match(/^([A-Za-z_$][\w$]*)(?:\s+as\s+([A-Za-z_$][\w$]*))?$/u);
+            if (!aliasMatch) {
+                continue;
+            }
+
+            names.add(aliasMatch[2] || aliasMatch[1]);
+        }
+    }
+
+    return [...names];
+}
+
+function hasNamespaceExposure(source, name) {
+    if (!source) {
+        return false;
+    }
+
+    const escaped = escapeRegExp(name);
+    const namespacePattern = new RegExp(`\\bG(?:\\.${escaped}|\\[['"]${escaped}['"]\\])`, 'u');
+    return namespacePattern.test(source);
+}
+
+function escapeRegExp(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+}
+
+function relative(filePath) {
+    return Path.relative(ROOT, filePath);
+}

--- a/tools/webpacks/externals.json
+++ b/tools/webpacks/externals.json
@@ -107,7 +107,8 @@
             "Core/Defaults",
             "Core/Globals",
             "Core/Renderer/RendererUtilities",
-            "Core/Utilities"
+            "Core/Utilities",
+            "Shared/Utilities"
         ],
         "included": [],
         "namespacePath": ""

--- a/ts/masters-dashboards/dashboards.src.ts
+++ b/ts/masters-dashboards/dashboards.src.ts
@@ -58,7 +58,26 @@ import HighchartsPlugin from '../Dashboards/Plugins/HighchartsPlugin.js';
 import PluginHandler from '../Dashboards/PluginHandler.js';
 import Sync from '../Dashboards/Components/Sync/Sync.js';
 import Utilities from '../Dashboards/Utilities.js';
-import { addEvent, merge, removeEvent } from '../Shared/Utilities.js';
+import {
+    addEvent,
+    createElement,
+    css,
+    defined,
+    diffObjects,
+    find,
+    fireEvent,
+    getStyle,
+    isArray,
+    isFunction,
+    isNumber,
+    isObject,
+    isString,
+    merge,
+    objectEach,
+    pick,
+    removeEvent,
+    splat
+} from '../Shared/Utilities.js';
 import { uniqueKey } from '../Core/Utilities.js';
 
 // Import components
@@ -80,10 +99,25 @@ declare global {
         addEvent: typeof addEvent;
         board: typeof Board.board;
         boards: typeof Globals.boards;
+        createElement: typeof createElement;
+        css: typeof css;
+        defined: typeof defined;
+        diffObjects: typeof diffObjects;
         error: typeof Utilities.error;
+        find: typeof find;
+        fireEvent: typeof fireEvent;
+        getStyle: typeof getStyle;
+        isArray: typeof isArray;
+        isFunction: typeof isFunction;
+        isNumber: typeof isNumber;
+        isObject: typeof isObject;
+        isString: typeof isString;
         merge: typeof merge;
+        objectEach: typeof objectEach;
+        pick: typeof pick;
         removeEvent: typeof removeEvent;
         setOptions: typeof Defaults.setOptions;
+        splat: typeof splat;
         uniqueKey: typeof uniqueKey;
         version: typeof Globals.version;
         win: typeof Globals.win;
@@ -128,10 +162,25 @@ const G = Globals as unknown as Dashboards;
 
 G.board = Board.board;
 G.addEvent = addEvent;
+G.createElement = createElement;
+G.css = css;
+G.defined = defined;
+G.diffObjects = diffObjects;
 G.error = Utilities.error;
+G.find = find;
+G.fireEvent = fireEvent;
+G.getStyle = getStyle;
+G.isArray = isArray;
+G.isFunction = isFunction;
+G.isNumber = isNumber;
+G.isObject = isObject;
+G.isString = isString;
 G.merge = merge;
+G.objectEach = objectEach;
+G.pick = pick;
 G.removeEvent = removeEvent;
 G.setOptions = Defaults.setOptions;
+G.splat = splat;
 G.uniqueKey = uniqueKey;
 G.AST = AST;
 G.Board = Board;

--- a/ts/masters/highcharts.src.ts
+++ b/ts/masters/highcharts.src.ts
@@ -61,6 +61,7 @@ import {
     clamp,
     correctFloat,
     createElement,
+    crisp,
     css,
     defined,
     destroyObjectProperties,
@@ -72,6 +73,9 @@ import {
     find,
     fireEvent,
     getMagnitude,
+    getAlignFactor,
+    getClosestDistance,
+    getNestedProperty,
     getStyle,
     isArray,
     isClass,
@@ -80,18 +84,22 @@ import {
     isNumber,
     isObject,
     isString,
+    internalClearTimeout,
     merge,
     normalizeTickInterval,
     objectEach,
     offset,
     pad,
     pick,
+    pushUnique,
     pInt,
     relativeLength,
     removeEvent,
+    replaceNested,
     splat,
     stableSort,
     syncTimeout,
+    ucfirst,
     wrap
 } from '../Shared/Utilities.js';
 import {
@@ -142,6 +150,7 @@ G.color = Color.parse;
 G.correctFloat = correctFloat;
 G.createElement = createElement;
 G.css = css;
+G.crisp = crisp;
 G.dateFormat = Templating.dateFormat;
 G.defaultOptions = Defaults.defaultOptions;
 G.defined = defined;
@@ -156,8 +165,11 @@ G.extendClass = extendClass;
 G.find = find;
 G.fireEvent = fireEvent;
 G.format = Templating.format;
+G.getAlignFactor = getAlignFactor;
+G.getClosestDistance = getClosestDistance;
 G.getDeferredAnimation = Animation.getDeferredAnimation;
 G.getMagnitude = getMagnitude;
+G.getNestedProperty = getNestedProperty;
 G.getOptions = Defaults.getOptions;
 G.getStyle = getStyle;
 G.insertItem = insertItem;
@@ -168,6 +180,7 @@ G.isFunction = isFunction;
 G.isNumber = isNumber;
 G.isObject = isObject;
 G.isString = isString;
+G.internalClearTimeout = internalClearTimeout;
 G.merge = merge;
 G.normalizeTickInterval = normalizeTickInterval;
 G.numberFormat = Templating.numberFormat;
@@ -175,9 +188,11 @@ G.objectEach = objectEach;
 G.offset = offset;
 G.pad = pad;
 G.pick = pick;
+G.pushUnique = pushUnique;
 G.pInt = pInt;
 G.relativeLength = relativeLength;
 G.removeEvent = removeEvent;
+G.replaceNested = replaceNested;
 G.seriesType = SeriesRegistry.seriesType;
 G.setAnimation = Animation.setAnimation;
 G.setOptions = Defaults.setOptions;
@@ -186,6 +201,7 @@ G.stableSort = stableSort;
 G.stop = Animation.stop;
 G.syncTimeout = syncTimeout;
 G.time = Defaults.defaultTime;
+G.ucfirst = ucfirst;
 G.timers = Fx.timers;
 G.timeUnits = timeUnits;
 G.uniqueKey = uniqueKey;


### PR DESCRIPTION
Externalized Shared/Utilities (and other duplicated modules) from secondary webpack bundles. 

Also added two validation scripts (check-duplicates.mjs, check-namespace-exposure.mjs) that catch accidental re-inlining or missing namespace exposures at build time, as well as an AGENTS.md file for repo context