### PR TITLE
grid/core-darkmode-styles-conflict

### DIFF
--- a/css/grid/grid-base-variables.css
+++ b/css/grid/grid-base-variables.css
@@ -55,8 +55,10 @@
     --highcharts-neutral-color-100: #000000;
 }
 
+/* Concrete values (:root:root beats the light-dark() Highcharts injects on
+   :root) so the page stays dark even when the embedder forces color-scheme. */
 @media (prefers-color-scheme: dark) {
-    :root {
+    :root:root {
         --highcharts-background-color: #141414;
         --highcharts-neutral-color-100: #ffffff;
     }
@@ -65,6 +67,15 @@
 .highcharts-dark {
     --highcharts-background-color: #141414;
     --highcharts-neutral-color-100: #ffffff;
+}
+
+/* Restore light-dark() on the chart itself, so a forced scheme
+   (.highcharts-light / .highcharts-dark) still overrides the values above. */
+@supports (color: light-dark(#fff, #000)) {
+    .highcharts-container {
+        --highcharts-background-color: light-dark(#ffffff, #141414);
+        --highcharts-neutral-color-100: light-dark(#000000, #ffffff);
+    }
 }
 
 /*  ==== End Highcharts Variables  ==== */

--- a/samples/grid-lite/e2e/bg-color/demo.css
+++ b/samples/grid-lite/e2e/bg-color/demo.css
@@ -1,0 +1,14 @@
+@import url("https://cdn.jsdelivr.net/npm/@highcharts/grid-lite/css/grid-lite.css");
+
+/* `color-scheme: light` simulates an embedding context (e.g. jsFiddle) that
+   forces the consumer of the --highcharts-* variables to the light scheme.
+   In dark mode the background must still be dark, which only holds if those
+   page-level variables use concrete `@media (prefers-color-scheme)` values
+   rather than light-dark() (whose result would be pinned to the forced light
+   scheme). */
+#cbc {
+    color-scheme: light;
+    height: 100px;
+    background: var(--highcharts-background-color);
+    color: var(--highcharts-neutral-color-100);
+}

--- a/samples/grid-lite/e2e/bg-color/demo.html
+++ b/samples/grid-lite/e2e/bg-color/demo.html
@@ -1,0 +1,4 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+
+<div id="container"></div>
+<div id="cbc">Content below chart</div>

--- a/samples/grid-lite/e2e/bg-color/demo.js
+++ b/samples/grid-lite/e2e/bg-color/demo.js
@@ -1,0 +1,5 @@
+Highcharts.chart('container', {
+    series: [{
+        data: [1, 2, 3]
+    }]
+});

--- a/tests/grid/grid-lite/bg-color.spec.ts
+++ b/tests/grid/grid-lite/bg-color.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '~/fixtures.ts';
+
+test.use({ colorScheme: 'dark' });
+
+test.describe('Page background using --highcharts-* variables in dark mode', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/grid-lite/e2e/bg-color');
+    });
+
+    // #cbc forces `color-scheme: light` to mimic an embedding context such as
+    // jsFiddle. In dark mode its background must still be dark, which only holds
+    // if the page-level --highcharts-* variables use concrete
+    // `@media (prefers-color-scheme)` values rather than light-dark(), whose
+    // result would otherwise be pinned to the forced light scheme.
+    test('background follows the OS even when the element is forced to color-scheme: light', async ({ page }) => {
+        await expect(page.locator('#cbc'))
+            .toHaveCSS('background-color', 'rgb(20, 20, 20)');
+    });
+});


### PR DESCRIPTION
Adjusted Grid's styles to avoid conflicts with Core color variables in jsFiddle demos.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215973071228127