### PR TITLE
bugfix/24608-cumulative-start-get-extremes

### DIFF
--- a/samples/unit-tests/series/cumulative/demo.js
+++ b/samples/unit-tests/series/cumulative/demo.js
@@ -103,7 +103,20 @@ QUnit.test('Stock: general tests for the Cumulative Sum', function (assert) {
 });
 
 QUnit.test('cumulative start option', function (assert) {
-    const data = [1, 1, 1, 1, 1];
+    const data = [1, 1, 1, 1, 1],
+        originalData = [
+            [1, 100],
+            [2, -300],
+            [3, 50],
+            [4, -200],
+            [5, -300],
+            [6, 150],
+            [7, 10],
+            [8, 20],
+            [9, 15],
+            [10, -5]
+        ];
+
     const chart = Highcharts.stockChart('container', {
         plotOptions: {
             series: {
@@ -153,5 +166,56 @@ QUnit.test('cumulative start option', function (assert) {
         point1,
         chart.yAxis[0].toPixels(0),
         'Frist Point should start at 0'
+    );
+
+    chart.update({
+        series: [{
+            cumulativeStart: true,
+            data: originalData
+        }]
+    }, false, true);
+    chart.xAxis[0].setExtremes(6, 10);
+
+    const visiblePoints = chart.series[0].points.filter(
+        point => point.x >= 6 && point.x <= 10
+    );
+
+    assert.strictEqual(
+        chart.yAxis[0].dataMin,
+        150,
+        `The cumulativeStart dataMin should start from the first visible
+        point.`
+    );
+
+    assert.strictEqual(
+        chart.yAxis[0].dataMax,
+        195,
+        `The cumulativeStart dataMax should exclude the pre-visible
+        shoulder point.`
+    );
+
+    visiblePoints.forEach(point => {
+        assert.ok(
+            point.plotY >= 0 && point.plotY <= chart.plotHeight,
+            'The visible cumulative points should be inside the plot area.'
+        );
+    });
+
+    chart.series[0].update({
+        cumulativeStart: false
+    });
+
+    assert.strictEqual(
+        chart.yAxis[0].dataMin,
+        -300,
+        `Without cumulativeStart, the pre-visible shoulder point should
+        still affect cumulative extremes.`
+    );
+
+    assert.strictEqual(
+        chart.yAxis[0].dataMax,
+        -105,
+        `Without cumulativeStart, the highest cumulative value should be
+        preserved.`
     );
 });

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -2592,6 +2592,11 @@ class Series {
             xMin = xExtremes.min;
             xMax = xExtremes.max;
         }
+        // Used only for `cumulativeStart`, #24608
+        const excludeShoulder = this.options.cumulative &&
+            this.options.cumulativeStart &&
+            shoulder &&
+            !getExtremesFromAll;
 
         for (i = 0; i < rowCount; i++) {
 
@@ -2605,6 +2610,8 @@ class Series {
                     (xData[i - shoulder] || x) <= xMax
                 )
             ) {
+                const skipShoulder = excludeShoulder && isNumber(x) && x < xMin;
+
                 for (const values of yAxisData) {
                     const val = values[i];
 
@@ -2613,7 +2620,8 @@ class Series {
                     // consider y extremes.
                     if (
                         isNumber(val) &&
-                        (val > 0 || !positiveValuesOnly)
+                        (val > 0 || !positiveValuesOnly) &&
+                        !skipShoulder
                     ) {
                         activeYData.push(val);
                     }

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -2554,11 +2554,11 @@ class Series {
         ),
         forceExtremesFromAll?: boolean
     ): DataExtremesObject {
-        const { xAxis, yAxis } = this,
+        const { options, xAxis, yAxis } = this,
             getExtremesFromAll =
                 forceExtremesFromAll ||
                 this.getExtremesFromAll ||
-                this.options.getExtremesFromAll, // #4599, #21003
+                options.getExtremesFromAll, // #4599, #21003
             table = getExtremesFromAll && this.cropped ?
                 this.dataTable :
                 this.dataTable.getModified(),
@@ -2575,14 +2575,19 @@ class Series {
             // non-sorted data like scatter (#7639).
             shoulder = this.requireSorting && !this.is('column') ?
                 1 : 0,
-            // #2117, need to compensate for log X axis
+            // Used only for `cumulativeStart` (#24608)
+            excludeShoulder = options.cumulative &&
+                options.cumulativeStart &&
+                shoulder &&
+                !getExtremesFromAll,
+            // Compensate for log X axis (#2117)
             positiveValuesOnly = yAxis ? yAxis.positiveValuesOnly : false,
             doAll = getExtremesFromAll ||
                 this.cropped ||
                 !xAxis; // For colorAxis support
 
         let xExtremes,
-            x,
+            x: number,
             i,
             xMin = 0,
             xMax = 0;
@@ -2592,25 +2597,19 @@ class Series {
             xMin = xExtremes.min;
             xMax = xExtremes.max;
         }
-        // Used only for `cumulativeStart`, #24608
-        const excludeShoulder = this.options.cumulative &&
-            this.options.cumulativeStart &&
-            shoulder &&
-            !getExtremesFromAll;
 
         for (i = 0; i < rowCount; i++) {
 
             x = xData[i];
 
-            // Check if it is within the selected x axis range
-            if (
+            // Check if it is within the selected x-axis range
+            if ((
                 doAll ||
                 (
                     (xData[i + shoulder] || x) >= xMin &&
                     (xData[i - shoulder] || x) <= xMax
                 )
-            ) {
-                const skipShoulder = excludeShoulder && isNumber(x) && x < xMin;
+            ) && (!excludeShoulder || x >= xMin)) {
 
                 for (const values of yAxisData) {
                     const val = values[i];
@@ -2620,8 +2619,7 @@ class Series {
                     // consider y extremes.
                     if (
                         isNumber(val) &&
-                        (val > 0 || !positiveValuesOnly) &&
-                        !skipShoulder
+                        (val > 0 || !positiveValuesOnly)
                     ) {
                         activeYData.push(val);
                     }


### PR DESCRIPTION
Fixed #24608, y-axis extremes were incorrent when using `cumulativeStart`.