### PR TITLE
bugfix/24796-wrong-size-and-slide-on-horizontal-color-axis

### DIFF
--- a/samples/unit-tests/coloraxis/members/demo.js
+++ b/samples/unit-tests/coloraxis/members/demo.js
@@ -44,8 +44,6 @@ QUnit.test('getSeriesExtremes', function (assert) {
     chart.update({
         colorAxis: {
             marker: {
-                // Read final path synchronously on the second hover
-                animation: false,
                 symbol: 'circle'
             }
         }

--- a/samples/unit-tests/coloraxis/members/demo.js
+++ b/samples/unit-tests/coloraxis/members/demo.js
@@ -1,5 +1,5 @@
 /**
- * Related issues: #8406
+ * Related issues: #8406, #24796
  */
 QUnit.test('getSeriesExtremes', function (assert) {
     var chart = Highcharts.chart('container', {
@@ -38,5 +38,64 @@ QUnit.test('getSeriesExtremes', function (assert) {
         series.points[2].color,
         'var(--highcharts-color-0)',
         'The third point on series should have the maxColor'
+    );
+
+    // Marker symbol size and position (#24796)
+    chart.update({
+        colorAxis: {
+            marker: {
+                // Read final path synchronously on the second hover
+                animation: false,
+                symbol: 'circle'
+            }
+        }
+    });
+
+    var axis = chart.colorAxis[0],
+        bBox;
+
+    series.points[0].onMouseOver();
+    bBox = axis.cross.getBBox();
+
+    assert.close(
+        bBox.width,
+        axis.height,
+        0.1,
+        'Horizontal axis: marker width should equal the axis height'
+    );
+    assert.close(
+        bBox.x + bBox.width / 2,
+        axis.toPixels(series.points[0].value),
+        1,
+        'Horizontal axis: marker should be centered on the hovered value'
+    );
+    assert.close(
+        bBox.y,
+        axis.top,
+        0.1,
+        'Horizontal axis: marker should be aligned to the axis top'
+    );
+
+    axis.update({ layout: 'vertical' });
+    series.points[1].onMouseOver();
+    bBox = axis.cross.getBBox();
+
+    assert.close(
+        bBox.height,
+        axis.width,
+        0.1,
+        'Vertical axis: marker height should equal the axis width'
+    );
+    assert.close(
+        bBox.y + bBox.height / 2,
+        axis.toPixels(series.points[1].value),
+        1,
+        'Vertical axis: marker should be centered on the hovered value'
+    );
+    assert.close(
+        bBox.x,
+        axis.left,
+        0.1,
+        'Vertical axis: marker should be aligned to the axis left'
     );
 });

--- a/test/karma-setup.js
+++ b/test/karma-setup.js
@@ -79,6 +79,11 @@ Highcharts.setOptions({
     chart: {
         animation: false
     },
+    colorAxis: {
+        marker: {
+            animation: false
+        }
+    },
     lang: {
         locale: 'en-GB'
     },

--- a/ts/Core/Axis/Color/ColorAxis.ts
+++ b/ts/Core/Axis/Color/ColorAxis.ts
@@ -715,13 +715,17 @@ class ColorAxis extends Axis implements ColorAxisBase {
         // Crosshairs only
         if (isNumber(pos)) {
 
-            const x = left,
-                w = axis.width,
-                y = pos - w / 2,
-                h = w;
-
             if (symbol) {
-                return this.chart.renderer.symbols[symbol](x, y, w, h);
+                let w = axis.height,
+                    x = pos - w / 2,
+                    y = top;
+
+                if (!axis.horiz) {
+                    w = axis.width;
+                    x = left;
+                    y = pos - w / 2;
+                }
+                return this.chart.renderer.symbols[symbol](x, y, w, w);
             }
 
             // Default to a triangle pointing to the value


### PR DESCRIPTION
Fixed #24796, wrong size and animation of marker symbol in horizontal `ColorAxis`.