### PR TITLE
bugfix/24845-decimalPoint-ignored-in-data-table

### DIFF
--- a/samples/unit-tests/export-data/basics/demo.js
+++ b/samples/unit-tests/export-data/basics/demo.js
@@ -1774,17 +1774,26 @@ QUnit.test('Dot notation in exporting data (#20470)', function (assert) {
     );
 });
 
-QUnit.test('Thousand separator from lang options', function (assert) {
+QUnit.test('Lang thousandsSep and decimalPoint in table', function (assert) {
     const chart = Highcharts.chart('container', {
-        lang: {
-            thousandsSep: '_THOUSAND_SEPARATOR_'
-        },
-        series: [{
-            data: [
-                [10000]
-            ]
-        }]
-    });
+            lang: {
+                thousandsSep: '_THOUSAND_SEPARATOR_',
+                decimalPoint: '_DECIMAL_POINT_'
+            },
+            series: [{
+                data: [
+                    [10000.5]
+                ]
+            }]
+        }),
+        table = chart.getTable();
 
-    assert.ok(chart.getTable().includes('_THOUSAND_SEPARATOR_'));
+    assert.ok(
+        table.includes('_THOUSAND_SEPARATOR_'),
+        'lang.thousandsSep should be applied in the data table.'
+    );
+    assert.ok(
+        table.includes('_DECIMAL_POINT_'),
+        'lang.decimalPoint should be applied in the data table (#24845).'
+    );
 });

--- a/ts/Extensions/ExportData/ExportData.ts
+++ b/ts/Extensions/ExportData/ExportData.ts
@@ -1228,7 +1228,7 @@ namespace ExportData {
             chart = exporting.chart,
             options = chart.options,
             decimalPoint =
-                useLocalDecimalPoint ? (1.1).toLocaleString()[1] : '.',
+                useLocalDecimalPoint ? (1.1).toLocaleString()[1] : void 0,
             useMultiLevelHeaders = pick(
                 exporting.options.useMultiLevelHeaders, true
             ),


### PR DESCRIPTION
Fixed #24845, `lang.decimalPoint` was ignored in the exported data table.