### PR TITLE
bugfix/24650-a11y-skip-null-points

### DIFF
--- a/samples/unit-tests/accessibility/accessibility-options/demo.js
+++ b/samples/unit-tests/accessibility/accessibility-options/demo.js
@@ -253,6 +253,42 @@ QUnit.test('Keyboard navigation', function (assert) {
     );
 });
 
+QUnit.test(
+    'skipNullPoints only skips null points, not valid ones (#24650)',
+    function (assert) {
+        const homeKey = 36;
+        const chart = Highcharts.chart('container', {
+            accessibility: {
+                keyboardNavigation: {
+                    seriesNavigation: {
+                        skipNullPoints: true
+                    }
+                }
+            },
+            series: [{
+                // The first null must be skipped, but the valid points
+                // after it should still be reachable.
+                data: [null, 2, 3]
+            }]
+        });
+
+        chart.accessibility.keyboardNavigation.onKeydown(
+            new KeyboardEvent('keydown', { keyCode: homeKey })
+        );
+        const point = chart.highlightedPoint;
+
+        assert.ok(
+            point,
+            'Keyboard navigation should reach a point when skipNullPoints ' +
+            'is true.'
+        );
+        assert.notOk(
+            point && point.isNull,
+            'Navigation should skip the null point and land on a valid point.'
+        );
+    }
+);
+
 QUnit.test('No data', function (assert) {
     var chart = Highcharts.chart('container', {
         series: [{}]

--- a/ts/Accessibility/Components/SeriesComponent/SeriesKeyboardNavigation.ts
+++ b/ts/Accessibility/Components/SeriesComponent/SeriesKeyboardNavigation.ts
@@ -136,18 +136,20 @@ function isSkipPoint(
         pointOptions = point.options,
         pointA11yOptions = pointOptions.accessibility,
         a11yOptions = series.chart.options.accessibility,
-        pointA11yDisabled = pointA11yOptions?.enabled === false;
+        pointA11yDisabled = pointA11yOptions?.enabled === false,
+        // Whether to skip null points. If the user did not set this
+        // option, use the opposite of nullInteraction as the default
+        // (#24650).
+        skipNullPoints = a11yOptions
+            .keyboardNavigation
+            .seriesNavigation
+            .skipNullPoints ?? !nullInteraction;
 
-    return a11yOptions
-        .keyboardNavigation
-        .seriesNavigation
-        .skipNullPoints ?? (
-        !(!point.isNull || nullInteraction) &&
-                point.visible === false ||
-                point.isInside === false ||
-                pointA11yDisabled ||
-                isSkipSeries(series)
-    );
+    return point.isNull && skipNullPoints ||
+        point.visible === false ||
+        point.isInside === false ||
+        pointA11yDisabled ||
+        isSkipSeries(series);
 }
 
 


### PR DESCRIPTION
Fixed #24650, the accessibility `skipNullPoints` option skipped all points in keyboard navigation.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214944815780250