### PR TITLE
Bugfix/24864 Point.destroy deletes condemned flag after timeout

### DIFF
--- a/samples/unit-tests/point/point/demo.js
+++ b/samples/unit-tests/point/point/demo.js
@@ -843,3 +843,155 @@ QUnit.test('NaN x value (#19148).', assert => {
         }
     });
 });
+
+QUnit.test('Destroying point without chart animation', assert => {
+    const chart = Highcharts.chart('container', {
+            chart: {
+                animation: false
+            },
+            series: [{
+                data: [4]
+            }]
+        }),
+        s1 = chart.series[0];
+
+    s1.points[0].destroy();
+
+    assert.strictEqual(
+        s1.points[0].destroyed,
+        true,
+        'Point should have the destroyed flag'
+    );
+
+    assert.ok(
+        !s1.points[0].graphic,
+        'Point should not have a graphic prop'
+    );
+});
+
+QUnit.test('Destroying point with chart animation enabled', assert => {
+    const done = assert.async(),
+        animDuration = 10,
+        chart = Highcharts.chart('container', {
+            chart: {
+                animation: {
+                    duration: animDuration
+                }
+            },
+            series: [{
+                data: [7]
+            }]
+        }),
+        s1 = chart.series[0];
+
+    s1.points[0].destroy();
+
+    assert.strictEqual(
+        s1.points[0].condemned,
+        true,
+        'Point should have the condemned flag'
+    );
+
+    assert.ok(
+        !s1.points[0].destroyed,
+        'Point should not have the destroyed flag'
+    );
+
+    assert.ok(
+        s1.points[0].graphic,
+        'Point should have a graphic prop'
+    );
+
+    setTimeout(() => {
+        assert.strictEqual(
+            s1.points[0].destroyed,
+            true,
+            'Point should have the destroyed flag'
+        );
+
+        assert.ok(
+            !s1.points[0].condemned,
+            'Point should not have the condemned flag'
+        );
+
+        assert.ok(
+            !s1.points[0].graphic,
+            'Point should not have a graphic prop'
+        );
+
+        done();
+    }, animDuration * 2);
+});
+
+QUnit.test('Update series visibility with chart.update (#24864)', assert => {
+    const done = assert.async(),
+        clone = opts => JSON.parse(JSON.stringify(opts)),
+        animDuration = 10,
+        options = {
+            chart: {
+                animation: {
+                    duration: animDuration
+                }
+            },
+            series: [
+                {
+                    name: 'Series1',
+                    data: [1, 3]
+                },
+                {
+                    name: 'Series2',
+                    data: [5, 2]
+                }
+            ]
+        },
+        { series } = options,
+        chart = Highcharts.chart('container', options),
+        s1 = chart.series[0];
+
+    series[0].visible = false;
+    chart.update(clone(options));
+
+    // Update Series2 when Series1 is already hidden on chart
+    series[1].visible = false;
+    chart.update(clone(options));
+
+    s1.points.forEach(p => assert.strictEqual(
+        p.condemned,
+        true,
+        'Series1 point should be condemned during animation'
+    ));
+
+    setTimeout(() => {
+        s1.points.forEach(p => assert.strictEqual(
+            p.destroyed,
+            true,
+            'Series1 point should be destroyed after animation'
+        ));
+
+        series[0].visible = true;
+
+        let error;
+        try {
+            chart.update(clone(options));
+        } catch (e) {
+            error = e;
+        }
+
+        assert.ok(
+            !error,
+            'Should not throw after condemned Point.destroy() attempt'
+        );
+
+        s1.points.forEach(p => assert.ok(
+            !p.condemned && !p.destroyed,
+            'Series1 point should not have destroyed and condemned flags'
+        ));
+
+        s1.points.forEach(p => assert.ok(
+            p.graphic,
+            'Series1 point should have a graphic prop'
+        ));
+
+        done();
+    }, animDuration * 2);
+});

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -713,7 +713,7 @@ class Point {
      * @function Highcharts.Point#destroy
      */
     public destroy(): void {
-        if (!this.condemned) {
+        if (!this.destroyed && !this.condemned) {
             const point = this,
                 series = point.series,
                 chart = series.chart,
@@ -740,6 +740,8 @@ class Point {
                 for (const prop in point) { // eslint-disable-line guard-for-in
                     delete point[prop];
                 }
+
+                this.destroyed = true;
             };
 
             if (point.legendItem) {


### PR DESCRIPTION
Fixed #24864, a v13.0.0 regression causing errors in certain cases when repeatedly toggling series visibility.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216435054497333