### PR TITLE
Samples: changed CSS to refer to divs in useHTML

### DIFF
--- a/changelog/highcharts/13.0.0.md
+++ b/changelog/highcharts/13.0.0.md
@@ -16,9 +16,9 @@
 - Solid gauge `radius` and `innerRadius`, when given as numeric values, defined on series or point level, no longer resolve as percents, but as pixels. To set it to a percent, use a percentage string like `radius: '50%'`.
 - The `dataSorting` feature now requires the `modules/data-sorting.js` file.
 - Default data label positions have changed slightly. Previously, the distance to the point or column was determined by `padding` and adjusted by `x` and `y`. Introduced new option, `dataLabels.distance`, in order to allow backgrounds with padding without touching the point.
-- Content marked with `useHTML` is now wrapped in a `div` instead of a `span`,
-  in order to comply to valid HTML. Custom CSS rules adressing the span may have
-  to be updated.
+- Content marked with `useHTML` is now wrapped in a `div` instead of a `span`
+  in order to comply with valid HTML. Custom CSS rules addressing the `span` may
+  have to be updated.
 
 ## Bug fixes
 - Fixed [#23771](https://github.com/highcharts/highcharts/issues/23771), boosted points were missing keyed values after zoom.

--- a/changelog/highcharts/13.0.0.md
+++ b/changelog/highcharts/13.0.0.md
@@ -16,6 +16,9 @@
 - Solid gauge `radius` and `innerRadius`, when given as numeric values, defined on series or point level, no longer resolve as percents, but as pixels. To set it to a percent, use a percentage string like `radius: '50%'`.
 - The `dataSorting` feature now requires the `modules/data-sorting.js` file.
 - Default data label positions have changed slightly. Previously, the distance to the point or column was determined by `padding` and adjusted by `x` and `y`. Introduced new option, `dataLabels.distance`, in order to allow backgrounds with padding without touching the point.
+- Content marked with `useHTML` is now wrapped in a `div` instead of a `span`,
+  in order to comply to valid HTML. Custom CSS rules adressing the span may have
+  to be updated.
 
 ## Bug fixes
 - Fixed [#23771](https://github.com/highcharts/highcharts/issues/23771), boosted points were missing keyed values after zoom.

--- a/samples/highcharts/demo/sparkline/demo.css
+++ b/samples/highcharts/demo/sparkline/demo.css
@@ -47,7 +47,7 @@ thead th {
     border-bottom: 2px solid gray;
 }
 
-.highcharts-tooltip > span {
+.highcharts-tooltip div {
     background: white;
     border: 1px solid silver;
     border-radius: 3px;

--- a/samples/highcharts/tooltip/fullhtml/demo.css
+++ b/samples/highcharts/tooltip/fullhtml/demo.css
@@ -2,7 +2,7 @@
     height: 400px;
 }
 
-.highcharts-tooltip > span {
+.highcharts-tooltip div {
     background: rgb(255 255 255 / 85%);
     border: 1px solid silver;
     border-radius: 3px;

--- a/samples/maps/demo/tooltip/demo.css
+++ b/samples/maps/demo/tooltip/demo.css
@@ -9,7 +9,7 @@ body {
     margin: 0 auto;
 }
 
-.highcharts-tooltip > span {
+.highcharts-tooltip div {
     padding: 10px;
     white-space: normal !important;
     width: 200px;


### PR DESCRIPTION
Samples: changed CSS to refer to divs in `useHTML`

Closes #24743 