### PR TITLE
bugfix/histogram-series

### DIFF
--- a/ts/Series/Bellcurve/BellcurveSeries.ts
+++ b/ts/Series/Bellcurve/BellcurveSeries.ts
@@ -134,7 +134,7 @@ class BellcurveSeries extends AreaSplineSeries {
         animation?: (boolean|Partial<AnimationOptions>),
         updatePoints?: boolean
     ): void {
-        let alteredData;
+        let alteredData: Array<Array<number>> = [];
         if (typeof data !== 'undefined' && data.length > 0) {
             // Support data array of objects (#24073).
             data = data

--- a/ts/Series/Histogram/HistogramSeries.ts
+++ b/ts/Series/Histogram/HistogramSeries.ts
@@ -149,7 +149,7 @@ class HistogramSeries extends ColumnSeries {
         animation?: (boolean|Partial<AnimationOptions>),
         updatePoints?: boolean
     ): void {
-        let alteredData;
+        let alteredData: Array<HistogramPointOptions> = [];
         if (typeof data !== 'undefined' && data.length > 0) {
             // Support data array of objects (#24073).
             data = data.map(function (


### PR DESCRIPTION
When histogram is updated with an empty dataset [], the alteredData variable remains undefined, and the chart fails to update.
Fixed by initializing alteredData as [].