### PR TITLE
Chores: Shorter name for borderRadiusObject utility

### DIFF
--- a/samples/unit-tests/series-boxplot/boxplot/demo.js
+++ b/samples/unit-tests/series-boxplot/boxplot/demo.js
@@ -110,11 +110,11 @@ QUnit.test('Individual fill color (#5770)', function (assert) {
     );
 
     chart.series[0].update({ borderRadius: 0 });
-    assert.strictEqual(
-        chart.series[0].points[0].box.pathArray.filter(
+    assert.deepEqual(
+        chart.series[0].points[0].box.pathArray.find(
             segment => segment[0] === 'A'
-        ).length,
-        0,
+        ).slice(0, 3),
+        ['A', 0, 0],
         'A borderRadius of 0 should fall back to sharp corners'
     );
 });

--- a/ts/Core/Axis/RadialAxis.ts
+++ b/ts/Core/Axis/RadialAxis.ts
@@ -38,7 +38,7 @@ import type Tick from './Tick';
 import type RadialAxisOptions from './RadialAxisOptions';
 import RadialAxisDefaults from './RadialAxisDefaults.js';
 
-import { optionsToBorderRadiusObject } from '../../Extensions/BorderRadius.js';
+import { borderRadiusObject } from '../../Extensions/BorderRadius.js';
 import D from '../Defaults.js';
 const { defaultOptions } = D;
 import H from '../Globals.js';
@@ -754,7 +754,7 @@ namespace RadialAxis {
             },
             center = this.center,
             { endAngleRad, startAngleRad } = this,
-            borderRadius = optionsToBorderRadiusObject(
+            borderRadius = borderRadiusObject(
                 options.borderRadius ??
                 this.pane.options.borderRadius
             ),

--- a/ts/Extensions/BorderRadius.ts
+++ b/ts/Extensions/BorderRadius.ts
@@ -322,7 +322,7 @@ function arc(
         sinHalfAlpha = Math.sin(alpha / 2),
         borderRadius = Math.max(Math.min(
             relativeLength(
-                optionsToBorderRadiusObject(options.borderRadius).radius,
+                borderRadiusObject(options.borderRadius).radius,
                 r - innerR
             ),
             // Cap to half the sector radius
@@ -371,7 +371,7 @@ function seriesOnAfterColumnTranslate(
             seriesDefault = defaultOptions.plotOptions
                 ?.[this.type]
                 ?.borderRadius,
-            borderRadius = optionsToBorderRadiusObject(
+            borderRadius = borderRadiusObject(
                 options.borderRadius,
                 isObject(seriesDefault) ? seriesDefault : {}
             ),
@@ -514,8 +514,12 @@ export function composeBorderRadius(
 
 }
 
-/** @internal */
-export function optionsToBorderRadiusObject(
+/**
+ * Utility function to get the full border radius options object, from a simple
+ * number or a partial options object.
+ * @internal
+ */
+export function borderRadiusObject(
     options?: number|string|Partial<BorderRadiusOptionsObject>,
     seriesBROptions?: Partial<BorderRadiusOptionsObject>
 ): BorderRadiusOptionsObject {
@@ -529,7 +533,7 @@ export function optionsToBorderRadiusObject(
 function pieSeriesOnAfterTranslate(
     this: PieSeries
 ): void {
-    const borderRadius = optionsToBorderRadiusObject(this.options.borderRadius);
+    const borderRadius = borderRadiusObject(this.options.borderRadius);
 
     for (const point of this.points) {
         const shapeArgs = point.shapeArgs;

--- a/ts/Series/BoxPlot/BoxPlotSeries.ts
+++ b/ts/Series/BoxPlot/BoxPlotSeries.ts
@@ -24,6 +24,7 @@ import type SVGAttributes from '../../Core/Renderer/SVG/SVGAttributes';
 import type SVGElement from '../../Core/Renderer/SVG/SVGElement';
 import type SVGPath from '../../Core/Renderer/SVG/SVGPath';
 
+import { borderRadiusObject } from '../../Extensions/BorderRadius.js';
 import BoxPlotSeriesDefaults from './BoxPlotSeriesDefaults.js';
 import ColumnSeries from '../Column/ColumnSeries.js';
 import H from '../../Core/Globals.js';
@@ -308,24 +309,24 @@ class BoxPlotSeries extends ColumnSeries {
                     point.medianShape.attr(medianAttr);
                 }
 
-                let d: SVGPath;
-
                 // The stem
                 const stemX = crisp(
                     (point.plotX || 0) + (series.pointXOffset || 0) +
                         ((series.barW || 0) / 2),
                     point.stem.strokeWidth()
                 );
-                d = [
-                    // Stem up
-                    ['M', stemX, q3Plot],
-                    ['L', stemX, highPlot],
 
-                    // Stem down
-                    ['M', stemX, q1Plot],
-                    ['L', stemX, lowPlot]
-                ];
-                point.stem[verb]({ d });
+                point.stem[verb]({
+                    d: [
+                        // Stem up
+                        ['M', stemX, q3Plot],
+                        ['L', stemX, highPlot],
+
+                        // Stem down
+                        ['M', stemX, q1Plot],
+                        ['L', stemX, lowPlot]
+                    ]
+                });
 
                 // The box
                 if (doQuartiles) {
@@ -336,34 +337,24 @@ class BoxPlotSeries extends ColumnSeries {
                     right = crisp(right, boxStrokeWidth);
 
                     // Optionally round the corners of the box
-                    const brOption = options.borderRadius,
-                        radius = brOption && typeof brOption === 'object' ?
-                            (brOption.radius || 0) : (brOption || 0),
-                        r = Math.min(
-                            relativeLength(radius, right - x),
-                            (right - x) / 2,
-                            Math.abs(q1Plot - q3Plot) / 2
-                        );
+                    const r = Math.min(
+                        relativeLength(
+                            borderRadiusObject(options.borderRadius).radius,
+                            right - x
+                        ),
+                        (right - x) / 2,
+                        Math.abs(q1Plot - q3Plot) / 2
+                    );
 
-                    if (r) {
-                        d = renderer.symbols.roundedRect(
+                    point.box[verb]({
+                        d: renderer.symbols.roundedRect(
                             x,
                             Math.min(q1Plot, q3Plot),
                             right - x,
                             Math.abs(q1Plot - q3Plot),
                             { r }
-                        );
-                    } else {
-                        d = [
-                            ['M', x, q3Plot],
-                            ['L', x, q1Plot],
-                            ['L', right, q1Plot],
-                            ['L', right, q3Plot],
-                            ['L', x, q3Plot],
-                            ['Z']
-                        ];
-                    }
-                    point.box[verb]({ d });
+                        )
+                    });
                 }
 
                 // The whiskers
@@ -394,11 +385,12 @@ class BoxPlotSeries extends ColumnSeries {
                     point.medianShape.strokeWidth()
                 );
 
-                d = [
-                    ['M', x, medianPlot],
-                    ['L', right, medianPlot]
-                ];
-                point.medianShape[verb]({ d });
+                point.medianShape[verb]({
+                    d: [
+                        ['M', x, medianPlot],
+                        ['L', right, medianPlot]
+                    ]
+                });
             }
         }
 

--- a/ts/Series/DependencyWheel/DependencyWheelSeries.ts
+++ b/ts/Series/DependencyWheel/DependencyWheelSeries.ts
@@ -24,7 +24,7 @@ import type DependencyWheelSeriesOptions from './DependencyWheelSeriesOptions';
 
 import A from '../../Core/Animation/AnimationUtilities.js';
 const { animObject } = A;
-import { optionsToBorderRadiusObject } from '../../Extensions/BorderRadius.js';
+import { borderRadiusObject } from '../../Extensions/BorderRadius.js';
 import DependencyWheelPoint from './DependencyWheelPoint.js';
 import DependencyWheelSeriesDefaults from './DependencyWheelSeriesDefaults.js';
 import H from '../../Core/Globals.js';
@@ -235,7 +235,7 @@ class DependencyWheelSeries extends SankeySeries {
                 (series.chart.plotHeight + series.getNodePadding()),
             center = series.getCenter(),
             startAngle = ((options.startAngle || 0) - 90) * deg2rad,
-            borderRadius = optionsToBorderRadiusObject(
+            borderRadius = borderRadiusObject(
                 options.borderRadius
             ).radius;
 

--- a/ts/Series/Funnel/FunnelSeries.ts
+++ b/ts/Series/Funnel/FunnelSeries.ts
@@ -35,7 +35,7 @@ const {
     composed,
     noop
 } = H;
-import { optionsToBorderRadiusObject } from '../../Extensions/BorderRadius.js';
+import { borderRadiusObject } from '../../Extensions/BorderRadius.js';
 import SeriesRegistry from '../../Core/Series/SeriesRegistry.js';
 const {
     column: ColumnSeries,
@@ -293,9 +293,7 @@ class FunnelSeries extends PieSeries {
             options = series.options,
             reversed = options.reversed,
             ignoreHiddenPoint = options.ignoreHiddenPoint,
-            borderRadiusObject = optionsToBorderRadiusObject(
-                options.borderRadius
-            ),
+            borderRadiusObj = borderRadiusObject(options.borderRadius),
             plotWidth = chart.plotWidth,
             plotHeight = chart.plotHeight,
             center: Array<(number|string)> = options.center as any,
@@ -308,10 +306,10 @@ class FunnelSeries extends PieSeries {
             neckY = (centerY - height / 2) + height - neckHeight,
             points = series.points,
             borderRadius = relativeLength(
-                borderRadiusObject.radius,
+                borderRadiusObj.radius,
                 width
             ),
-            radiusScope = borderRadiusObject.scope,
+            radiusScope = borderRadiusObj.scope,
             half = (
                 (options.dataLabels as any).position === 'left' ?
                     1 :

--- a/ts/Series/PolarComposition.ts
+++ b/ts/Series/PolarComposition.ts
@@ -47,7 +47,7 @@ import type Tick from '../Core/Axis/Tick';
 
 import A from '../Core/Animation/AnimationUtilities.js';
 const { animObject } = A;
-import { optionsToBorderRadiusObject } from '../Extensions/BorderRadius.js';
+import { borderRadiusObject } from '../Extensions/BorderRadius.js';
 import D from '../Core/Defaults.js';
 const { defaultOptions } = D;
 import H from '../Core/Globals.js';
@@ -681,7 +681,7 @@ function onSeriesAfterColumnTranslate(
         const seriesDefault = defaultOptions.plotOptions
                 ?.[this.type]
                 ?.borderRadius,
-            { scope, where = 'end' } = optionsToBorderRadiusObject(
+            { scope, where = 'end' } = borderRadiusObject(
                 options.borderRadius,
                 isObject(seriesDefault) ? seriesDefault : {}
             );
@@ -1119,7 +1119,7 @@ function onAfterColumnTranslate(
                 r = Math.max(barX + (point.pointWidth || 0), 0);
 
                 // Handle border radius
-                const brOption = optionsToBorderRadiusObject(
+                const brOption = borderRadiusObject(
                         options.borderRadius
                     ),
                     borderRadius = relativeLength(brOption.radius, r - innerR);

--- a/ts/Series/SolidGauge/SolidGaugeSeries.ts
+++ b/ts/Series/SolidGauge/SolidGaugeSeries.ts
@@ -25,7 +25,7 @@ import type SolidGaugeSeriesOptions from './SolidGaugeSeriesOptions';
 import type SVGAttributes from '../../Core/Renderer/SVG/SVGAttributes';
 import type SVGPath from '../../Core/Renderer/SVG/SVGPath';
 
-import { optionsToBorderRadiusObject } from '../../Extensions/BorderRadius.js';
+import { borderRadiusObject } from '../../Extensions/BorderRadius.js';
 import SeriesRegistry from '../../Core/Series/SeriesRegistry.js';
 const {
     gauge: GaugeSeries,
@@ -117,7 +117,7 @@ class SolidGaugeSeries extends GaugeSeries {
             renderer = series.chart.renderer,
             overshoot = options.overshoot,
             rounded = options.rounded,
-            borderRadius = optionsToBorderRadiusObject(
+            borderRadius = borderRadiusObject(
                 rounded ? '50%' : (
                     options.borderRadius ??
                     yAxis.pane.options.borderRadius

--- a/ts/Stock/Navigator/NavigatorSymbols.ts
+++ b/ts/Stock/Navigator/NavigatorSymbols.ts
@@ -22,7 +22,7 @@ import type SVGPath from '../../Core/Renderer/SVG/SVGPath';
 import type SymbolOptions from '../../Core/Renderer/SVG/SymbolOptions';
 import type { SymbolTypeRegistry } from '../../Core/Renderer/SVG/SymbolType';
 
-import { optionsToBorderRadiusObject } from '../../Extensions/BorderRadius.js';
+import { borderRadiusObject } from '../../Extensions/BorderRadius.js';
 import rect from '../../Core/Renderer/SVG/Symbols.js';
 import { relativeLength } from '../../Shared/Utilities.js';
 
@@ -46,7 +46,7 @@ function navigatorHandle(
     const halfWidth = options.width ? options.width / 2 : width,
         markerPosition = 1.5,
         r = relativeLength(
-            optionsToBorderRadiusObject(options.borderRadius).radius,
+            borderRadiusObject(options.borderRadius).radius,
             Math.min(halfWidth * 2, height)
         );
 


### PR DESCRIPTION
Chores: Shorter name for `borderRadiusObject` utility, analogous to the `animObject`.

Also some simplification in the BoxPlot border radius logic.