### PR TITLE
Fixed issue with missing color-mix interpolation in headless browser

### DIFF
--- a/ts/Core/Chart/ChartDefaults.ts
+++ b/ts/Core/Chart/ChartDefaults.ts
@@ -870,7 +870,7 @@ const ChartDefaults: ChartOptions = {
      * @type      {Highcharts.ColorType}
      * @since     2.1.7
      */
-    selectionMarkerFill: 'color-mix(var(--highcharts-highlight-color-80) 25%, transparent)', // eslint-disable-line max-len
+    selectionMarkerFill: 'color-mix(in srgb, var(--highcharts-highlight-color-80) 25%, transparent)', // eslint-disable-line max-len
 
     /**
      * Whether to apply a drop shadow to the global series group. This causes

--- a/ts/Stock/Navigator/NavigatorDefaults.ts
+++ b/ts/Stock/Navigator/NavigatorDefaults.ts
@@ -223,8 +223,7 @@ const NavigatorDefaults: NavigatorOptions = {
      *
      * @type    {Highcharts.ColorType}
      */
-    maskFill:
-        'color-mix(var(--highcharts-highlight-color-60) 30%, transparent)',
+    maskFill: 'color-mix(in srgb, var(--highcharts-highlight-color-60) 30%, transparent)', // eslint-disable-line max-len
 
     /**
      * The color of the line marking the currently zoomed area in the


### PR DESCRIPTION
Fixed issue with missing explicit color-mix interpolation in headless browser.

This worked in modern browsers:
`mix(var(--highcharts-highlight-color-60) 30%, transparent)`

... but apparently failed in whatever headless browser we are using to build the demo page thumbnails.