### PR TITLE
demo/solidgauge-label-position-update

### DIFF
--- a/samples/highcharts/demo/gauge-solid/demo.js
+++ b/samples/highcharts/demo/gauge-solid/demo.js
@@ -35,7 +35,7 @@ const gaugeOptions = {
     plotOptions: {
         solidgauge: {
             dataLabels: {
-                y: -15
+                y: -18
             }
         }
     }


### PR DESCRIPTION
When the series get focused state it will not overlap labels at the bottom. See https://github.com/highcharts/highcharts/issues/21824