### PR TITLE
Fix mismatched legend label in bubble chart demo

### DIFF
--- a/samples/highcharts/website/homepage-react-demo/demo.js
+++ b/samples/highcharts/website/homepage-react-demo/demo.js
@@ -41,7 +41,7 @@ Highcharts.chart('container', {
         },
         {
             type: 'bubble',
-            name: 'Purple bubbles',
+            name: 'Green bubbles',
             data: [
                 [42, 38, 20],
                 [6, 18, 1],

--- a/samples/highcharts/website/industry-software-demos/demo.js
+++ b/samples/highcharts/website/industry-software-demos/demo.js
@@ -976,7 +976,7 @@ function react() {
             },
             {
                 type: 'bubble',
-                name: 'Purple bubbles',
+                name: 'Green bubbles',
                 data: [
                     [42, 38, 20],
                     [6, 18, 1],


### PR DESCRIPTION
The second bubble series is styled green but was still labeled "Purple bubbles" in the legend. Renamed to "Green bubbles" to match the actual rendered color.