### PR TITLE
Fixed #24717, tooltip followTouchMove blocked page scroll

### DIFF
--- a/css/highcharts.css
+++ b/css/highcharts.css
@@ -183,10 +183,6 @@
     color-scheme: dark;
 }
 
-.highcharts-no-touch-action {
-    touch-action: none;
-}
-
 .highcharts-root {
     display: block;
 }

--- a/samples/unit-tests/pointer/touch/demo.js
+++ b/samples/unit-tests/pointer/touch/demo.js
@@ -259,11 +259,15 @@ QUnit.test('followPointer and followTouchMove', function (assert) {
         followTouchMove: false
     });
     swipe();
+
+    /*
+    // Works in browser, fails in karma, unknown why
     assert.equal(
         chart.tooltip.label.element.textContent.indexOf('Bananas'),
         -1,
         'The tooltip should not show Bananas after tooltip.update'
     );
+    */
 
     chart = Highcharts.chart('container', {
         chart: {

--- a/samples/unit-tests/pointer/touch/demo.js
+++ b/samples/unit-tests/pointer/touch/demo.js
@@ -260,14 +260,11 @@ QUnit.test('followPointer and followTouchMove', function (assert) {
     });
     swipe();
 
-    /*
-    // Works in browser, fails in karma, unknown why
     assert.equal(
         chart.tooltip.label.element.textContent.indexOf('Bananas'),
         -1,
         'The tooltip should not show Bananas after tooltip.update'
     );
-    */
 
     chart = Highcharts.chart('container', {
         chart: {

--- a/ts/Core/Pointer.ts
+++ b/ts/Core/Pointer.ts
@@ -246,6 +246,9 @@ class Pointer {
      */
     public eventsToUnbind: Array<Function> = [];
 
+    /** @internal */
+    public followTouchMove?: boolean;
+
     /**
      * The document mousemove event handler.
      * @internal
@@ -1373,9 +1376,8 @@ class Pointer {
                 ) ||
                 pointer.runChartClick
             ),
-            tooltip = chart.tooltip,
             followTouchMove = touchesLength === 1 &&
-                pick(tooltip?.options.followTouchMove, true);
+                pointer.followTouchMove;
 
         // Don't initiate panning until the user has pinched. This prevents us
         // from blocking page scrolling as users scroll down a long page
@@ -1972,23 +1974,24 @@ class Pointer {
      * @function Highcharts.Pointer#setPointerCapture
     */
     public setPointerCapture(): void {
-        // Only for touch
-        if (!isTouchDevice) {
-            return;
-        }
-
         const pointer = this,
             events = pointer.pointerCaptureEventsToUnbind,
             chart = pointer.chart,
             container = chart.container,
-            followTouchMove = pick(
-                chart.options.tooltip?.followTouchMove,
-                true
-            ),
-            shouldHave = followTouchMove && chart.series.some(
+            // Set this.followTouchMove here to be read in the pinch and touch
+            // functions
+            followTouchMove = pointer.followTouchMove =
+                chart.options.tooltip?.followTouchMove ??
+                true,
+            shouldHave = followTouchMove && isTouchDevice && chart.series.some(
                 (series): boolean => (series.options.findNearestPointBy as any)
                     .indexOf('y') > -1
             );
+
+        // Only for touch
+        if (!isTouchDevice) {
+            return;
+        }
 
         if (!pointer.hasPointerCapture && shouldHave) {
             // Add
@@ -2019,12 +2022,6 @@ class Pointer {
                 )
             );
 
-            if (!chart.styledMode) {
-                css(container, { 'touch-action': 'none' });
-            }
-            // Mostly for styled mode
-            container.className += ' highcharts-no-touch-action';
-
             pointer.hasPointerCapture = true;
         } else if (pointer.hasPointerCapture && !shouldHave) {
             // Remove
@@ -2032,20 +2029,6 @@ class Pointer {
             // Unbind
             events.forEach((e: Function): void => e());
             events.length = 0;
-
-            if (!chart.styledMode) {
-                css(container, {
-                    'touch-action': pick(
-                        chart.options.chart.style?.['touch-action'],
-                        'manipulation'
-                    )
-                });
-            }
-            // Mostly for styled mode
-            container.className = container.className.replace(
-                ' highcharts-no-touch-action',
-                ''
-            );
 
             pointer.hasPointerCapture = false;
         }
@@ -2135,6 +2118,12 @@ class Pointer {
             } else if (start) {
                 // Hide the tooltip on touching outside the plot area (#1203)
                 this.reset();
+            }
+
+            // If inside, capture touch-drag and display tooltip. If not inside,
+            // allow dragging the finger to scroll the page
+            if (this.followTouchMove && isInside) {
+                e.preventDefault();
             }
 
         } else if ((e as any).touches.length === 2) {

--- a/ts/Core/Pointer.ts
+++ b/ts/Core/Pointer.ts
@@ -1981,7 +1981,7 @@ class Pointer {
             chart = pointer.chart,
             container = chart.container,
             followTouchMove = chart.options.tooltip?.followTouchMove ?? true,
-            shouldHave = followTouchMove && isTouchDevice && chart.series.some(
+            shouldHave = followTouchMove && chart.series.some(
                 (series): boolean => (series.options.findNearestPointBy as any)
                     .indexOf('y') > -1
             );

--- a/ts/Core/Pointer.ts
+++ b/ts/Core/Pointer.ts
@@ -246,9 +246,6 @@ class Pointer {
      */
     public eventsToUnbind: Array<Function> = [];
 
-    /** @internal */
-    public followTouchMove?: boolean;
-
     /**
      * The document mousemove event handler.
      * @internal
@@ -1377,7 +1374,7 @@ class Pointer {
                 pointer.runChartClick
             ),
             followTouchMove = touchesLength === 1 &&
-                pointer.followTouchMove;
+                (chart.tooltip?.options.followTouchMove ?? true);
 
         // Don't initiate panning until the user has pinched. This prevents us
         // from blocking page scrolling as users scroll down a long page
@@ -1974,24 +1971,20 @@ class Pointer {
      * @function Highcharts.Pointer#setPointerCapture
     */
     public setPointerCapture(): void {
-        const pointer = this,
-            events = pointer.pointerCaptureEventsToUnbind,
-            chart = pointer.chart,
-            container = chart.container,
-            // Set this.followTouchMove here to be read in the pinch and touch
-            // functions
-            followTouchMove = pointer.followTouchMove =
-                chart.options.tooltip?.followTouchMove ??
-                true,
-            shouldHave = followTouchMove && isTouchDevice && chart.series.some(
-                (series): boolean => (series.options.findNearestPointBy as any)
-                    .indexOf('y') > -1
-            );
-
         // Only for touch
         if (!isTouchDevice) {
             return;
         }
+
+        const pointer = this,
+            events = pointer.pointerCaptureEventsToUnbind,
+            chart = pointer.chart,
+            container = chart.container,
+            followTouchMove = chart.options.tooltip?.followTouchMove ?? true,
+            shouldHave = followTouchMove && isTouchDevice && chart.series.some(
+                (series): boolean => (series.options.findNearestPointBy as any)
+                    .indexOf('y') > -1
+            );
 
         if (!pointer.hasPointerCapture && shouldHave) {
             // Add
@@ -2122,7 +2115,10 @@ class Pointer {
 
             // If inside, capture touch-drag and display tooltip. If not inside,
             // allow dragging the finger to scroll the page
-            if (this.followTouchMove && isInside) {
+            if (
+                (chart.tooltip?.options.followTouchMove ?? true) &&
+                isInside
+            ) {
                 e.preventDefault();
             }
 

--- a/ts/Core/TooltipOptions.ts
+++ b/ts/Core/TooltipOptions.ts
@@ -293,7 +293,7 @@ export interface TooltipOptions {
     /**
      * Whether the tooltip should update as the finger moves on a touch
      * device. If this is `true` and [chart.panning](#chart.panning) is
-     * set,`followTouchMove` will take over one-finger touches, so the user
+     * set, `followTouchMove` will take over one-finger touches, so the user
      * needs to use two fingers for zooming and panning.
      *
      * Note the difference to [followPointer](#tooltip.followPointer) that


### PR DESCRIPTION
Fixed #24717, `tooltip.followTouchMove` unnecessarily blocked page scroll when touch-dragging on chart margins.