### PR TITLE
bugfix/24760 missing js extension

### DIFF
--- a/samples/highcharts/esm/es-modules-masters/demo.css
+++ b/samples/highcharts/esm/es-modules-masters/demo.css
@@ -1,0 +1,5 @@
+#container {
+    height: 400px;
+    max-width: 800px;
+    margin: 0 auto;
+}

--- a/samples/highcharts/esm/es-modules-masters/demo.details
+++ b/samples/highcharts/esm/es-modules-masters/demo.details
@@ -1,0 +1,7 @@
+---
+ name: Highcharts ESM Demo
+ authors:
+   - Jon Arild Nygård
+ requiresManualTesting: true
+ js_wrap: b
+...

--- a/samples/highcharts/esm/es-modules-masters/demo.html
+++ b/samples/highcharts/esm/es-modules-masters/demo.html
@@ -1,0 +1,113 @@
+<div id="container"></div>
+
+<script type="module">
+import Highcharts from 'https://code.highcharts.com/es-modules/masters/highcharts.src.js';
+import 'https://code.highcharts.com/es-modules/masters/highcharts-more.src.js';
+import 'https://code.highcharts.com/es-modules/masters/modules/exporting.src.js';
+import 'https://code.highcharts.com/es-modules/masters/modules/export-data.src.js';
+
+Highcharts.chart('container', {
+    chart: {
+        type: 'bubble',
+        plotBorderWidth: 1,
+        zoomType: 'xy'
+    },
+    legend: {
+        enabled: false
+    },
+    title: {
+        text: 'Sugar and fat intake per country'
+    },
+    subtitle: {
+        text: 'Source: <a href="http://www.euromonitor.com/">Euromonitor</a> and <a href="https://data.oecd.org/">OECD</a>'
+    },
+    xAxis: {
+        gridLineWidth: 1,
+        title: {
+            text: 'Daily fat intake'
+        },
+        labels: {
+            format: '{value} gr'
+        },
+        plotLines: [{
+            color: 'black',
+            dashStyle: 'dot',
+            width: 2,
+            value: 65,
+            label: {
+                rotation: 0,
+                y: 15,
+                style: {
+                    fontStyle: 'italic'
+                },
+                text: 'Safe fat intake 65g/day'
+            },
+            zIndex: 3
+        }]
+    },
+    yAxis: {
+        startOnTick: false,
+        endOnTick: false,
+        title: {
+            text: 'Daily sugar intake'
+        },
+        labels: {
+            format: '{value} gr'
+        },
+        maxPadding: 0.2,
+        plotLines: [{
+            color: 'black',
+            dashStyle: 'dot',
+            width: 2,
+            value: 50,
+            label: {
+                align: 'right',
+                style: {
+                    fontStyle: 'italic'
+                },
+                text: 'Safe sugar intake 50g/day',
+                x: -10
+            },
+            zIndex: 3
+        }]
+    },
+    tooltip: {
+        useHTML: true,
+        headerFormat: '<table>',
+        pointFormat: '<tr><th colspan="2"><h3>{point.country}</h3></th></tr>' +
+            '<tr><th>Fat intake:</th><td>{point.x}g</td></tr>' +
+            '<tr><th>Sugar intake:</th><td>{point.y}g</td></tr>' +
+            '<tr><th>Obesity (adults):</th><td>{point.z}%</td></tr>',
+        footerFormat: '</table>',
+        followPointer: true
+    },
+    plotOptions: {
+        series: {
+            dataLabels: {
+                enabled: true,
+                format: '{point.name}'
+            }
+        }
+    },
+    series: [{
+        data: [
+            { x: 95, y: 95, z: 13.8, name: 'BE', country: 'Belgium' },
+            { x: 86.5, y: 102.9, z: 14.7, name: 'DE', country: 'Germany' },
+            { x: 80.8, y: 91.5, z: 15.8, name: 'FI', country: 'Finland' },
+            { x: 80.4, y: 102.5, z: 12, name: 'NL', country: 'Netherlands' },
+            { x: 80.3, y: 86.1, z: 11.8, name: 'SE', country: 'Sweden' },
+            { x: 78.4, y: 70.1, z: 16.6, name: 'ES', country: 'Spain' },
+            { x: 74.2, y: 68.5, z: 14.5, name: 'FR', country: 'France' },
+            { x: 73.5, y: 83.1, z: 10, name: 'NO', country: 'Norway' },
+            { x: 71, y: 93.2, z: 24.7, name: 'UK', country: 'United Kingdom' },
+            { x: 69.2, y: 57.6, z: 10.4, name: 'IT', country: 'Italy' },
+            { x: 68.6, y: 20, z: 16, name: 'RU', country: 'Russia' },
+            { x: 65.5, y: 126.4, z: 35.3, name: 'US', country: 'United States' },
+            { x: 65.4, y: 50.8, z: 28.5, name: 'HU', country: 'Hungary' },
+            { x: 63.4, y: 51.8, z: 15.4, name: 'PT', country: 'Portugal' },
+            { x: 64, y: 82.9, z: 31.3, name: 'NZ', country: 'New Zealand' }
+        ],
+        colorByPoint: true
+    }]
+});
+</script>

--- a/samples/highcharts/esm/es-modules-masters/demo.js
+++ b/samples/highcharts/esm/es-modules-masters/demo.js
@@ -1,0 +1,6 @@
+/**
+ * In this example the JavaScript code is located in the HTML file.
+ * The reason behind this is because to use JavaScript modules the script tag
+ * has to contain the attribute type="module". At the time of writing this
+ * attribute was unable to be set in all online code editors.
+ */

--- a/samples/highcharts/esm/es-modules-masters/demo.js
+++ b/samples/highcharts/esm/es-modules-masters/demo.js
@@ -1,6 +1,6 @@
 /**
  * In this example the JavaScript code is located in the HTML file.
- * The reason behind this is because to use JavaScript modules the script tag
+ * The reason for this is that, to use JavaScript modules, the script tag
  * has to contain the attribute type="module". At the time of writing this
  * attribute was unable to be set in all online code editors.
  */

--- a/tools/gulptasks/scripts-webpack.js
+++ b/tools/gulptasks/scripts-webpack.js
@@ -55,19 +55,78 @@ async function scriptsWebpack() {
 
     for (const productName of Object.keys(configs)) {
         config = Path.join('tools', 'webpacks', configs[productName]);
+        const webpackCommand = `npx webpack -c ${config} --no-color`;
 
         if (argv.verbose) {
             LogLib.warn(config);
         }
 
-        log += await ProcessLib.exec(
-            `npx webpack -c ${config} --no-color`,
-            {
-                maxBuffer: 1024 * 1024,
-                silent: argv.verbose ? 1 : 2,
-                timeout: 60000
+        try {
+            log += await ProcessLib.exec(
+                webpackCommand,
+                {
+                    maxBuffer: 8 * 1024 * 1024,
+                    silent: argv.verbose ? 1 : 2,
+                    timeout: 60000
+                }
+            );
+        } catch (error) {
+            const stderr = (
+                error &&
+                typeof error.stderr === 'string' &&
+                error.stderr.trim()
+            ) ? error.stderr.trim() : '';
+            const stdout = (
+                error &&
+                typeof error.stdout === 'string' &&
+                error.stdout.trim()
+            ) ? error.stdout.trim() : '';
+            const detail = stderr || stdout;
+
+            if (detail) {
+                const detailLines = detail.split(/\r?\n/u);
+                const maxLines = 200;
+                const excerpt = detailLines.slice(-maxLines).join('\n');
+
+                LogLib.failure(
+                    `Webpack failed for ${productName} (${config}). ` +
+                    `Showing last ${Math.min(detailLines.length, maxLines)} line(s):`
+                );
+                process.stderr.write(`${excerpt}\n`);
+                log += `${stdout}${stdout && stderr ? '\n' : ''}${stderr}\n`;
+            } else {
+                LogLib.failure(
+                    `Webpack failed for ${productName} (${config}), ` +
+                    'but no compiler output was captured.'
+                );
             }
-        );
+
+            LogLib.warn(
+                'Re-running failed webpack command with detailed diagnostics...'
+            );
+
+            try {
+                await ProcessLib.exec(
+                    (
+                        `${webpackCommand} --bail ` +
+                        '--stats errors-warnings'
+                    ),
+                    {
+                        maxBuffer: 8 * 1024 * 1024,
+                        silent: 0,
+                        timeout: 60000
+                    }
+                );
+            } catch {
+                // Ignore: this run is only for interactive diagnostics.
+            }
+
+            if (log) {
+                await FSP.writeFile('webpack.log', log, { flag: 'a' });
+            }
+
+            throw error;
+        }
 
     }
 

--- a/tools/webpacks/dashboards.webpack.mjs
+++ b/tools/webpacks/dashboards.webpack.mjs
@@ -114,6 +114,13 @@ const webpacks = FSLib
                 })
             ],
             resolve: {
+                byDependency: {
+                    esm: {
+                        // Imports need full .js extensions, otherwise custom
+                        // bundlers may fail (#24760)
+                        fullySpecified: true
+                    }
+                },
                 extensions: ['.js', '.ts']
             }
         };

--- a/tools/webpacks/externals.mjs
+++ b/tools/webpacks/externals.mjs
@@ -49,7 +49,7 @@ const externals = [];
  * @param  {...Array<string>} pathMembers
  * Path to resolve to.
  *
- * @returns 
+ * @returns
  * UMD configuration.
  */
 function createUMDConfig(namespace, ...pathMembers) {
@@ -96,6 +96,42 @@ function decorateImportPath(
     }
 
     return path;
+}
+
+/**
+ * Validates relative import specifiers for strict ESM compatibility (#24760).
+ *
+ * @param {string} request
+ * Import specifier to validate.
+ *
+ * @param {string} context
+ * File path of the importing module.
+ *
+ * @param {string} masterName
+ * Name of the master bundle currently being processed.
+ */
+function validateRelativeImportPath(
+    request,
+    context,
+    masterName
+) {
+    if (typeof request !== 'string') {
+        return;
+    }
+
+    if (!request.match(/^[.]{1,2}\//u)) {
+        return;
+    }
+
+    const requestPath = request.split(/[?#]/u, 1)[0];
+
+    if (!requestPath.match(/\.(?:js|mjs|cjs)$/u)) {
+        throw new Error(
+            'Missing file extension in relative import "' + request +
+            '" from "' + context + '" while bundling "' + masterName +
+            '". Relative imports must be fully specified (for example "./x.js").'
+        );
+    }
 }
 
 
@@ -238,6 +274,8 @@ export async function resolveExternals(
     externalsProduct = 'highcharts',
     externalsType = 'umd'
 ) {
+
+    validateRelativeImportPath(info.request, info.context, masterName);
 
     // Quick exit
     if (

--- a/tools/webpacks/grid.webpack.mjs
+++ b/tools/webpacks/grid.webpack.mjs
@@ -98,6 +98,13 @@ const webpacks = FSLib
                 })
             ],
             resolve: {
+                byDependency: {
+                    esm: {
+                        // Imports need full .js extensions, otherwise custom
+                        // bundlers may fail (#24760)
+                        fullySpecified: true
+                    }
+                },
                 extensions: ['.js', '.ts']
             }
         };

--- a/tools/webpacks/highcharts-es5.webpack.mjs
+++ b/tools/webpacks/highcharts-es5.webpack.mjs
@@ -121,6 +121,13 @@ const webpacks = [].concat(...mastersFolders.map(mastersFolder => FSLib
                 // })
             ],
             resolve: {
+                byDependency: {
+                    esm: {
+                        // Imports need full .js extensions, otherwise custom
+                        // bundlers may fail (#24760)
+                        fullySpecified: true
+                    }
+                },
                 extensions: ['.js', '.ts']
             },
             target: 'es5'

--- a/tools/webpacks/highcharts.webpack.mjs
+++ b/tools/webpacks/highcharts.webpack.mjs
@@ -126,6 +126,13 @@ const umdWebpacks = FSLib
                 // })
             ],
             resolve: {
+                byDependency: {
+                    esm: {
+                        // Imports need full .js extensions, otherwise custom
+                        // bundlers may fail (#24760)
+                        fullySpecified: true
+                    }
+                },
                 extensions: ['.js', '.ts']
             }
         };
@@ -176,6 +183,14 @@ const esmWebpacks = umdWebpacks.map(umdWebpack => {
         },
         mode: 'production',
         optimization: umdWebpack.optimization,
+        resolve: {
+            byDependency: {
+                esm: {
+                    fullySpecified: true
+                }
+            },
+            extensions: ['.js', '.ts']
+        },
         output: {
             filename: masterPath,
             globalObject: 'this',

--- a/ts/Core/Renderer/SVG/SVGRenderer.ts
+++ b/ts/Core/Renderer/SVG/SVGRenderer.ts
@@ -56,7 +56,7 @@ const {
     symbolSizes,
     win
 } = H;
-import Palette from '../../Color/Palette';
+import Palette from '../../Color/Palette.js';
 import SVGElement from './SVGElement.js';
 import SVGLabel from './SVGLabel.js';
 import Symbols from './Symbols.js';

--- a/ts/Extensions/Annotations/Popup/PopupAnnotations.ts
+++ b/ts/Extensions/Annotations/Popup/PopupAnnotations.ts
@@ -30,8 +30,8 @@ const {
     doc,
     isFirefox
 } = H;
-import BaseFormIcons from '../../../Shared/BaseFormIcons';
-import getIcon from '../../../Shared/BaseFormUtils';
+import BaseFormIcons from '../../../Shared/BaseFormIcons.js';
+import getIcon from '../../../Shared/BaseFormUtils.js';
 
 import {
     createElement,

--- a/ts/Stock/Indicators/APO/APOPoint.ts
+++ b/ts/Stock/Indicators/APO/APOPoint.ts
@@ -13,7 +13,7 @@
  *
  * */
 
-import APOIndicator from './APOIndicator';
+import type APOIndicator from './APOIndicator';
 import type EMAPoint from '../EMA/EMAPoint';
 
 

--- a/ts/Stock/Indicators/AroonOscillator/AroonOscillatorPoint.ts
+++ b/ts/Stock/Indicators/AroonOscillator/AroonOscillatorPoint.ts
@@ -12,7 +12,7 @@
  *
  * */
 
-import AroonOscillatorIndicator from './AroonOscillatorIndicator';
+import type AroonOscillatorIndicator from './AroonOscillatorIndicator';
 import type AroonPoint from '../Aroon/AroonPoint';
 
 /* *

--- a/ts/Stock/Indicators/DEMA/DEMAPoint.ts
+++ b/ts/Stock/Indicators/DEMA/DEMAPoint.ts
@@ -13,7 +13,7 @@
  *
  * */
 
-import DEMAIndicator from './DEMAIndicator';
+import type DEMAIndicator from './DEMAIndicator';
 import type EMAPoint from '../EMA/EMAPoint';
 
 /* *

--- a/ts/Stock/Indicators/DPO/DPOPoint.ts
+++ b/ts/Stock/Indicators/DPO/DPOPoint.ts
@@ -13,7 +13,7 @@
  *
  * */
 
-import DPOIndicator from './DPOIndicator';
+import type DPOIndicator from './DPOIndicator';
 import type SMAPoint from '../SMA/SMAPoint';
 
 /* *

--- a/ts/Stock/Indicators/MFI/MFIPoint.ts
+++ b/ts/Stock/Indicators/MFI/MFIPoint.ts
@@ -12,7 +12,7 @@
  *
  * */
 
-import MFIIndicator from './MFIIndicator';
+import type MFIIndicator from './MFIIndicator';
 import type SMAPoint from '../SMA/SMAPoint';
 
 /* *

--- a/ts/Stock/Indicators/OBV/OBVIndicator.ts
+++ b/ts/Stock/Indicators/OBV/OBVIndicator.ts
@@ -25,7 +25,7 @@ import type IndicatorValuesObject from '../IndicatorValuesObject';
 import type LineSeries from '../../../Series/Line/LineSeries';
 
 import SeriesRegistry from '../../../Core/Series/SeriesRegistry.js';
-import Series from '../../../Core/Series/Series';
+import type Series from '../../../Core/Series/Series';
 const {
     sma: SMAIndicator
 } = SeriesRegistry.seriesTypes;

--- a/ts/Stock/Indicators/PC/PCPoint.ts
+++ b/ts/Stock/Indicators/PC/PCPoint.ts
@@ -13,7 +13,7 @@
  *
  * */
 
-import PCIndicator from './PCIndicator';
+import type PCIndicator from './PCIndicator';
 import type SMAPoint from '../SMA/SMAPoint';
 
 /* *

--- a/ts/Stock/Indicators/PPO/PPOPoint.ts
+++ b/ts/Stock/Indicators/PPO/PPOPoint.ts
@@ -12,7 +12,7 @@
  *  Imports
  *
  * */
-import PPOIndicator from './PPOIndicator';
+import type PPOIndicator from './PPOIndicator';
 import type EMAPoint from '../EMA/EMAPoint';
 
 /* *

--- a/ts/Stock/Indicators/VBP/VBPPoint.ts
+++ b/ts/Stock/Indicators/VBP/VBPPoint.ts
@@ -23,7 +23,7 @@ const {
         }
     }
 } = SeriesRegistry.seriesTypes;
-import VBPIndicator from './VBPIndicator';
+import type VBPIndicator from './VBPIndicator';
 
 /* *
  *

--- a/ts/Stock/StockTools/StockToolbar.ts
+++ b/ts/Stock/StockTools/StockToolbar.ts
@@ -32,7 +32,7 @@ import type {
 import AST from '../../Core/Renderer/HTML/AST.js';
 import StockToolsUtilities from './StockToolsUtilities.js';
 
-import getIcon from '../../Shared/BaseFormUtils';
+import getIcon from '../../Shared/BaseFormUtils.js';
 import StockToolsIcons from '../../Stock/StockTools/StockToolsIcons.js';
 
 import type HTMLAttributes from '../../Core/Renderer/HTML/HTMLAttributes';

--- a/ts/Stock/StockTools/StockToolsBindings.ts
+++ b/ts/Stock/StockTools/StockToolsBindings.ts
@@ -46,7 +46,7 @@ const {
     updateNthPoint,
     updateRectSize
 } = STU;
-import FibonacciTimeZones from '../../Extensions/Annotations/Types/FibonacciTimeZones';
+import FibonacciTimeZones from '../../Extensions/Annotations/Types/FibonacciTimeZones.js';
 import getIcon from '../../Shared/BaseFormUtils.js';
 import StockToolsIcons from './StockToolsIcons.js';
 import { fireEvent, merge } from '../../Shared/Utilities.js';

--- a/ts/Stock/StockTools/StockToolsBindings.ts
+++ b/ts/Stock/StockTools/StockToolsBindings.ts
@@ -47,8 +47,8 @@ const {
     updateRectSize
 } = STU;
 import FibonacciTimeZones from '../../Extensions/Annotations/Types/FibonacciTimeZones';
-import getIcon from '../../Shared/BaseFormUtils';
-import StockToolsIcons from './StockToolsIcons';
+import getIcon from '../../Shared/BaseFormUtils.js';
+import StockToolsIcons from './StockToolsIcons.js';
 import { fireEvent, merge } from '../../Shared/Utilities.js';
 
 /* *

--- a/ts/Stock/StockTools/StockToolsBindings.ts
+++ b/ts/Stock/StockTools/StockToolsBindings.ts
@@ -26,6 +26,7 @@ import type {
 } from '../../Extensions/Annotations/AnnotationOptions';
 import type AxisType from '../../Core/Axis/AxisType';
 import type { DeepPartial } from '../../Shared/Types';
+import type FibonacciTimeZones from '../../Extensions/Annotations/Types/FibonacciTimeZones';
 import type { HTMLDOMElement } from '../../Core/Renderer/DOMElementType';
 import type NavigationBindingsOptions from '../../Extensions/Annotations/NavigationBindingsOptions';
 import type PointerEvent from '../../Core/PointerEvent';
@@ -46,7 +47,6 @@ const {
     updateNthPoint,
     updateRectSize
 } = STU;
-import FibonacciTimeZones from '../../Extensions/Annotations/Types/FibonacciTimeZones.js';
 import getIcon from '../../Shared/BaseFormUtils.js';
 import StockToolsIcons from './StockToolsIcons.js';
 import { fireEvent, merge } from '../../Shared/Utilities.js';

--- a/ts/Stock/StockTools/StockToolsGui.ts
+++ b/ts/Stock/StockTools/StockToolsGui.ts
@@ -34,8 +34,8 @@ import D from '../../Core/Defaults.js';
 const { setOptions } = D;
 import StockToolsDefaults from './StockToolsDefaults.js';
 import Toolbar from './StockToolbar.js';
-import getIcon from '../../Shared/BaseFormUtils';
-import StockToolsIcons from './StockToolsIcons';
+import getIcon from '../../Shared/BaseFormUtils.js';
+import StockToolsIcons from './StockToolsIcons.js';
 import { addEvent, getStyle, merge, pick } from '../../Shared/Utilities.js';
 
 /* *


### PR DESCRIPTION
Fixed #24760, build errors with bundlers like Rollup caused by missing `.js` extension in import statements

In order to prevent this from happening again, I also set up webpack to fail on missing extensions. The utils has also been updated with similar requirements for esbuild.
