### PR TITLE
bugfix/24608-cumulativestart-yaxis-extremes

### DIFF
--- a/samples/unit-tests/series/cumulative/demo.js
+++ b/samples/unit-tests/series/cumulative/demo.js
@@ -169,15 +169,12 @@ QUnit.test('cumulative start option', function (assert) {
     );
 
     chart.update({
-        xAxis: {
-            min: 6,
-            max: 10
-        },
         series: [{
             cumulativeStart: true,
             data: originalData
         }]
-    }, true, true);
+    }, false, true);
+    chart.xAxis[0].setExtremes(6, 10);
 
     const visiblePoints = chart.series[0].points.filter(
         point => point.x >= 6 && point.x <= 10

--- a/samples/unit-tests/series/cumulative/demo.js
+++ b/samples/unit-tests/series/cumulative/demo.js
@@ -155,3 +155,101 @@ QUnit.test('cumulative start option', function (assert) {
         'Frist Point should start at 0'
     );
 });
+
+QUnit.test(
+    'cumulative start excludes the pre-visible point from extremes',
+    function (assert) {
+        const data = [
+                [1, -50],
+                [2, -50],
+                [3, -50],
+                [4, -50],
+                [5, -50],
+                [6, -50],
+                [7, -50],
+                [8, -50],
+                [9, -50],
+                [10, -50]
+            ],
+            createChart = cumulativeStart => Highcharts.stockChart(
+                'container',
+                {
+                    navigator: {
+                        enabled: false
+                    },
+                    scrollbar: {
+                        enabled: false
+                    },
+                    rangeSelector: {
+                        enabled: false
+                    },
+                    xAxis: {
+                        min: 6,
+                        max: 10,
+                        ordinal: false
+                    },
+                    yAxis: {
+                        startOnTick: false,
+                        endOnTick: false
+                    },
+                    plotOptions: {
+                        series: {
+                            cumulative: true,
+                            dataGrouping: {
+                                enabled: false
+                            }
+                        }
+                    },
+                    series: [{
+                        cumulativeStart,
+                        data
+                    }]
+                }
+            ),
+            chart = createChart(true),
+            visiblePoints = chart.series[0].points.filter(
+                point => point.x >= 6 && point.x <= 10
+            );
+
+        assert.strictEqual(
+            chart.yAxis[0].dataMin,
+            -250,
+            `The cumulativeStart dataMin should start from the first visible
+            point.`
+        );
+
+        assert.strictEqual(
+            chart.yAxis[0].dataMax,
+            -50,
+            `The cumulativeStart dataMax should exclude the pre-visible
+            shoulder point.`
+        );
+
+        visiblePoints.forEach(point => {
+            assert.ok(
+                point.plotY >= 0 && point.plotY <= chart.plotHeight,
+                'The visible cumulative points should be inside the plot area.'
+            );
+        });
+
+        chart.destroy();
+
+        const chartWithoutCumulativeStart = createChart(false);
+
+        assert.strictEqual(
+            chartWithoutCumulativeStart.yAxis[0].dataMin,
+            -300,
+            `Without cumulativeStart, the pre-visible shoulder point should
+            still affect cumulative extremes.`
+        );
+
+        assert.strictEqual(
+            chartWithoutCumulativeStart.yAxis[0].dataMax,
+            -50,
+            `Without cumulativeStart, the highest cumulative value should be
+            preserved.`
+        );
+
+        chartWithoutCumulativeStart.destroy();
+    }
+);

--- a/samples/unit-tests/series/cumulative/demo.js
+++ b/samples/unit-tests/series/cumulative/demo.js
@@ -103,7 +103,20 @@ QUnit.test('Stock: general tests for the Cumulative Sum', function (assert) {
 });
 
 QUnit.test('cumulative start option', function (assert) {
-    const data = [1, 1, 1, 1, 1];
+    const data = [1, 1, 1, 1, 1],
+        originalData = [
+            [1, 100],
+            [2, -300],
+            [3, 50],
+            [4, -200],
+            [5, -300],
+            [6, 150],
+            [7, 10],
+            [8, 20],
+            [9, 15],
+            [10, -5]
+        ];
+
     const chart = Highcharts.stockChart('container', {
         plotOptions: {
             series: {
@@ -154,102 +167,58 @@ QUnit.test('cumulative start option', function (assert) {
         chart.yAxis[0].toPixels(0),
         'Frist Point should start at 0'
     );
+
+    chart.update({
+        xAxis: {
+            min: 6,
+            max: 10
+        },
+        series: [{
+            cumulativeStart: true,
+            data: originalData
+        }]
+    }, true, true);
+
+    const visiblePoints = chart.series[0].points.filter(
+        point => point.x >= 6 && point.x <= 10
+    );
+
+    assert.strictEqual(
+        chart.yAxis[0].dataMin,
+        150,
+        `The cumulativeStart dataMin should start from the first visible
+        point.`
+    );
+
+    assert.strictEqual(
+        chart.yAxis[0].dataMax,
+        195,
+        `The cumulativeStart dataMax should exclude the pre-visible
+        shoulder point.`
+    );
+
+    visiblePoints.forEach(point => {
+        assert.ok(
+            point.plotY >= 0 && point.plotY <= chart.plotHeight,
+            'The visible cumulative points should be inside the plot area.'
+        );
+    });
+
+    chart.series[0].update({
+        cumulativeStart: false
+    });
+
+    assert.strictEqual(
+        chart.yAxis[0].dataMin,
+        -300,
+        `Without cumulativeStart, the pre-visible shoulder point should
+        still affect cumulative extremes.`
+    );
+
+    assert.strictEqual(
+        chart.yAxis[0].dataMax,
+        -105,
+        `Without cumulativeStart, the highest cumulative value should be
+        preserved.`
+    );
 });
-
-QUnit.test(
-    'cumulative start excludes the pre-visible point from extremes',
-    function (assert) {
-        const data = [
-                [1, -50],
-                [2, -50],
-                [3, -50],
-                [4, -50],
-                [5, -50],
-                [6, -50],
-                [7, -50],
-                [8, -50],
-                [9, -50],
-                [10, -50]
-            ],
-            createChart = cumulativeStart => Highcharts.stockChart(
-                'container',
-                {
-                    navigator: {
-                        enabled: false
-                    },
-                    scrollbar: {
-                        enabled: false
-                    },
-                    rangeSelector: {
-                        enabled: false
-                    },
-                    xAxis: {
-                        min: 6,
-                        max: 10,
-                        ordinal: false
-                    },
-                    yAxis: {
-                        startOnTick: false,
-                        endOnTick: false
-                    },
-                    plotOptions: {
-                        series: {
-                            cumulative: true,
-                            dataGrouping: {
-                                enabled: false
-                            }
-                        }
-                    },
-                    series: [{
-                        cumulativeStart,
-                        data
-                    }]
-                }
-            ),
-            chart = createChart(true),
-            visiblePoints = chart.series[0].points.filter(
-                point => point.x >= 6 && point.x <= 10
-            );
-
-        assert.strictEqual(
-            chart.yAxis[0].dataMin,
-            -250,
-            `The cumulativeStart dataMin should start from the first visible
-            point.`
-        );
-
-        assert.strictEqual(
-            chart.yAxis[0].dataMax,
-            -50,
-            `The cumulativeStart dataMax should exclude the pre-visible
-            shoulder point.`
-        );
-
-        visiblePoints.forEach(point => {
-            assert.ok(
-                point.plotY >= 0 && point.plotY <= chart.plotHeight,
-                'The visible cumulative points should be inside the plot area.'
-            );
-        });
-
-        chart.destroy();
-
-        const chartWithoutCumulativeStart = createChart(false);
-
-        assert.strictEqual(
-            chartWithoutCumulativeStart.yAxis[0].dataMin,
-            -300,
-            `Without cumulativeStart, the pre-visible shoulder point should
-            still affect cumulative extremes.`
-        );
-
-        assert.strictEqual(
-            chartWithoutCumulativeStart.yAxis[0].dataMax,
-            -50,
-            `Without cumulativeStart, the highest cumulative value should be
-            preserved.`
-        );
-
-        chartWithoutCumulativeStart.destroy();
-    }
-);

--- a/ts/Series/DataModifyComposition.ts
+++ b/ts/Series/DataModifyComposition.ts
@@ -310,11 +310,25 @@ namespace DataModifyComposition {
             } else if (
                 this.options.cumulative &&
                 isArray(activeYData) &&
-                // If only one y visible, sum doesn't change
-                // so no need to change extremes
-                activeYData.length >= 2
+                activeYData.length
             ) {
-                extremes = Additions.getCumulativeExtremes(activeYData);
+                const cumulativeYData = this.options.cumulativeStart ?
+                    getVisibleYData(this, activeYData) :
+                    activeYData;
+
+                if (cumulativeYData.length >= 2) {
+                    extremes = Additions.getCumulativeExtremes(
+                        cumulativeYData
+                    );
+                } else if (
+                    this.options.cumulativeStart &&
+                    cumulativeYData.length
+                ) {
+                    extremes = [
+                        cumulativeYData[0],
+                        cumulativeYData[0]
+                    ];
+                }
             }
 
             if (extremes) {
@@ -322,6 +336,53 @@ namespace DataModifyComposition {
                 dataExtremes.dataMax = arrayMax(extremes);
             }
         }
+    }
+
+    /**
+     * Get only the visible y values for cumulativeStart. Series#getExtremes
+     * includes a shoulder point outside the x-range for line continuity, but
+     * cumulativeStart should anchor at the first visible point.
+     * @private
+     */
+    function getVisibleYData(
+        series: Series,
+        activeYData: Array<number>
+    ): Array<number> {
+        const { xAxis, yAxis } = series;
+
+        if (!xAxis) {
+            return activeYData;
+        }
+
+        const xExtremes = xAxis.getExtremes(),
+            xData = series.getColumn('x', true),
+            yData = series.getColumn((
+                series.pointArrayMap &&
+                (series.options.pointValKey || series.pointValKey)
+            ) || 'y', true),
+            positiveValuesOnly = yAxis ? yAxis.positiveValuesOnly : false,
+            visibleYData: Array<number> = [];
+
+        if (xData.length !== yData.length) {
+            return activeYData;
+        }
+
+        for (let i = 0, iEnd = yData.length; i < iEnd; ++i) {
+            const x = xData[i],
+                y = yData[i];
+
+            if (
+                isNumber(x) &&
+                x >= xExtremes.min &&
+                x <= xExtremes.max &&
+                isNumber(y) &&
+                (y > 0 || !positiveValuesOnly)
+            ) {
+                visibleYData.push(y);
+            }
+        }
+
+        return visibleYData;
     }
 
     /* ********************************************************************** *

--- a/ts/Series/DataModifyComposition.ts
+++ b/ts/Series/DataModifyComposition.ts
@@ -348,7 +348,7 @@ namespace DataModifyComposition {
         series: Series,
         activeYData: Array<number>
     ): Array<number> {
-        const { xAxis, yAxis } = series;
+        const { xAxis } = series;
 
         if (!xAxis) {
             return activeYData;
@@ -360,7 +360,6 @@ namespace DataModifyComposition {
                 series.pointArrayMap &&
                 (series.options.pointValKey || series.pointValKey)
             ) || 'y', true),
-            positiveValuesOnly = yAxis ? yAxis.positiveValuesOnly : false,
             visibleYData: Array<number> = [];
 
         if (xData.length !== yData.length) {
@@ -375,8 +374,7 @@ namespace DataModifyComposition {
                 isNumber(x) &&
                 x >= xExtremes.min &&
                 x <= xExtremes.max &&
-                isNumber(y) &&
-                (y > 0 || !positiveValuesOnly)
+                isNumber(y)
             ) {
                 visibleYData.push(y);
             }


### PR DESCRIPTION
Fixed #24608, `cumulativeStart` included a point outside the visible range in the cumulative total, scaling the `yAxis` wrong.

___

Originally posted in https://github.com/highcharts/highcharts/pull/24641