### PR TITLE
bugfix/24820-wrong-border-radius-funnel-bottom-point

### DIFF
--- a/samples/unit-tests/series-funnel/funnel/demo.js
+++ b/samples/unit-tests/series-funnel/funnel/demo.js
@@ -261,6 +261,44 @@ QUnit.test('Funnel path', function (assert) {
         0,
         'The fourth point should not have rounded corners (#20319)'
     );
+
+    series.update({
+        borderRadius: 20,
+        data: [40, 30, 20]
+    });
+
+    const lastPointPath = series.points[2].graphic.d;
+
+    series.update({
+        data: [40, 30, 20, null]
+    });
+
+    assert.strictEqual(
+        series.points[2].graphic.d,
+        lastPointPath,
+        'A trailing null point should not affect the rounding of the last ' +
+        'visible point (#24820)'
+    );
+
+    series.update({
+        data: [40, 30, 20, 0]
+    });
+
+    assert.strictEqual(
+        series.points[2].graphic.d,
+        lastPointPath,
+        'A trailing zero point should not affect the rounding of the last ' +
+        'visible point (#24820)'
+    );
+
+    series.points[2].setVisible(false);
+
+    assert.strictEqual(
+        series.points[1].graphic.d.split(' ').filter(s => s === 'C').length,
+        4,
+        'After hiding the last point, the point above should take the ' +
+        'bottom rounding (#24820)'
+    );
 });
 
 QUnit.test('Funnel dataLabels', function (assert) {

--- a/ts/Series/Funnel/FunnelSeries.ts
+++ b/ts/Series/Funnel/FunnelSeries.ts
@@ -316,7 +316,8 @@ class FunnelSeries extends PieSeries {
                     0
             ),
             roundingFactors = (
-                angle: number
+                angle: number,
+                maxT: number
             ): Record<string, Array<number>> => {
                 const tan = Math.tan(angle / 2),
                     cosA = Math.cos(alpha),
@@ -340,11 +341,12 @@ class FunnelSeries extends PieSeries {
 
         let sum = 0,
             cumulative = 0, // Start at top
+            firstIdx = -1,
+            lastIdx = -1,
             tempWidth,
             path: SVGPath,
             fraction,
             alpha: number, // The angle between top and left point's edges
-            maxT: number,
             x1: number,
             y1: number,
             x2: number,
@@ -406,13 +408,19 @@ class FunnelSeries extends PieSeries {
 
         */
 
-        // get the total sum
+        // Get the total sum and the first and last contributing points,
+        // which take the outer rounding regardless of trailing null, zero
+        // or hidden points (#24820)
         for (const point of points) {
             if (
                 point.y && point.isValid() &&
                 (!ignoreHiddenPoint || point.visible !== false)
             ) {
                 sum += point.y;
+                if (firstIdx === -1) {
+                    firstIdx = point.index;
+                }
+                lastIdx = point.index;
             }
         }
 
@@ -455,8 +463,8 @@ class FunnelSeries extends PieSeries {
 
             if (borderRadius && (
                 radiusScope === 'point' ||
-                point.index === 0 ||
-                point.index === points.length - 1 ||
+                point.index === firstIdx ||
+                point.index === lastIdx ||
                 y5 !== null
             )) {
                 // Creating the path of funnel points with rounded corners
@@ -464,22 +472,16 @@ class FunnelSeries extends PieSeries {
                 const h = Math.abs(y3 - y1),
                     xSide = x2 - x4,
                     lBase = x4 - x3,
-                    lSide = Math.sqrt(xSide * xSide + h * h);
+                    lSide = Math.sqrt(xSide * xSide + h * h),
+                    lTop = x2 - x1;
 
                 // If xSide equals zero, return Infinity to avoid dividing
                 // by zero (#20319)
                 alpha = Math.atan(xSide !== 0 ? h / xSide : Infinity);
-                maxT = lSide / 2;
-                if (y5 !== null) {
-                    maxT = Math.min(maxT, Math.abs(y5 - y3) / 2);
-                }
-                if (lBase >= 1) {
-                    maxT = Math.min(maxT, lBase / 2);
-                }
 
                 // Creating a point base
-                let f = roundingFactors(alpha);
-                if (radiusScope === 'stack' && point.index !== 0) {
+                let f = roundingFactors(alpha, Math.min(lTop, lSide) / 2);
+                if (radiusScope === 'stack' && point.index !== firstIdx) {
                     path = [
                         ['M', x1, y1],
                         ['L', x2, y1]
@@ -505,8 +507,15 @@ class FunnelSeries extends PieSeries {
 
                 if (y5 !== null) {
                     // Closure of point with extension
-                    const fr = roundingFactors(Math.PI / 2);
-                    f = roundingFactors(Math.PI / 2 + alpha);
+                    const lNeck = Math.abs(y5 - y3),
+                        fr = roundingFactors(
+                            Math.PI / 2,
+                            Math.min(lBase, lNeck) / 2
+                        );
+                    f = roundingFactors(
+                        Math.PI / 2 + alpha,
+                        Math.min(lSide, lNeck) / 2
+                    );
                     path.push(
                         ['L', x4 + f.dx[0], y3 - f.dy[0]],
                         [
@@ -519,7 +528,7 @@ class FunnelSeries extends PieSeries {
 
                     if (
                         radiusScope === 'stack' &&
-                        point.index !== points.length - 1
+                        point.index !== lastIdx
                     ) {
                         path.push(['L', x4, y5], ['L', x3, y5]);
                     } else {
@@ -552,8 +561,11 @@ class FunnelSeries extends PieSeries {
                     );
                 } else if (lBase >= 1) {
                     // Closure of point without extension
-                    f = roundingFactors(Math.PI - alpha);
-                    if (radiusScope === 'stack' && point.index === 0) {
+                    f = roundingFactors(
+                        Math.PI - alpha,
+                        Math.min(lSide, lBase) / 2
+                    );
+                    if (radiusScope === 'stack' && point.index !== lastIdx) {
                         path.push(['L', x4, y3], ['L', x3, y3]);
                     } else {
                         path.push(
@@ -575,7 +587,7 @@ class FunnelSeries extends PieSeries {
                     }
                 } else {
                     // Creating a rounded tip of the "pyramid"
-                    f = roundingFactors(Math.PI - alpha * 2);
+                    f = roundingFactors(Math.PI - alpha * 2, lSide / 2);
                     path.push(
                         ['L', x3 + f.dx[0], y3 - f.dy[0]],
                         [


### PR DESCRIPTION
Fixed #24820, `borderRadius` was not applied correctly to the bottom corners of funnel points, and trailing null or zero points suppressed the rounding of the last visible point.