### PR TITLE
Fixed #24734, a regression causing waterfall with upColor to crash

### DIFF
--- a/samples/unit-tests/series-waterfall/waterfall/demo.js
+++ b/samples/unit-tests/series-waterfall/waterfall/demo.js
@@ -17,7 +17,8 @@ QUnit.test('General waterfall tests', function (assert) {
                     null,
                     5,
                     { isSum: true }
-                ]
+                ],
+                upColor: 'lightgreen' // #24734
             }
         ]
     });

--- a/ts/Series/Waterfall/WaterfallSeries.ts
+++ b/ts/Series/Waterfall/WaterfallSeries.ts
@@ -226,14 +226,14 @@ class WaterfallSeries extends ColumnSeries {
 
     // Postprocess mapping between options and SVG attributes
     public pointAttribs(
-        point: WaterfallPoint,
-        state: StatesOptionsKey
+        point?: WaterfallPoint,
+        state?: StatesOptionsKey
     ): SVGAttributes {
 
         const upColor = this.options.upColor;
 
         // Set or reset up color (#3710, update to negative)
-        if (upColor && !point.options.color && isNumber(point.y)) {
+        if (upColor && point && !point.options.color && isNumber(point.y)) {
             point.color = point.y > 0 ? upColor : void 0;
         }
 


### PR DESCRIPTION
Fixed #24734, a regression causing waterfall with `upColor` to crash