### PR TITLE
bugfix/24867-wrong-opacity-after-tiledwebmap-update

### DIFF
--- a/samples/unit-tests/maps/tiledwebmap/demo.js
+++ b/samples/unit-tests/maps/tiledwebmap/demo.js
@@ -177,6 +177,29 @@ QUnit.test('Tiled Web Map on the chart', assert => {
         Object.keys(series.tiles).length > 0,
         'Map should be loaded from custom URL entered by user.'
     );
+
+    let protoDrawPointsCount = 0;
+    const twmProto = Highcharts.seriesTypes.tiledwebmap.prototype,
+        protoDrawPoints = twmProto.drawPoints;
+    twmProto.drawPoints = function () {
+        protoDrawPointsCount++;
+        return protoDrawPoints.apply(this, arguments);
+    };
+
+    series.update({
+        provider: {
+            type: 'TestProvider',
+            url: void 0
+        }
+    });
+
+    twmProto.drawPoints = protoDrawPoints;
+
+    assert.strictEqual(
+        protoDrawPointsCount,
+        1,
+        'Series update should redraw tiles once, #24867.'
+    );
 });
 
 QUnit.test('Tiled Web Map should stop tile animations on pan', assert => {

--- a/ts/Series/TiledWebMap/TiledWebMapSeries.ts
+++ b/ts/Series/TiledWebMap/TiledWebMapSeries.ts
@@ -805,7 +805,7 @@ class TiledWebMapSeries extends MapSeries {
                     projection: {
                         name: (new ProviderDefinition()).initialProjectionName
                     }
-                });
+                }, false);
             }
         }
 


### PR DESCRIPTION
Fixed #24867, tiled web map tiles could stay hidden when a chart or series update interrupted their fade-in animation.