### PR TITLE
fix: add/correct 12 missing or mistyped TypeScript declaration options

### DIFF
--- a/test/typescript-dts/highcharts/highcharts.ts
+++ b/test/typescript-dts/highcharts/highcharts.ts
@@ -19,6 +19,7 @@ test_seriesLine();
 test_seriesPie();
 test_tooltip();
 test_yAxis();
+test_declarationOptions();
 
 /**
  * Tests legend options.
@@ -532,4 +533,130 @@ function test_yAxis() {
             }
         }
     })
+}
+
+/**
+ * Tests documented options that are generated from API doclets.
+ */
+function test_declarationOptions() {
+    const paneBackground: Highcharts.PaneBackgroundOptions = {
+        backgroundColor: '#fff'
+    };
+    const radiusOnly: Highcharts.BorderRadiusOptionsObject = {
+        radius: 4
+    };
+    const radiusAndWhere: Highcharts.BorderRadiusOptionsObject = {
+        radius: '50%',
+        where: 'all'
+    };
+    const scopeOnly: Highcharts.BorderRadiusOptionsObject = {
+        scope: 'point'
+    };
+    const whereOnly: Highcharts.BorderRadiusOptionsObject = {
+        where: 'end'
+    };
+
+    Highcharts.chart('container', {
+        navigation: {
+            buttonOptions: {
+                theme: {
+                    fill: '#252931',
+                    style: {
+                        color: 'silver',
+                        whiteSpace: 'nowrap'
+                    },
+                    states: {
+                        hover: {
+                            fill: '#333'
+                        }
+                    }
+                }
+            }
+        },
+        exporting: {
+            buttons: {
+                contextButton: {
+                    theme: {
+                        style: {
+                            color: 'silver'
+                        },
+                        states: {
+                            select: {
+                                fill: '#333'
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        pane: [{
+            background: null
+        }, {
+            background: paneBackground
+        }, {
+            background: [paneBackground]
+        }],
+        plotOptions: {
+            column: {
+                borderRadius: radiusAndWhere
+            },
+            sunburst: {
+                levelIsConstant: true
+            },
+            treemap: {
+                levelIsConstant: false
+            }
+        },
+        series: [{
+            type: 'sunburst',
+            levelIsConstant: false,
+            levels: [{
+                level: 1,
+                levelIsConstant: true
+            }]
+        }, {
+            type: 'funnel',
+            dataLabels: {
+                inside: true
+            }
+        }, {
+            type: 'bubble',
+            colorByPoint: true
+        }, {
+            type: 'treemap',
+            borderColor: '#fff'
+        }, {
+            type: 'treemap',
+            levels: [{
+                level: 1,
+                levelIsConstant: false
+            }, {
+                level: 2,
+                groupPadding: 4
+            }]
+        }, {
+            type: 'arcdiagram',
+            dataLabels: {
+                padding: 0
+            }
+        }, {
+            type: 'column',
+            borderRadius: radiusOnly
+        }, {
+            type: 'column',
+            borderRadius: scopeOnly
+        }, {
+            type: 'column',
+            borderRadius: whereOnly
+        }, {
+            type: 'column',
+            borderRadius: 4
+        }, {
+            type: 'column',
+            borderRadius: '25%'
+        }]
+    });
+
+    Highcharts.Templating.helpers['substr'] = (value, start, length) =>
+        String(value).substr(Number(start), Number(length));
 }

--- a/test/typescript-dts/highmaps/highmaps.ts
+++ b/test/typescript-dts/highmaps/highmaps.ts
@@ -10,6 +10,7 @@ import * as Highcharts from 'highcharts/highmaps';
 
 test_series();
 test_simple();
+test_shadowOptions();
 
 /**
  * Tests Highcharts.seriesTypes.map, Highcharts.seriesTypes.mapline, and
@@ -142,6 +143,27 @@ function test_simple() {
                 path: ['M', 20, 20, 'L', 30, 20, 15, 15, 20, 30, 'Z'],
                 name: 'b'
             }]
+        }]
+    });
+}
+
+/**
+ * Tests shadow options for map and mapline series.
+ */
+function test_shadowOptions() {
+    Highcharts.mapChart('container', {
+        series: [{
+            type: 'map',
+            shadow: true
+        }, {
+            type: 'mapline',
+            shadow: {
+                color: '#000',
+                offsetX: 1,
+                offsetY: 1,
+                opacity: 0.15,
+                width: 3
+            }
         }]
     });
 }

--- a/test/typescript-dts/highstock/highstock.ts
+++ b/test/typescript-dts/highstock/highstock.ts
@@ -11,6 +11,7 @@ import * as Highcharts from 'highcharts/highstock';
 test_seriesLine();
 test_seriesCandleStick();
 test_theme();
+test_declarationOptions();
 
 /**
  * Tests Highcharts.seriesTypes.line in a simple use case.
@@ -81,7 +82,7 @@ function test_theme() {
                     }
                     // disabled: { ... }
                 }
-            } as any,
+            },
             inputBoxBorderColor: 'gray',
             inputBoxWidth: 120,
             inputBoxHeight: 18,
@@ -107,7 +108,7 @@ function test_theme() {
                                 }
                             }
                         }
-                    } as any
+                    }
                 }
             }
         },
@@ -115,6 +116,30 @@ function test_theme() {
             type: 'line',
             name: 'USD to EUR',
             data: []
+        }]
+    });
+}
+
+/**
+ * Tests documented navigator and Sankey options.
+ */
+function test_declarationOptions() {
+    const navigatorSeries: Highcharts.NavigatorSeriesOptions = {
+        fillColor: '#333'
+    };
+
+    Highcharts.stockChart('container', {
+        navigator: {
+            series: navigatorSeries
+        },
+        series: [{
+            type: 'sankey',
+            borderRadius: 3,
+            data: [{
+                from: 'A',
+                to: 'B',
+                weight: 1
+            }]
         }]
     });
 }

--- a/ts/Core/Renderer/SVG/ButtonThemeObject.ts
+++ b/ts/Core/Renderer/SVG/ButtonThemeObject.ts
@@ -56,7 +56,14 @@ export interface ButtonThemeObject extends SVGAttributes {
      */
     'stroke-linecap'?: SVGAttributes['stroke-linecap'];
 
+    /**
+     * The button's theme for the hover, select and disabled states.
+     */
     states?: ButtonThemeStatesObject;
+
+    /**
+     * CSS styles for the button text.
+     */
     style?: CSSObject;
 }
 

--- a/ts/Core/Templating.ts
+++ b/ts/Core/Templating.ts
@@ -56,7 +56,7 @@ interface MatchObject {
 }
 
 /** @internal */
-const helpers: Record<string, Function> = {
+const helpers: Record<string, Templating.HelperFunction> = {
     // Built-in helpers
     add: (a: number, b: number): number => a + b,
     divide: (a: number, b: number): number | string => (b !== 0 ? a / b : ''),
@@ -555,6 +555,10 @@ const Templating = {
 };
 
 namespace Templating {
+    export interface HelperFunction {
+        (...args: Array<any>): any;
+    }
+
     export interface FormatterCallback<T> {
         (this: T, ...args: Array<any>): string;
     }
@@ -592,6 +596,18 @@ export default Templating;
  * */
 
 /**
+ * A callback function used by a templating helper.
+ *
+ * @callback Highcharts.TemplatingHelperFunction
+ *
+ * @param {...*} args
+ *        Arguments passed to the helper.
+ *
+ * @return {*}
+ *         The value inserted into the template.
+ */
+
+/**
  * @interface Highcharts.Templating
  *
  * The Highcharts.Templating interface provides a structure for defining
@@ -610,7 +626,14 @@ export default Templating;
  * format: 'Absolute value: {abs point.y}'
  *
  * @name Highcharts.Templating#helpers
- * @type {Record<string, Function>}
+ * @type {Record<string, Highcharts.TemplatingHelperFunction>}
+ */
+
+/**
+ * The global templating object containing built-in and custom helpers.
+ *
+ * @name Highcharts.Templating
+ * @type {Highcharts.Templating}
  */
 
 (''); // Keeps doclets above in file

--- a/ts/Extensions/BorderRadius.ts
+++ b/ts/Extensions/BorderRadius.ts
@@ -66,7 +66,7 @@ export interface BorderRadiusOptionsObject {
      * @sample highcharts/plotoptions/series-border-radius
      *         Column and pie with rounded border
      */
-    radius: number|string;
+    radius?: number|string;
 
     /**
      * The scope of the rounding for column charts. In a stacked column chart,
@@ -77,7 +77,7 @@ export interface BorderRadiusOptionsObject {
      * @sample {highcharts} highcharts/plotoptions/column-borderradius/
      *         Rounded columns
      */
-    scope: 'point'|'stack';
+    scope?: 'point'|'stack';
 
     /**
      * For column charts, where in the point or stack to apply rounding. The
@@ -685,7 +685,7 @@ function roundedRect(
  *          Column and pie with rounded border
  *
  * @name Highcharts.BorderRadiusOptionsObject#radius
- * @type {string|number}
+ * @type {string|number|undefined}
  *//**
  * The scope of the rounding for column charts. In a stacked column chart, the
  * value `point` means each single point will get rounded corners. The value
@@ -697,7 +697,7 @@ function roundedRect(
  *
  * @name Highcharts.BorderRadiusOptionsObject#scope
  * @validvalue ["point", "stack"]
- * @type {string}
+ * @type {string|undefined}
  *//**
  * For column charts, where in the point or stack to apply rounding. The `end`
  * value means only those corners at the point value will be rounded, leaving
@@ -709,7 +709,7 @@ function roundedRect(
  *
  * @name Highcharts.BorderRadiusOptionsObject#where
  * @validvalue ["all", "end"]
- * @type {string}
+ * @type {string|undefined}
  * @default end
  */
 

--- a/ts/Extensions/Exporting/ExportingDefaults.ts
+++ b/ts/Extensions/Exporting/ExportingDefaults.ts
@@ -897,6 +897,44 @@ const navigation: NavigationOptions = {
              * Default stroke linecap for the buttons.
              */
             'stroke-linecap': 'round'
+
+            /**
+             * CSS styles for the button text.
+             *
+             * @type      {Highcharts.CSSObject}
+             * @apioption navigation.buttonOptions.theme.style
+             */
+
+            /**
+             * The button's theme for the hover, select and disabled states.
+             *
+             * @type      {Object}
+             * @apioption navigation.buttonOptions.theme.states
+             */
+
+            /**
+             * The button theme for the hover state.
+             *
+             * @extends   navigation.buttonOptions.theme
+             * @excluding states
+             * @apioption navigation.buttonOptions.theme.states.hover
+             */
+
+            /**
+             * The button theme for the selected state.
+             *
+             * @extends   navigation.buttonOptions.theme
+             * @excluding states
+             * @apioption navigation.buttonOptions.theme.states.select
+             */
+
+            /**
+             * The button theme for the disabled state.
+             *
+             * @extends   navigation.buttonOptions.theme
+             * @excluding states
+             * @apioption navigation.buttonOptions.theme.states.disabled
+             */
         }
     },
 

--- a/ts/Extensions/Pane/PaneDefaults.ts
+++ b/ts/Extensions/Pane/PaneDefaults.ts
@@ -40,7 +40,7 @@ import { Palette } from '../../Core/Color/Palettes.js';
  * @sample {highcharts} highcharts/demo/gauge-speedometer/
  *         Speedometer gauge with multiple backgrounds
  *
- * @type         {*|Array<*>}
+ * @type         {null|*|Array<*>}
  * @requires     highcharts-more
  * @optionparent pane.background
  */

--- a/ts/Extensions/Pane/PaneOptions.ts
+++ b/ts/Extensions/Pane/PaneOptions.ts
@@ -131,7 +131,7 @@ export interface PaneOptions {
      *           Speedometer gauge with multiple backgrounds
      * @requires highcharts-more
      */
-    background?: PaneBackgroundOptions|Array<PaneBackgroundOptions>;
+    background?: null|PaneBackgroundOptions|Array<PaneBackgroundOptions>;
     /**
      * The center of a polar chart or angular gauge, given as an array
      * of [x, y] positions. Positions can be given as integers that

--- a/ts/Series/ArcDiagram/ArcDiagramSeriesDefaults.ts
+++ b/ts/Series/ArcDiagram/ArcDiagramSeriesDefaults.ts
@@ -92,6 +92,13 @@ const ArcDiagramSeriesDefaults: ArcDiagramSeriesOptions = {
     dataLabels: {
 
         /**
+         * The padding between the data label and the node it points to.
+         *
+         * @type      {number}
+         * @apioption plotOptions.arcdiagram.dataLabels.padding
+         */
+
+        /**
          * Options for a _link_ label text which should follow link
          * connection. Border and background are disabled for a label that
          * follows a path.

--- a/ts/Series/Bubble/BubbleSeriesOptions.ts
+++ b/ts/Series/Bubble/BubbleSeriesOptions.ts
@@ -53,6 +53,21 @@ import type { ScatterSeriesTooltipOptions } from '../Scatter/ScatterSeriesOption
 export interface BubbleSeriesOptions extends ScatterSeriesOptions {
 
     /**
+     * When using automatic point colors pulled from the global
+     * [colors](colors) or series-specific
+     * [plotOptions.bubble.colors](series.colors) collections, this option
+     * determines whether the chart should receive one color per series or
+     * one color per point.
+     *
+     * @default false
+     *
+     * @since 2.0
+     *
+     * @product highcharts highstock
+     */
+    colorByPoint?: boolean;
+
+    /**
      * Whether to display negative sized bubbles. The threshold is given
      * by the [zThreshold](#plotOptions.bubble.zThreshold) option, and negative
      * bubbles can be visualized by setting

--- a/ts/Series/Funnel/FunnelSeriesDefaults.ts
+++ b/ts/Series/Funnel/FunnelSeriesDefaults.ts
@@ -129,6 +129,13 @@ const FunnelSeriesDefaults: FunnelSeriesOptions = {
      */
     size: true as any,
 
+    /**
+     * Whether to position the data labels inside the funnel area.
+     *
+     * @type      {boolean}
+     * @apioption plotOptions.funnel.dataLabels.inside
+     */
+
     dataLabels: {
         connectorWidth: 1,
         verticalAlign: 'middle'

--- a/ts/Series/Map/MapSeriesDefaults.ts
+++ b/ts/Series/Map/MapSeriesDefaults.ts
@@ -47,6 +47,16 @@ import { isNumber } from '../../Shared/Utilities.js';
 const MapSeriesDefaults: MapSeriesOptions = {
 
     /**
+     * Whether to apply a drop shadow to the map areas. The shadow can also be
+     * an object configuration containing `color`, `offsetX`, `offsetY`,
+     * `opacity` and `width`.
+     *
+     * @type      {boolean|Highcharts.ShadowOptionsObject}
+     * @product   highmaps
+     * @apioption plotOptions.map.shadow
+     */
+
+    /**
      * Whether the MapView takes this series into account when computing the
      * default zoom and center of the map.
      *

--- a/ts/Series/MapLine/MapLineSeriesDefaults.ts
+++ b/ts/Series/MapLine/MapLineSeriesDefaults.ts
@@ -46,6 +46,16 @@ import type MapLineSeriesOptions from './MapLineSeriesOptions';
 const MapLineSeriesDefaults: MapLineSeriesOptions = {
 
     /**
+     * Whether to apply a drop shadow to the map lines. The shadow can also be
+     * an object configuration containing `color`, `offsetX`, `offsetY`,
+     * `opacity` and `width`.
+     *
+     * @type      {boolean|Highcharts.ShadowOptionsObject}
+     * @product   highmaps
+     * @apioption plotOptions.mapline.shadow
+     */
+
+    /**
      * Pixel width of the mapline line.
      *
      * @type      {number}

--- a/ts/Series/Sankey/SankeySeriesDefaults.ts
+++ b/ts/Series/Sankey/SankeySeriesDefaults.ts
@@ -45,8 +45,8 @@ import type SankeySeries from './SankeySeries';
  * @extends      plotOptions.column
  * @since        6.0.0
  * @product      highcharts
- * @excluding    animationLimit, boostBlending, boostThreshold, borderRadius,
- *               crisp, cropThreshold, colorAxis, colorKey, dataSorting, depth,
+ * @excluding    animationLimit, boostBlending, boostThreshold, crisp,
+ *               cropThreshold, colorAxis, colorKey, dataSorting, depth,
  *               dragDrop, edgeColor, edgeWidth, findNearestPointBy, grouping,
  *               groupPadding, groupZPadding, legendSymbolColor, maxPointWidth,
  *               minPointLength, negativeColor, pointInterval,
@@ -59,6 +59,13 @@ import type SankeySeries from './SankeySeries';
  * @private
  */
 const SankeySeriesDefaults: PlotOptionsOf<SankeySeries> = {
+
+    /**
+     * The border radius in pixels for the nodes.
+     *
+     * @type      {number}
+     * @apioption plotOptions.sankey.borderRadius
+     */
 
     borderWidth: 0,
 
@@ -408,8 +415,8 @@ const SankeySeriesDefaults: PlotOptionsOf<SankeySeries> = {
  *
  * @extends   series,plotOptions.sankey
  * @excluding animationLimit, boostBlending, boostThreshold, borderColor,
- *            borderRadius, borderWidth, crisp, cropThreshold, dataParser,
- *            dataURL, depth, dragDrop, edgeColor, edgeWidth,
+ *            borderWidth, crisp, cropThreshold, dataParser, dataURL, depth,
+ *            dragDrop, edgeColor, edgeWidth,
  *            findNearestPointBy, getExtremesFromAll, grouping, groupPadding,
  *            groupZPadding, label, maxPointWidth, negativeColor, pointInterval,
  *            pointIntervalUnit, pointPadding, pointPlacement, pointRange,

--- a/ts/Series/Sankey/SankeySeriesOptions.d.ts
+++ b/ts/Series/Sankey/SankeySeriesOptions.d.ts
@@ -271,9 +271,9 @@ export interface SankeySeriesNodeOptions {
  *
  * @product highcharts
  *
- * @excluding animationLimit, boostThreshold, borderRadius,
- *            crisp, cropThreshold, colorAxis, colorKey, depth, dragDrop,
- *            edgeColor, edgeWidth, findNearestPointBy, grouping,
+ * @excluding animationLimit, boostThreshold, crisp, cropThreshold, colorAxis,
+ *            colorKey, depth, dragDrop, edgeColor, edgeWidth,
+ *            findNearestPointBy, grouping,
  *            groupPadding, groupZPadding, maxPointWidth, negativeColor,
  *            pointInterval, pointIntervalUnit, pointPadding,
  *            pointPlacement, pointRange, pointStart, pointWidth,
@@ -281,8 +281,8 @@ export interface SankeySeriesNodeOptions {
  *            zones, minPointLength, dataSorting, boostBlending
  *
  * @excluding animationLimit, boostBlending, boostThreshold, borderColor,
- *            borderRadius, borderWidth, crisp, cropThreshold, dataParser,
- *            dataURL, depth, dragDrop, edgeColor, edgeWidth,
+ *            borderWidth, crisp, cropThreshold, dataParser, dataURL, depth,
+ *            dragDrop, edgeColor, edgeWidth,
  *            findNearestPointBy, getExtremesFromAll, grouping, groupPadding,
  *            groupZPadding, label, maxPointWidth, negativeColor, pointInterval,
  *            pointIntervalUnit, pointPadding, pointPlacement, pointRange,
@@ -292,6 +292,11 @@ export interface SankeySeriesNodeOptions {
  * @requires modules/sankey
  */
 export interface SankeySeriesOptions extends ColumnSeriesOptions, NodesComposition.SeriesCompositionOptions {
+
+    /**
+     * The border radius in pixels for the nodes.
+     */
+    borderRadius?: number;
 
     borderWidth?: number;
 

--- a/ts/Series/Sunburst/SunburstSeriesDefaults.ts
+++ b/ts/Series/Sunburst/SunburstSeriesDefaults.ts
@@ -139,6 +139,17 @@ const SunburstSeriesDefaults: SunburstSeriesOptions = {
      */
 
     /**
+     * Used together with the levels and `allowTraversingTree` options. When
+     * set to false, the first level visible when traversing is considered
+     * to be level one. Otherwise the level will be the same as the tree
+     * structure.
+     *
+     * @type      {boolean}
+     * @default   true
+     * @apioption plotOptions.sunburst.levels.levelIsConstant
+     */
+
+    /**
      * Decides which level takes effect from the options set in the levels
      * object.
      *

--- a/ts/Series/Treemap/TreemapSeriesDefaults.ts
+++ b/ts/Series/Treemap/TreemapSeriesDefaults.ts
@@ -466,6 +466,19 @@ const TreemapSeriesDefaults: TreemapSeriesOptions = {
      */
 
     /**
+     * Group padding for parent elements on this level, in pixels. See also the
+     * `nodeSizeBy` option that controls how the leaf nodes' size is affected by
+     * the padding.
+     *
+     * @sample    {highcharts} highcharts/series-treemap/grouppadding/
+     *            Group padding
+     * @type      {number}
+     * @since     12.2.0
+     * @product   highcharts
+     * @apioption plotOptions.treemap.levels.groupPadding
+     */
+
+    /**
      * Can set the layoutAlgorithm option on a specific level.
      *
      * @type       {string}
@@ -498,13 +511,26 @@ const TreemapSeriesDefaults: TreemapSeriesOptions = {
      * @apioption plotOptions.treemap.levels.level
      */
 
+    /**
+     * Used together with the levels and `allowTraversingTree` options. When
+     * set to false, the first level visible when traversing is considered
+     * to be level one. Otherwise the level will be the same as the tree
+     * structure.
+     *
+     * @type      {boolean}
+     * @default   true
+     * @since     4.1.0
+     * @product   highcharts
+     * @apioption plotOptions.treemap.levels.levelIsConstant
+     */
 
     // Presentational options
 
     /**
      * The color of the border surrounding each tree map item.
      *
-     * @type {Highcharts.ColorString}
+     * @type      {Highcharts.ColorString}
+     * @apioption plotOptions.treemap.borderColor
      */
     borderColor: Palette.neutralColor10,
 

--- a/ts/Stock/Navigator/NavigatorDefaults.ts
+++ b/ts/Stock/Navigator/NavigatorDefaults.ts
@@ -382,10 +382,17 @@ const NavigatorDefaults: NavigatorOptions = {
         className: 'highcharts-navigator-series',
 
         /**
-         * Sets the fill color of the navigator series.
+         * Sets the color of the navigator series.
          *
          * @type      {Highcharts.ColorType}
          * @apioption navigator.series.color
+         */
+
+        /**
+         * Sets the fill color of the navigator series.
+         *
+         * @type      {Highcharts.ColorType}
+         * @apioption navigator.series.fillColor
          */
 
         /**


### PR DESCRIPTION
## Summary

Highcharts' public `.d.ts` is generated from JSDoc `@apioption` / `@type` doclets by `@highcharts/highcharts-documentation-generators` (via `gulp jsdoc-dts`), NOT hand-edited. The generated option interfaces (`PlotSunburstLevelsOptions`, `SeriesSankeyOptions`, `NavigationButtonThemeOptions`, etc.) are derived from the option-path doclets in the `*SeriesDefaults.ts` / options source files.

## Why this matters

The bundled public TypeScript declarations (`highcharts@13.0.0`) reject 12 option usages that are documented and honoured at runtime, all failing under `strict` mode. They are declaration-only defects of the same kind: options that exist and work at runtime but are missing from, or mistyped in, the generated `.d.ts`. Examples include `navigation.buttonOptions.theme.style`/`.states`, sunburst/treemap per-level `levelIsConstant`, funnel `dataLabels.inside`, sankey `borderRadius` (typed `undefined`), `pane.background: null`, bubble `colorByPoint`, arcdiagram `dataLabels.padding` (typed `object` instead of `number`), the entirely-absent `Highcharts.Templating`, navigator series `fillColor`, map/mapline `shadow`, and `BorderRadiusOptionsObject` members declared required instead of optional.

## Testing

- Happy path: each of the 12 documented snippets from the issue compiles cleanly against the regenerated declarations in `strict` mode (added as `test_*` cases in the `typescript-dts` fixtures for the correct product: core options in `highcharts.ts`, navigator/sankey in `highstock.ts`, map/mapline in `highmaps.ts`).
- Edge cases: `pane.background` accepts `null`, a single `PaneBackgroundOptions`, and an array; `BorderRadiusOptionsObject` accepts any subset of `{radius, scope, where}` including a bare `{radius}` and `{radius, where}`; sunburst/treemap `levelIsConstant` accepts `true`/`false` at both series and per-level; arcdiagram `dataLabels.padding` accepts a plain `number`.
- Error paths / regression guard: `npx gulp jsdoc-dts` regenerates without new warnings and `npx gulp lint-dts` passes for Highcharts, Highstock, and Highmaps; previously-valid option usages (e.g. the already-open `rangeSelector.buttonTheme`, existing `borderRadius` string/number forms) still type-check, confirming no narrowing regressions were introduced.

Fixes #24856

AI was used for assistance.
