### PR TITLE
bugfix/flex-config-chart-shrinking

### DIFF
--- a/samples/unit-tests/chart/reflow/demo.js
+++ b/samples/unit-tests/chart/reflow/demo.js
@@ -343,38 +343,6 @@ QUnit.test('Chart reflow using ResizeObserver, #17951.', assert => {
 });
 
 QUnit.test(
-    'The renderTo must not receive inline styles in styled mode', assert => {
-        const renderTo = document.createElement('div');
-        renderTo.style.width = '600px';
-        renderTo.style.height = '400px';
-        document.getElementById('container').appendChild(renderTo);
-
-        // Save the styles to compare it later
-        const userStyles = renderTo.getAttribute('style');
-        Highcharts.chart(renderTo, {
-            chart: {
-                styledMode: true,
-                animation: false
-            },
-            series: [{
-                data: [1, 2, 3]
-            }]
-        });
-
-        assert.strictEqual(
-            renderTo.getAttribute('style'),
-            userStyles,
-            'The `renderTo` inline style should not be mutated by Highcharts.'
-        );
-        assert.strictEqual(
-            renderTo.style.overflow,
-            '',
-            'The `overflow` must not be forced inline.'
-        );
-    }
-);
-
-QUnit.test(
     'A11y elements must not inflate chart height in styled mode',
     assert => {
         if (!window.requestAnimationFrame) {

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -2105,11 +2105,8 @@ class Chart {
         let chartWidth = chart.chartWidth;
 
         // Allow table cells and flex-boxes to shrink without the chart
-        // blocking them out (#6427) but skip in styled mode so inline styles
-        // don't override user CSS on renderTo
-        if (!chart.styledMode) {
-            css(renderTo, { overflow: 'hidden' });
-        }
+        // blocking them out (#6427)
+        css(renderTo, { overflow: 'hidden' });
 
         // Create the inner container
         if (!chart.styledMode) {


### PR DESCRIPTION
Fixed chart not correctly fitting its container in flex layouts.

This is a fix for the regression introduced in the https://github.com/highcharts/highcharts/pull/24503.