### PR TITLE
Upgrade @playwright/test to ^1.60.0 to fix CI install hang

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -4,3 +4,4 @@ fund=false
 package-lock=true
 strict-ssl=true
 registry=https://registry.npmjs.org/
+min-package-age=5d

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@highcharts/highsoft-websearch": "github:highcharts/highsoft-websearch#v0.0.5",
         "@highcharts/map-collection": "^2.2.0",
         "@octokit/rest": "^20.1.1",
-        "@playwright/test": "^1.53.2",
+        "@playwright/test": "^1.60.0",
         "@stylistic/eslint-plugin": "^3.0.0",
         "@swc/core": "^1.9.2",
         "@types/gulp": "^4.0.17",
@@ -7001,10 +7001,12 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.57.0",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.57.0"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -23778,10 +23780,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.57.0",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.57.0"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -23794,7 +23798,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.57.0",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -23805,6 +23811,9 @@
     },
     "node_modules/playwright/node_modules/fsevents": {
       "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -31508,7 +31508,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@playwright/test": "^1.54.1"
+        "@playwright/test": "^1.60.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.31.0",
@@ -31518,7 +31518,6 @@
         "@typescript-eslint/parser": "^8.37.0",
         "eslint-plugin-n": "^17.21.0",
         "eslint-plugin-playwright": "^2.2.0",
-        "playwright": "1.56.1",
         "typescript-eslint": "^8.37.0"
       }
     },
@@ -31735,18 +31734,6 @@
         "node": ">=16"
       }
     },
-    "tests/node_modules/fsevents": {
-      "version": "2.3.2",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "tests/node_modules/glob-parent": {
       "version": "6.0.2",
       "dev": true,
@@ -31808,34 +31795,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "tests/node_modules/playwright": {
-      "version": "1.56.1",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright-core": "1.56.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "tests/node_modules/playwright-core": {
-      "version": "1.56.1",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "tests/node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@highcharts/highsoft-websearch": "github:highcharts/highsoft-websearch#v0.0.5",
     "@highcharts/map-collection": "^2.2.0",
     "@octokit/rest": "^20.1.1",
-    "@playwright/test": "^1.53.2",
+    "@playwright/test": "^1.60.0",
     "@stylistic/eslint-plugin": "^3.0.0",
     "@swc/core": "^1.9.2",
     "@types/gulp": "^4.0.17",

--- a/tests/package.json
+++ b/tests/package.json
@@ -18,10 +18,9 @@
     "@typescript-eslint/parser": "^8.37.0",
     "eslint-plugin-n": "^17.21.0",
     "eslint-plugin-playwright": "^2.2.0",
-    "playwright": "1.56.1",
     "typescript-eslint": "^8.37.0"
   },
   "dependencies": {
-    "@playwright/test": "^1.54.1"
+    "@playwright/test": "^1.60.0"
   }
 }


### PR DESCRIPTION
## Problem

Playwright browser install step hangs in CI after download reaches 100%. This is a known bug affecting Playwright < 1.60.0 on Node 24.16.0 (microsoft/playwright#41000, microsoft/playwright#40998).

Our CI uses `node-version: 'lts/*'` which now resolves to Node 24.16.0, triggering the extraction hang.

## Fix

Upgrade `@playwright/test` from `^1.53.2` to `^1.60.0` which includes the fix for this issue.

## Affected workflows

- grid-test.yml
- dashboards-test.yml
- highcharts-headless.yml
- visual-compare-playwright.yml
- nightly.yml