### PR TITLE
Trying to fix timezone tests in CI

### DIFF
--- a/tests/highcharts/time/timezone.spec.ts
+++ b/tests/highcharts/time/timezone.spec.ts
@@ -21,7 +21,7 @@ const TIMEZONES = [
 ] as const;
 
 /**
- * Helper to set up a page with Highcharts and optionally moment-timezone
+ * Helper to set up a page with Highcharts
  */
 async function setupPage(page: import('@playwright/test').Page) {
     await page.setContent(`
@@ -38,8 +38,17 @@ async function setupPage(page: import('@playwright/test').Page) {
 }
 
 for (const tz of TIMEZONES) {
-    test.describe(`Timezone: ${tz}; userAgent: ${navigator.userAgent}`, () => {
+    test.describe(`Timezone: ${tz}`, () => {
         test.use({ timezoneId: tz });
+
+        test.afterEach(async ({ page }, testInfo) => {
+            if (testInfo.status !== testInfo.expectedStatus) {
+                const userAgent = await page.evaluate(
+                    () => navigator.userAgent
+                );
+                console.log(`userAgent: ${userAgent}`);
+            }
+        });
 
         test('Time.dateFormat with fixed CET timezone across DST', async ({ page }) => {
             await setupPage(page);

--- a/tests/highcharts/time/timezone.spec.ts
+++ b/tests/highcharts/time/timezone.spec.ts
@@ -8,12 +8,6 @@
  * This replaces the previous QUnit-based approach with native Playwright tests.
  */
 import { test, expect } from '~/fixtures.ts';
-import { join } from 'node:path';
-
-// Paths relative to repo root (where Playwright runs from)
-// Using 1970-2030 data file to ensure timezone data is available for test dates
-const MOMENT_PATH = join('node_modules', 'moment', 'moment.js');
-const MOMENT_TZ_PATH = join('node_modules', 'moment-timezone', 'builds', 'moment-timezone-with-data-1970-2030.min.js');
 
 const TIMEZONES = [
     'Australia/Melbourne',
@@ -29,7 +23,7 @@ const TIMEZONES = [
 /**
  * Helper to set up a page with Highcharts and optionally moment-timezone
  */
-async function setupPage(page: import('@playwright/test').Page, needsMoment = false) {
+async function setupPage(page: import('@playwright/test').Page) {
     await page.setContent(`
         <!DOCTYPE html>
         <html>
@@ -41,22 +35,14 @@ async function setupPage(page: import('@playwright/test').Page, needsMoment = fa
     // Load Highcharts from local code via route rewriting
     await page.addScriptTag({ url: 'https://code.highcharts.com/highcharts.js' });
     await page.waitForFunction(() => !!(window as any).Highcharts);
-
-    if (needsMoment) {
-        // Load moment first, then moment-timezone (which depends on moment)
-        await page.addScriptTag({ path: MOMENT_PATH });
-        await page.waitForFunction(() => !!(window as any).moment);
-        await page.addScriptTag({ path: MOMENT_TZ_PATH });
-        await page.waitForFunction(() => !!(window as any).moment.tz);
-    }
 }
 
 for (const tz of TIMEZONES) {
-    test.describe(`Timezone: ${tz}`, () => {
+    test.describe(`Timezone: ${tz}; userAgent: ${navigator.userAgent}`, () => {
         test.use({ timezoneId: tz });
 
         test('Time.dateFormat with fixed CET timezone across DST', async ({ page }) => {
-            await setupPage(page, true);
+            await setupPage(page);
 
             const result = await page.evaluate(() => {
                 const Highcharts = (window as any).Highcharts;
@@ -94,7 +80,7 @@ for (const tz of TIMEZONES) {
         });
 
         test('Time.parse with timezone information', async ({ page }) => {
-            await setupPage(page, false);
+            await setupPage(page);
 
             const result = await page.evaluate(() => {
                 const Highcharts = (window as any).Highcharts;
@@ -112,8 +98,8 @@ for (const tz of TIMEZONES) {
                 ];
 
                 const expected = new Date(samples[0]).toISOString();
-                const results: { 
-                    sample: string; parsed: string; matches: boolean 
+                const results: {
+                    sample: string; parsed: string; matches: boolean
                 }[] = [];
 
                 samples.forEach(sample => {
@@ -131,14 +117,14 @@ for (const tz of TIMEZONES) {
 
             for (const r of result.results) {
                 expect(
-                    r.matches, 
+                    r.matches,
                     `${r.sample} should parse to ${result.expected}, got ${r.parsed}`
                 ).toBe(true);
             }
         });
 
         test('Time.parse short month format', async ({ page }) => {
-            await setupPage(page, false);
+            await setupPage(page);
 
             const result = await page.evaluate(() => {
                 const Highcharts = (window as any).Highcharts;
@@ -159,7 +145,7 @@ for (const tz of TIMEZONES) {
         });
 
         test('Time ticks across DST transition', async ({ page }) => {
-            await setupPage(page, true);
+            await setupPage(page);
 
             const result = await page.evaluate(() => {
                 const Highcharts = (window as any).Highcharts;
@@ -191,11 +177,11 @@ for (const tz of TIMEZONES) {
         });
 
         test('Chart timezone option', async ({ page }) => {
-            await setupPage(page, true);
+            await setupPage(page);
 
             const result = await page.evaluate(() => {
                 const Highcharts = (window as any).Highcharts;
-                
+
                 const chart = Highcharts.chart('container', {
                     title: { text: 'Timezone test' },
                     time: { timezone: 'Europe/Oslo' },
@@ -220,11 +206,11 @@ for (const tz of TIMEZONES) {
         });
 
         test('Chart.update timezone change', async ({ page }) => {
-            await setupPage(page, true);
+            await setupPage(page);
 
             const result = await page.evaluate(() => {
                 const Highcharts = (window as any).Highcharts;
-                
+
                 const chart = Highcharts.chart('container', {
                     chart: { width: 600, height: 200 },
                     time: { timezone: 'Europe/Oslo' },
@@ -269,11 +255,11 @@ for (const tz of TIMEZONES) {
         });
 
         test('Updating from global to instance time', async ({ page }) => {
-            await setupPage(page, true);
+            await setupPage(page);
 
             const result = await page.evaluate(() => {
                 const Highcharts = (window as any).Highcharts;
-                
+
                 const chart = Highcharts.chart('container', {
                     series: [{ data: [1, 3, 2, 4] }]
                 });


### PR DESCRIPTION
Trying to fix timezone tests in [nightly runs](https://github.com/highcharts/highcharts/actions/runs/27521845510) that started appearing on June 2nd. 

These tests run on node directly, and don't seem to be related to a change in Highcharts. May be the node version changed. The tests used Moment and Moment Timezone, but Highcharts no longer use that since v12.