### PR TITLE
Fixed #24779, body padding affected tooltip and other useHTML elements

### DIFF
--- a/ts/Core/Renderer/HTML/HTMLElement.ts
+++ b/ts/Core/Renderer/HTML/HTMLElement.ts
@@ -384,7 +384,9 @@ class HTMLElement extends SVGElement {
                 .css({
                     background: 'transparent',
                     // 3px is to avoid clipping on the right
-                    margin: '0 3px 0 0'
+                    margin: '0 3px 0 0',
+                    // Avoid inheriting padding from page body (#24779)
+                    padding: 0
                 })
                 .add(foreignObject)
         );


### PR DESCRIPTION
Fixed #24779, a v13.0.0 regression that caused tooltips and other elements with `useHTML` to be affected by page-level body padding.