### PR TITLE
bugfix/24386-scatter-zoom-boost

### DIFF
--- a/samples/unit-tests/boost/scatter-with-boost-zoom-reset/demo.css
+++ b/samples/unit-tests/boost/scatter-with-boost-zoom-reset/demo.css
@@ -1,0 +1,5 @@
+#container {
+    width: 600px;
+    height: 350px;
+    margin: 0 auto;
+}

--- a/samples/unit-tests/boost/scatter-with-boost-zoom-reset/demo.details
+++ b/samples/unit-tests/boost/scatter-with-boost-zoom-reset/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/boost/scatter-with-boost-zoom-reset/demo.html
+++ b/samples/unit-tests/boost/scatter-with-boost-zoom-reset/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/boost.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container"></div>

--- a/samples/unit-tests/boost/scatter-with-boost-zoom-reset/demo.js
+++ b/samples/unit-tests/boost/scatter-with-boost-zoom-reset/demo.js
@@ -1,0 +1,127 @@
+QUnit[Highcharts.hasWebGLSupport() ? 'test' : 'skip'](
+    'Boosted scatter reset zoom restores Y extremes (#24386)',
+    function (assert) {
+        const data = [];
+        for (let i = 0; i < 1000000; i++) {
+            data.push([
+                Math.pow(Math.random(), 2) * 100,
+                Math.pow(Math.random(), 2) * 100
+            ]);
+        }
+
+        const chart = Highcharts.chart('container', {
+            chart: {
+                type: 'scatter',
+                zooming: {
+                    type: 'y'
+                }
+            },
+            boost: {
+                useGPUTranslations: true
+            },
+            series: [{
+                boostThreshold: 1,
+                data: data
+            }]
+        });
+
+        const series = chart.series[0],
+            yAxis = chart.yAxis[0],
+            initialDataMin = yAxis.dataMin,
+            initialDataMax = yAxis.dataMax;
+
+        assert.ok(
+            series.boosted,
+            'Series should be boosted.'
+        );
+
+        // Zoom in on the Y axis
+        yAxis.setExtremes(40, 60);
+
+        assert.ok(
+            yAxis.max - yAxis.min < initialDataMax - initialDataMin,
+            'Y axis should be zoomed in.'
+        );
+
+        // Reset zoom
+        yAxis.setExtremes(null, null);
+
+        assert.strictEqual(
+            yAxis.dataMin,
+            initialDataMin,
+            'yAxis dataMin should be restored after reset zoom.'
+        );
+
+        assert.strictEqual(
+            yAxis.dataMax,
+            initialDataMax,
+            'yAxis dataMax should be restored after reset zoom.'
+        );
+    }
+);
+
+QUnit[Highcharts.hasWebGLSupport() ? 'test' : 'skip'](
+    'Boosted scatter reset zoom after a deep zoom disables boost (#24386)',
+    function (assert) {
+        const data = [];
+        for (let i = 0; i < 1000000; i++) {
+            data.push([
+                Math.pow(Math.random(), 2) * 100,
+                Math.pow(Math.random(), 2) * 100
+            ]);
+        }
+
+        const chart = Highcharts.chart('container', {
+            chart: {
+                type: 'scatter',
+                zooming: {
+                    type: 'y'
+                }
+            },
+            boost: {
+                useGPUTranslations: true
+            },
+            series: [{
+                data: data
+            }]
+        });
+
+        const series = chart.series[0],
+            yAxis = chart.yAxis[0],
+            initialYDataMin = yAxis.dataMin,
+            initialYDataMax = yAxis.dataMax;
+
+        assert.ok(
+            series.boosted,
+            'Series should be boosted from the start.'
+        );
+
+        // Zoom into a tiny Y sector with few points to disable boost
+        yAxis.setExtremes(995, 1000);
+
+        assert.notOk(
+            series.boosted,
+            'Boost should be disabled when very few points are visible.'
+        );
+
+        // Reset zoom
+        yAxis.setExtremes(null, null);
+
+        assert.strictEqual(
+            yAxis.dataMin,
+            initialYDataMin,
+            'yAxis dataMin should be restored after reset zoom.'
+        );
+
+        assert.strictEqual(
+            yAxis.dataMax,
+            initialYDataMax,
+            'yAxis dataMax should be restored after reset zoom.'
+        );
+
+        assert.ok(
+            series.boosted,
+            'Boost should re-enable after reset zoom.'
+        );
+    }
+);

--- a/samples/unit-tests/boost/scatter-with-boost-zoom-reset/demo.js
+++ b/samples/unit-tests/boost/scatter-with-boost-zoom-reset/demo.js
@@ -44,7 +44,7 @@ QUnit[Highcharts.hasWebGLSupport() ? 'test' : 'skip'](
         );
 
         // Reset zoom
-        yAxis.setExtremes(null, null);
+        chart.zoomOut();
 
         assert.strictEqual(
             yAxis.dataMin,
@@ -97,7 +97,7 @@ QUnit[Highcharts.hasWebGLSupport() ? 'test' : 'skip'](
         );
 
         // Zoom into a tiny Y sector with few points to disable boost
-        yAxis.setExtremes(995, 1000);
+        yAxis.setExtremes(99.5, 100);
 
         assert.notOk(
             series.boosted,
@@ -105,7 +105,7 @@ QUnit[Highcharts.hasWebGLSupport() ? 'test' : 'skip'](
         );
 
         // Reset zoom
-        yAxis.setExtremes(null, null);
+        chart.zoomOut();
 
         assert.strictEqual(
             yAxis.dataMin,

--- a/ts/Extensions/Boost/Boost.ts
+++ b/ts/Extensions/Boost/Boost.ts
@@ -155,6 +155,22 @@ function compose(
                     opacity
                 });
         }
+
+        // Boosted scatter crops its data table on the Y axis, so it must be
+        // reprocessed when the axis extremes change (#24386).
+        if (!this.isPanning) {
+            for (const series of this.series) {
+                if (
+                    series.boost &&
+                    series.is('scatter') &&
+                    !series.is('bubble') &&
+                    !series.is('treemap') &&
+                    !series.is('heatmap')
+                ) {
+                    series.isDirty = true;
+                }
+            }
+        }
     });
 }
 

--- a/ts/Extensions/Boost/BoostSeries.ts
+++ b/ts/Extensions/Boost/BoostSeries.ts
@@ -1046,7 +1046,15 @@ function scatterProcessData(
         yData = series.getColumn('y'),
         yExtremes = yAxis.getExtremes(),
         yMax = yExtremes.max ?? Number.MAX_VALUE,
-        yMin = yExtremes.min ?? -Number.MAX_VALUE;
+        yMin = yExtremes.min ?? -Number.MAX_VALUE,
+        // Crop on the Y axis only against the hard options bounds, not the
+        // auto-scaled `yAxis.min` and `yAxis.max`. Cropping against them would
+        // lock reset zoom to the old window and stop the data extremes from
+        // being restored (#24386).
+        yCropMin = yAxis.userMin ?? (isNumber(yAxis.options.min) ?
+            yAxis.options.min : -Number.MAX_VALUE),
+        yCropMax = yAxis.userMax ?? (isNumber(yAxis.options.max) ?
+            yAxis.options.max : Number.MAX_VALUE);
 
     /// if (series.boost) {
     //     delete series.boost.pointDataIndices;
@@ -1110,7 +1118,7 @@ function scatterProcessData(
 
         if (
             x >= xMin && x <= xMax &&
-            y >= yMin && y <= yMax
+            y >= yCropMin && y <= yCropMax
         ) {
             processedXData.push(x);
             processedYData.push(y);


### PR DESCRIPTION
Fixed #24386, wrong y-axis extremes after zooming out on boosted scatter.