### PR TITLE
bugfix/24728-boosted-exported-image

### DIFF
--- a/docs/advanced-chart-features/boost-module.md
+++ b/docs/advanced-chart-features/boost-module.md
@@ -94,7 +94,7 @@ The Boost module contains a WebGL renderer that replaces parts of the SVG render
 * Marker shapes, apart from circles, are not supported.
 * Dash style for lines is not supported.
 * Stacking, and negative colors are not supported.
-* Line width is supported, but handled globally. The `lineWidth` setting applies to all boosted line series and individual per-series values are not respected. For consistent behavior, it is recommended to set the width via `plotOptions.line.lineWidth` rather than per series.
+* Line width is supported, but handled globally. The `lineWidth` setting applies to all boosted line series and individual per-series values are not respected. For consistent behavior, it is recommended to set the width via `plotOptions.line.lineWidth` rather than per series. When a boosted line series shares its rendering target with a boosted non-line series (chart-level boosting mixed with e.g. `area` or `scatter`), the line width is limited to 1px to avoid degrading the other series.
 * [`stickyTracking`](https://api.highcharts.com/highcharts/plotOptions.series.stickyTracking) is forced.
 
 The intended way of using the module, is to set thresholds in such a way that the SVG-renderer “takes over” rendering when zooming in. This approach gives the expected interactivity when the points are less dense, coupled with high performance when the point density is high.

--- a/samples/unit-tests/boost/general/demo.js
+++ b/samples/unit-tests/boost/general/demo.js
@@ -1153,6 +1153,68 @@ QUnit[Highcharts.hasWebGLSupport() ? 'test' : 'skip'](
     }
 );
 
+QUnit[Highcharts.hasWebGLSupport() ? 'test' : 'skip'](
+    'Boosted line width filter should not wash out other boosted series ' +
+    '(#24728)',
+    function (assert) {
+        const chart = Highcharts.chart('container', {
+            boost: {
+                seriesThreshold: 1
+            },
+            series: [
+                {
+                    type: 'area',
+                    boostThreshold: 1,
+                    data: [1, 2, 3, 4, 5]
+                },
+                {
+                    type: 'line',
+                    lineWidth: 3,
+                    boostThreshold: 1,
+                    zIndex: 20,
+                    data: [5, 4, 3, 2, 1]
+                }
+            ]
+        });
+
+        assert.strictEqual(
+            chart.boost.target.attr('filter'),
+            'none',
+            `A boosted line series sharing the chart-level boost target with
+            a boosted non-line series should not apply the line-width dilate
+            filter, or it would wash out the other series (#24728).`
+        );
+
+        const lineOnlyChart = Highcharts.chart('container', {
+            boost: {
+                seriesThreshold: 1
+            },
+            series: [
+                {
+                    type: 'line',
+                    lineWidth: 3,
+                    boostThreshold: 1,
+                    data: [1, 2, 3, 4, 5]
+                },
+                {
+                    type: 'line',
+                    lineWidth: 3,
+                    boostThreshold: 1,
+                    data: [5, 4, 3, 2, 1]
+                }
+            ]
+        });
+
+        assert.strictEqual(
+            lineOnlyChart.boost.target.attr('filter'),
+            'url(#linewidth)',
+            `When every boosted series sharing the chart-level boost target
+            is a line, the dilate filter should still apply so the line
+            width is respected (#23666).`
+        );
+    }
+);
+
 // QUnit[Highcharts.hasWebGLSupport() ? 'test' : 'skip'](
 // Skipped since the DataTable refactor
 // @todo find out how it works in the master

--- a/ts/Extensions/Boost/BoostSeries.ts
+++ b/ts/Extensions/Boost/BoostSeries.ts
@@ -1366,25 +1366,44 @@ function seriesRenderCanvas(this: Series): void {
 
     fireEvent(this, 'renderCanvas');
 
-    if (chartBoost && lineWidth > 1 && this.is('line')) {
-        chartBoost.lineWidthFilter?.remove();
-        chartBoost.lineWidthFilter = chart.renderer.definition({
-            tagName: 'filter',
-            children: [
-                {
-                    tagName: 'feMorphology',
-                    attributes: {
-                        operator: 'dilate',
-                        radius: 0.25 * lineWidth
-                    }
-                }
-            ],
-            attributes: { id: 'linewidth' }
-        });
+    if (chartBoost && this.type === 'line') {
+        const boostTarget = seriesBoost?.target || chartBoost.target,
+            // The dilate filter is applied to the whole render target, so
+            // it must stay off when that target is shared with a
+            // non-line series (chart-level boosting). Otherwise it would
+            // also dilate/blur their pixels, washing out the chart
+            // (#24728). Note `this.is('line')` would also match `area`
+            // and other types inheriting from the line series, so an
+            // exact type check is used here and below.
+            sharesTargetWithNonLine = !seriesBoost?.target &&
+                chart.series.some((otherSeries): boolean =>
+                    otherSeries !== this &&
+                    !!otherSeries.boosted &&
+                    otherSeries.type !== 'line'
+                );
 
-        (seriesBoost?.target || chartBoost.target)?.attr({
-            filter: 'url(#linewidth)'
-        });
+        if (lineWidth > 1 && !sharesTargetWithNonLine) {
+            chartBoost.lineWidthFilter?.remove();
+            chartBoost.lineWidthFilter = chart.renderer.definition({
+                tagName: 'filter',
+                children: [
+                    {
+                        tagName: 'feMorphology',
+                        attributes: {
+                            operator: 'dilate',
+                            radius: 0.25 * lineWidth
+                        }
+                    }
+                ],
+                attributes: { id: 'linewidth' }
+            });
+
+            boostTarget?.attr({
+                filter: 'url(#linewidth)'
+            });
+        } else {
+            boostTarget?.attr({ filter: 'none' });
+        }
     }
 
     if (renderer) {


### PR DESCRIPTION
Fixed #24728, line width filter washed out boosted charts.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215630684772520