### PR TITLE
fix: incorrect Gantt/xrange rendering after data update with non-unique start/end

### DIFF
--- a/samples/unit-tests/series/setdata/demo.js
+++ b/samples/unit-tests/series/setdata/demo.js
@@ -375,6 +375,31 @@ QUnit.test('Series.setData with updatePoints', function (assert) {
         'All points with id should be mapped, no errors'
     );
 
+    // Non-unique IDs should not match the same point more than once
+    scatterS.setData(
+        [
+            { id: 'shared', x: 0, y: 1 },
+            { id: 'shared', x: 1, y: 2 }
+        ],
+        true,
+        false,
+        false
+    );
+    scatterS.points.forEach(function (p) {
+        p.wasThere = true;
+    });
+    scatterS.setData([
+        { id: 'shared', x: 2, y: 3 },
+        { id: 'shared', x: 3, y: 4 }
+    ]);
+    assert.deepEqual(
+        scatterS.points.map(function (p) {
+            return p.wasThere;
+        }),
+        [true, undefined],
+        'Points with duplicate IDs should not collapse onto one point'
+    );
+
     // Pie series, no X
     var pieS = chart.addSeries({ type: 'pie' });
     pieS.setData(
@@ -826,6 +851,103 @@ QUnit.test(
             referenceArray,
             `After updating the allowMutatingData property to false,
             setData should not mutate the original data.`
+        );
+    }
+);
+
+QUnit.test(
+    'X-range setData point matching with non-unique keys, #12545',
+    function (assert) {
+        const chart = Highcharts.chart('container', {
+                series: [{
+                    type: 'xrange',
+                    data: [
+                        { x: 0, x2: 2, y: 0 },
+                        { x: 0, x2: 4, y: 3 }
+                    ]
+                }]
+            }),
+            series = chart.series[0];
+
+        series.setData([
+            { x: 0, x2: 4, y: 4 },
+            { x: 0, x2: 2, y: 1 }
+        ]);
+
+        assert.deepEqual(
+            series.points.map(point => [point.x, point.x2, point.y]),
+            [
+                [0, 2, 1],
+                [0, 4, 4]
+            ],
+            'Points with the same start and different ends should all update'
+        );
+        assert.ok(
+            series.points.every(point => point.graphic),
+            'All updated points should render'
+        );
+        assert.deepEqual(
+            [series.yAxis.dataMin, series.yAxis.dataMax],
+            [1, 4],
+            'The y-axis extremes should include every updated point'
+        );
+
+        series.setData(
+            [
+                { id: 'shared', x: 1, x2: 3, y: 0 },
+                { id: 'shared', x: 1, x2: 5, y: 2 }
+            ],
+            true,
+            false,
+            false
+        );
+        series.points.forEach(point => {
+            point.wasThere = true;
+        });
+        series.setData([
+            { id: 'shared', x: 2, x2: 4, y: 1 },
+            { id: 'shared', x: 2, x2: 6, y: 5 }
+        ]);
+        series.setData([
+            { id: 'shared', x: 3, x2: 5, y: 2 },
+            { id: 'shared', x: 3, x2: 7, y: 6 }
+        ]);
+
+        assert.deepEqual(
+            series.points.map(point => [
+                point.x,
+                point.x2,
+                point.y,
+                point.wasThere
+            ]),
+            [
+                [3, 5, 2, true],
+                [3, 7, 6, true]
+            ],
+            'Reused non-unique IDs should preserve both point instances'
+        );
+        assert.deepEqual(
+            [series.yAxis.dataMin, series.yAxis.dataMax],
+            [2, 6],
+            'Extremes should remain correct after successive updates'
+        );
+
+        series.setData([{ x: 4, x2: 6, y: 3 }]);
+        assert.deepEqual(
+            [series.points.length, series.yAxis.dataMin, series.yAxis.dataMax],
+            [1, 3, 3],
+            'Setting fewer points should remove unmatched points'
+        );
+
+        series.setData([
+            { x: 5, x2: 6, y: 0 },
+            { x: 5, x2: 7, y: 4 },
+            { x: 5, x2: 8, y: 8 }
+        ]);
+        assert.deepEqual(
+            [series.points.length, series.yAxis.dataMin, series.yAxis.dataMax],
+            [3, 0, 8],
+            'Setting more points should add every unmatched point'
         );
     }
 );

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -1468,6 +1468,16 @@ class Series {
                     lastIndex
                 );
 
+                // A point can only be matched once during the update. Series
+                // with non-unique keys may otherwise resolve repeatedly to
+                // the same point when sorting is not required.
+                if (
+                    isNumber(pointIndex) &&
+                    oldData[pointIndex]?.touched
+                ) {
+                    pointIndex = void 0;
+                }
+
                 // Matching X not found or used already due to non-unique x
                 // values (#8995), add point (but later)
                 if (

--- a/ts/Series/XRange/XRangeSeries.ts
+++ b/ts/Series/XRange/XRangeSeries.ts
@@ -241,7 +241,9 @@ class XRangeSeries extends ColumnSeries {
         let pointIndex: (number|undefined);
 
         if (id) {
-            const point = find(points, (point): boolean => point.id === id);
+            const point = find(points, (point): boolean => (
+                point.id === id && !point.touched
+            ));
             pointIndex = point ? point.index : void 0;
         }
 


### PR DESCRIPTION
## Summary
In `Series.updateData` (ts/Core/Series/Series.ts, matching loop around lines 1580-1660) the update path builds an x-based needle and calls `haystack.indexOf(needle, lastIndex)`; on a match it sets `oldData[pointIndex].touched = true` but only advances `lastIndex` when `requireSorting` is true. For xrange/gantt series (`requireSorting` is false) with non-unique `x` (start) values, the same old-point index is re-matched by every subsequent new point sharing that x, so only the first survives and the rest are wrongly dropped instead of added, which drops rendered points and skews the yAxis extremes.

## Why this matters
When a Gantt (xrange-based) series is updated via `series.setData` / `series.update` with point updating enabled, points whose `start`/`end` (x/x2) values are not unique are matched incorrectly: several updated points collapse onto the same existing point, so some points are not rendered and the yAxis extremes come out wrong. Maintainers confirmed the bug (pawelfus diagnosed it as id / x / start / end matching, pawellysy reopened it, karolkolodziej: "we'll need to wait for the fix") and reproduced it with plain Highcharts jsFiddles with no Angular, so the root cause is the core point-matching logic, not the highcharts-angular wrapper. The issue is labeled Type: Bug and Product: Highcharts Gantt and remains an acknowledged open bug after being auto-staled.

## Testing
- Happy path: an xrange series with unique start/end values updates correctly via `setData` (no regression in the existing "Series.setData with updatePoints" matching tests).
- Edge case (the #12545 repro): two points sharing the same `x` (start) but different `x2` (end); after `setData` with updated data both points remain and render with their correct start/end, and yAxis extremes cover both.
- Edge case: non-unique `id`s reused across successive `setData` calls do not collapse distinct points onto the first match.
- Error path: updating with fewer or more points than before still adds/removes points correctly and the yAxis extremes are recomputed from the full surviving point set.

Fixes #12545