### PR TITLE
fix: respect lang.decimalPoint in View data table export

### DIFF
--- a/samples/unit-tests/export-data/basics/demo.js
+++ b/samples/unit-tests/export-data/basics/demo.js
@@ -1788,3 +1788,54 @@ QUnit.test('Thousand separator from lang options', function (assert) {
 
     assert.ok(chart.getTable().includes('_THOUSAND_SEPARATOR_'));
 });
+
+QUnit.test('Decimal point from lang options', function (assert) {
+    const getTable = (lang, value, useLocalDecimalPoint) => {
+        const chart = Highcharts.chart('container', {
+                lang,
+                series: [{
+                    data: [value]
+                }]
+            }),
+            table = chart.getTable(useLocalDecimalPoint);
+
+        chart.destroy();
+        return table;
+    };
+
+    assert.ok(
+        getTable({ decimalPoint: ',' }, 1.5).includes('1,5'),
+        'Decimal point is inherited from lang options'
+    );
+
+    assert.ok(
+        getTable({
+            decimalPoint: '_DECIMAL_POINT_',
+            thousandsSep: '_THOUSAND_SEPARATOR_'
+        }, 10000.5).includes(
+            '10_THOUSAND_SEPARATOR_000_DECIMAL_POINT_5'
+        ),
+        'Decimal point and thousand separator are both inherited'
+    );
+
+    assert.ok(
+        getTable({}, 1.5).includes('1.5'),
+        'The default decimal point is unchanged'
+    );
+
+    const toLocaleString = Number.prototype.toLocaleString;
+
+    Number.prototype.toLocaleString = function () {
+        return String(this).replace('.', ',');
+    };
+
+    try {
+        assert.ok(
+            getTable({ decimalPoint: '_DECIMAL_POINT_' }, 1.5, true)
+                .includes('1,5'),
+            'The browser locale takes precedence when requested'
+        );
+    } finally {
+        Number.prototype.toLocaleString = toLocaleString;
+    }
+});

--- a/ts/Extensions/ExportData/ExportData.ts
+++ b/ts/Extensions/ExportData/ExportData.ts
@@ -1221,7 +1221,7 @@ namespace ExportData {
             chart = exporting.chart,
             options = chart.options,
             decimalPoint =
-                useLocalDecimalPoint ? (1.1).toLocaleString()[1] : '.',
+                useLocalDecimalPoint ? (1.1).toLocaleString()[1] : void 0,
             useMultiLevelHeaders = pick(
                 exporting.options.useMultiLevelHeaders, true
             ),


### PR DESCRIPTION
## Summary
In `ts/Extensions/ExportData/ExportData.ts`, `getTableAST()` computes a local `decimalPoint = useLocalDecimalPoint ? (1.1).toLocaleString()[1] : '.'` and passes it explicitly as the 3rd argument to `chart.numberFormatter(...)` inside `getCellHTMLFromValue`.

## Why this matters
Setting `lang.decimalPoint` does not change the decimal separator in the "View data table" rendered from the exporting menu, even though `lang.thousandsSep` already does (and works in both the chart and the data table). The decimal point in the exported/viewed table is effectively hardcoded to `.`. The reporter provides a JSFiddle repro (https://jsfiddle.net/BlackLabel/09rv2mx7/). A Highcharts maintainer acknowledged the report and added it to the backlog; there is no assignee, no claim, and no prior PR.

## Testing
- Happy path: a chart with `lang: { decimalPoint: ',' }` and a float data value produces `chart.getTable()` output whose numeric cell uses `,` as the decimal separator (mirrors the existing `getTable().includes('_THOUSAND_SEPARATOR_')` assertion for thousandsSep).
- Edge: `lang.decimalPoint` and `lang.thousandsSep` set together (e.g. value `10000.5`) - both custom separators appear in the table cell.
- Regression: with no `lang.decimalPoint` set, the table still renders `.` as the decimal separator (numberFormat default), unchanged.
- Regression: `getTableAST(true)` / `getTable(true)` with `useLocalDecimalPoint = true` still uses the browser-locale decimal character, unaffected by the change.

Fixes #24845