### PR TITLE
bugfix/24795-plotBorderRadius-clipping

### DIFF
--- a/samples/unit-tests/gantt/grid-axis/demo.js
+++ b/samples/unit-tests/gantt/grid-axis/demo.js
@@ -2196,6 +2196,17 @@ QUnit.test(
             chart.xAxis[0].options.labels.align,
             'Label align options should still not be defined.'
         );
+
+        assert.ok(
+            chart.xAxis[0].clippable,
+            'Axes without grid.enabled should remain clippable when Gantt ' +
+            'module is loaded. #24795'
+        );
+        assert.ok(
+            chart.yAxis[0].clippable,
+            'Axes without grid.enabled should remain clippable when Gantt ' +
+            'module is loaded. #24795'
+        );
     }
 );
 

--- a/ts/Core/Axis/GridAxis.ts
+++ b/ts/Core/Axis/GridAxis.ts
@@ -1111,7 +1111,9 @@ function onInit(
 
     axis.hiddenLabels = [];
     axis.hiddenMarks = [];
-    axis.clippable = false;
+    if (gridOptions.enabled) {
+        axis.clippable = false;
+    }
 }
 
 /**


### PR DESCRIPTION
Fixed #24795, `plotBorderRadius` clipping did not work when the Gantt module was loaded.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216006748833597