### PR TITLE
grid/inline-filtering-hide-dropdown

### DIFF
--- a/docs/grid/columns/filtering.md
+++ b/docs/grid/columns/filtering.md
@@ -72,6 +72,45 @@ columnDefaults: {
 
 Inline mode works well for data-heavy tables where filtering is a primary interaction.
 
+#### Hiding the operator dropdown
+
+When `hideDropdown` is `true` together with `inline: true`, the operator
+`<select>` is not rendered. Filtering uses a fixed operator:
+
+* the first operator for the column `dataType`, or
+* the first entry in `filtering.operators` when that list is set, or
+* `filtering.rule.operator` when it is valid for the column.
+
+End users cannot change the operator in the UI. Update
+`filtering.rule.operator` programmatically (for example via `grid.update()`)
+to switch operators.
+
+For `boolean` columns the dropdown is the only inline control, so hiding it
+removes all interactive filtering in the cell; use `filtering.rule` or
+`grid.update()` instead.
+
+```js
+columnDefaults: {
+    filtering: {
+        enabled: true,
+        inline: true,
+        hideDropdown: true
+    }
+},
+columns: [{
+    id: 'product',
+    // Uses default string operator: contains
+}, {
+    id: 'stock',
+    filtering: {
+        operators: ['greaterThan', 'lessThan']
+        // Uses greaterThan (first in operators)
+    }
+}]
+```
+
+See also: [Inline filtering with hidden operator dropdown](https://www.highcharts.com/samples/grid-lite/options/inline-filtering-hide-dropdown).
+
 ## Filter operators by data type
 
 Available filter operators depend on the column’s `dataType`.

--- a/docs/grid/columns/filtering.md
+++ b/docs/grid/columns/filtering.md
@@ -99,7 +99,7 @@ columnDefaults: {
 },
 columns: [{
     id: 'product',
-    // Uses default string operator: contains
+    // Uses default string filtering operator: contains
 }, {
     id: 'stock',
     filtering: {

--- a/samples/grid-lite/e2e/inline-filtering-hide-dropdown/demo.css
+++ b/samples/grid-lite/e2e/inline-filtering-hide-dropdown/demo.css
@@ -1,0 +1,23 @@
+@import url("https://cdn.jsdelivr.net/npm/@highcharts/grid-lite/css/grid-lite.css");
+
+body {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
+.content {
+    padding: 8px;
+}
+
+code {
+    font-family: Consolas, "courier new", monospace;
+}

--- a/samples/grid-lite/e2e/inline-filtering-hide-dropdown/demo.details
+++ b/samples/grid-lite/e2e/inline-filtering-hide-dropdown/demo.details
@@ -1,0 +1,6 @@
+---
+name: Inline Filtering Hide Dropdown
+authors:
+  - Sebastian Bochan
+js_wrap: b
+...

--- a/samples/grid-lite/e2e/inline-filtering-hide-dropdown/demo.html
+++ b/samples/grid-lite/e2e/inline-filtering-hide-dropdown/demo.html
@@ -1,0 +1,3 @@
+<script src="https://cdn.jsdelivr.net/npm/@highcharts/grid-lite/grid-lite.js"></script>
+
+<div id="container"></div>

--- a/samples/grid-lite/e2e/inline-filtering-hide-dropdown/demo.js
+++ b/samples/grid-lite/e2e/inline-filtering-hide-dropdown/demo.js
@@ -1,0 +1,40 @@
+window.grid = Grid.grid('container', {
+    data: {
+        columns: {
+            id: [1, 2, 3, 4, 5, 6],
+            product: [
+                'Apples',
+                'Pears',
+                'Plums',
+                'Bananas',
+                'Oranges',
+                'Grapes'
+            ],
+            category: [
+                'Fruit',
+                'Fruit',
+                'Fruit',
+                'Tropical',
+                'Citrus',
+                'Berry'
+            ]
+        }
+    },
+    columnDefaults: {
+        filtering: {
+            enabled: true,
+            inline: true,
+            hideDropdown: true
+        }
+    },
+    columns: [{
+        id: 'product',
+        dataType: 'string'
+    }, {
+        id: 'category',
+        dataType: 'string',
+        filtering: {
+            operators: ['contains', 'beginsWith']
+        }
+    }]
+});

--- a/samples/grid-lite/options/inline-filtering-hide-dropdown/demo.css
+++ b/samples/grid-lite/options/inline-filtering-hide-dropdown/demo.css
@@ -1,0 +1,23 @@
+@import url("https://cdn.jsdelivr.net/npm/@highcharts/grid-lite/css/grid-lite.css");
+
+body {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
+.content {
+    padding: 8px;
+}
+
+code {
+    font-family: Consolas, "courier new", monospace;
+}

--- a/samples/grid-lite/options/inline-filtering-hide-dropdown/demo.details
+++ b/samples/grid-lite/options/inline-filtering-hide-dropdown/demo.details
@@ -1,0 +1,6 @@
+---
+name: Inline filtering with hidden operator dropdown
+authors:
+  - Sebastian Bochan
+js_wrap: b
+...

--- a/samples/grid-lite/options/inline-filtering-hide-dropdown/demo.html
+++ b/samples/grid-lite/options/inline-filtering-hide-dropdown/demo.html
@@ -1,0 +1,11 @@
+<script src="https://cdn.jsdelivr.net/npm/@highcharts/grid-lite/grid-lite.js"></script>
+
+<div class="content">
+    <div id="container"></div>
+    <p class="highcharts-description">
+        With <code>filtering.inline</code> and <code>filtering.hideDropdown</code>,
+        only the value input is shown. The operator is fixed to the first
+        available for the column type, or the first entry in
+        <code>filtering.operators</code> when set.
+    </p>
+</div>

--- a/samples/grid-lite/options/inline-filtering-hide-dropdown/demo.js
+++ b/samples/grid-lite/options/inline-filtering-hide-dropdown/demo.js
@@ -1,0 +1,52 @@
+Grid.grid('container', {
+    data: {
+        columns: {
+            id: [1, 2, 3, 4, 5, 6],
+            product: [
+                'Apples',
+                'Pears',
+                'Plums',
+                'Bananas',
+                'Oranges',
+                'Grapes'
+            ],
+            category: [
+                'Fruit',
+                'Fruit',
+                'Fruit',
+                'Tropical',
+                'Citrus',
+                'Berry'
+            ],
+            stock: [120, 40, 5, 200, 85, 60],
+            price: [1.5, 2.53, 5, 4.5, 3.2, 6.75]
+        }
+    },
+    columnDefaults: {
+        filtering: {
+            enabled: true,
+            inline: true,
+            hideDropdown: true
+        }
+    },
+    columns: [{
+        id: 'id',
+        width: 60
+    }, {
+        id: 'product',
+        dataType: 'string'
+    }, {
+        id: 'stock',
+        filtering: {
+            operators: ['greaterThan', 'lessThan']
+        }
+    }, {
+        id: 'price',
+        filtering: {
+            operators: ['greaterThan']
+        },
+        cells: {
+            format: '${value:.2f}'
+        }
+    }]
+});

--- a/tests/grid/shared/options/filtering.spec.ts
+++ b/tests/grid/shared/options/filtering.spec.ts
@@ -645,4 +645,86 @@ test.describe('Grid datetime filtering', () => {
             );
         });
     });
+
+    test.describe('Inline filtering with hideDropdown option', () => {
+        const inputProductFilter =
+            '.hcg-header-cell[data-column-id="product"] input';
+        const inputCategoryFilter =
+            '.hcg-header-cell[data-column-id="category"] input';
+        const productColumn = 'td[data-column-id="product"]';
+        const categoryColumn = 'td[data-column-id="category"]';
+
+        test.beforeEach(async ({ page }) => {
+            await page.goto(
+                '/grid-lite/e2e/inline-filtering-hide-dropdown',
+                { waitUntil: 'networkidle' }
+            );
+            await page.waitForFunction(() => {
+                return typeof (window as any).Grid !== 'undefined' &&
+                    (window as any).Grid.grids &&
+                    (window as any).Grid.grids.length > 0;
+            });
+        });
+
+        test('inline hideDropdown hides select and filters columns', async ({
+            page
+        }) => {
+            await expect(
+                page.locator(
+                    'th[data-column-id="product"] select'
+                )
+            ).toHaveCount(0);
+            await expect(page.locator(inputProductFilter)).toBeVisible();
+
+            await typeFilterValue(page, inputProductFilter, 'Pear');
+            await verifyRowCount(page, 1);
+            await verifyRowsContent(
+                page,
+                productColumn,
+                (text) => (text ?? '').includes('Pear')
+            );
+
+            await clearFilterInput(page, inputProductFilter);
+            await verifyRowCount(page, 6);
+
+            await typeFilterValue(page, inputCategoryFilter, 'Citrus');
+            await verifyRowCount(page, 1);
+            await verifyRowsContent(
+                page,
+                categoryColumn,
+                (text) => (text ?? '').includes('Citrus')
+            );
+        });
+
+        test('hideDropdown without inline keeps select in popup', async ({
+            page
+        }) => {
+            await page.evaluate(() => {
+                const data = (window as any).grid.userOptions.data;
+                (window as any).grid.destroy();
+                (window as any).grid = (window as any).Grid.grid('container', {
+                    data,
+                    columns: [{
+                        id: 'product',
+                        dataType: 'string',
+                        filtering: {
+                            enabled: true,
+                            hideDropdown: true
+                        }
+                    }]
+                });
+            });
+
+            await page
+                .locator(
+                    '[data-column-id="product"] ' +
+                    '.hcg-header-cell-filter-icon button'
+                )
+                .evaluate((button: HTMLButtonElement) => button.click());
+            await expect(
+                page.locator('.hcg-popup-content select')
+            ).toBeVisible();
+        });
+
+    });
 });

--- a/ts/Grid/Core/ColumnPolicyResolver.ts
+++ b/ts/Grid/Core/ColumnPolicyResolver.ts
@@ -301,6 +301,22 @@ class ColumnPolicyResolver {
     }
 
     /**
+     * Returns whether the inline filter operator dropdown is hidden.
+     *
+     * @param columnId
+     * Grid column id.
+     */
+    public isFilterDropdownHidden(columnId: string): boolean {
+        const hideDropdown = (
+            this.getIndividualColumnOptions(columnId)
+                ?.filtering?.hideDropdown ??
+            this.columnDefaults.filtering?.hideDropdown
+        );
+        return this.isColumnInlineFilteringEnabled(columnId) &&
+            !!hideDropdown;
+    }
+
+    /**
      * Returns whether editing should be enabled for the column.
      *
      * @param columnId

--- a/ts/Grid/Core/Options.ts
+++ b/ts/Grid/Core/Options.ts
@@ -1158,6 +1158,21 @@ export interface ColumnFilteringOptions {
      * @default false
      */
     inline?: boolean;
+
+    /**
+     * Hides the operator dropdown in inline filtering. Ignored in popup mode.
+     *
+     * Uses {@link ColumnFilteringOptions.rule} operator when valid, otherwise
+     * the first operator for the column `dataType` or
+     * {@link ColumnFilteringOptions.operators}. Not supported for `boolean`
+     * columns (no value input).
+     *
+     * @sample grid-lite/options/inline-filtering-hide-dropdown
+     *         Inline filtering with hidden operator dropdown
+     *
+     * @default false
+     */
+    hideDropdown?: boolean;
 }
 
 /* *

--- a/ts/Grid/Core/Table/Actions/ColumnFiltering/ColumnFiltering.ts
+++ b/ts/Grid/Core/Table/Actions/ColumnFiltering/ColumnFiltering.ts
@@ -289,7 +289,12 @@ class ColumnFiltering {
             className: Globals.getClassName('columnFilterWrapper')
         }, container);
 
-        this.renderConditionSelect(inputWrapper);
+        if (
+            !column.viewport.grid.columnPolicy
+                .isFilterDropdownHidden(column.id)
+        ) {
+            this.renderConditionSelect(inputWrapper);
+        }
         if (columnType !== 'boolean') {
             this.renderFilteringInput(inputWrapper, columnType);
         }
@@ -345,7 +350,7 @@ class ColumnFiltering {
      */
     private applyFilterFromForm(): void {
         const result: FilteringCondition = {
-            condition: this.filterSelect?.value as Condition
+            condition: this.getActiveCondition()
         };
 
         if (this.filterInput) {
@@ -518,9 +523,7 @@ class ColumnFiltering {
                 value.toString();
         }
 
-        if (this.filterSelect) {
-            this.disableInputIfNeeded();
-        }
+        this.disableInputIfNeeded();
 
         const eventTypes = {
             string: ['keyup'],
@@ -607,12 +610,9 @@ class ColumnFiltering {
      * `true` if filtering is applied to the column, `false` otherwise.
      */
     private isFilteringApplied(): boolean {
-        const {
-            filterSelect: select,
-            filterInput: input
-        } = this;
+        const { filterInput: input } = this;
         const { dataType } = this.column;
-        const condition = select?.value as Condition;
+        const condition = this.getActiveCondition();
 
         if (dataType === 'boolean') {
             return condition !== 'all';
@@ -629,20 +629,57 @@ class ColumnFiltering {
      * Disables the input element if the condition is `empty` or `notEmpty`.
      */
     private disableInputIfNeeded(): void {
-        const {
-            filterSelect: select,
-            filterInput: input
-        } = this;
-        const condition = select?.value as Condition;
+        const { filterInput: input } = this;
+        const condition = this.getActiveCondition();
 
-        if (!input || !select) {
+        if (!input) {
             return;
         }
 
         if (condition === 'empty' || condition === 'notEmpty') {
             input.disabled = true;
-        } else if (input?.disabled) {
+        } else if (input.disabled) {
             input.disabled = false;
+        }
+    }
+
+    /**
+     * Returns the current filtering operator from the dropdown or options.
+     */
+    private getActiveCondition(): Condition {
+        if (this.filterSelect) {
+            return this.filterSelect.value as Condition;
+        }
+
+        const conditions = this.getAllowedConditions();
+        const filteringOperator = ColumnFiltering.mapOperatorAliases(
+            this.column.options.filtering?.rule?.operator ??
+            this.column.options.filtering?.condition
+        );
+
+        if (filteringOperator && conditions.includes(filteringOperator)) {
+            return filteringOperator;
+        }
+
+        return conditions[0];
+    }
+
+    /**
+     * Focuses the first filter control in tab order for inline filtering.
+     */
+    public focusFirstControl(): void {
+        if (!this.filterSelect?.disabled) {
+            this.filterSelect?.focus();
+            return;
+        }
+
+        if (!this.filterInput?.disabled) {
+            this.filterInput?.focus();
+            return;
+        }
+
+        if (!this.clearButton?.disabled) {
+            this.clearButton?.focus();
         }
     }
 

--- a/ts/Grid/Core/Table/Actions/ColumnFiltering/FilterCell.ts
+++ b/ts/Grid/Core/Table/Actions/ColumnFiltering/FilterCell.ts
@@ -92,7 +92,7 @@ class FilterCell extends HeaderCell {
                 this.column.viewport.grid.columnPolicy
                     .isColumnInlineFilteringEnabled(this.column.id)
             ) {
-                this.column.filtering?.filterSelect?.focus();
+                this.column.filtering?.focusFirstControl();
             } else {
                 super.onKeyDown(e);
             }


### PR DESCRIPTION
Added the hideDropdown API option to the inline filtering.

----
- [x] - tests
- [x] - `hideDropdown` API option
- [x] - samples
- [x] - docs