### PR TITLE
dash/24857-fix-board-destroy

### DIFF
--- a/tests/dashboards/board.spec.ts
+++ b/tests/dashboards/board.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from '~/fixtures.ts';
+
+// HTML setup for Dashboards with layout module only
+const dashboardsWithLayoutHTML = `
+    <!DOCTYPE html>
+    <html>
+        <head>
+            <script src="https://code.highcharts.com/dashboards/dashboards.src.js"></script>
+            <script src="https://code.highcharts.com/dashboards/modules/layout.src.js"></script>
+        </head>
+        <body>
+            <div id="container"></div>
+        </body>
+    </html>
+`;
+
+test.describe('Board Tests', () => {
+    // Regression test for #24857
+    test('Board.destroy() with multiple layouts', async ({ page }) => {
+        await page.setContent(
+            dashboardsWithLayoutHTML,
+            { waitUntil: 'networkidle' }
+        );
+
+        const result = await page.evaluate(async () => {
+            const Dashboards = (window as any).Dashboards;
+
+            const board = await Dashboards.board('container', {
+                gui: {
+                    layouts: [{
+                        id: 'layout-1',
+                        rows: [{ cells: [{ id: 'dashboard-cell-1' }] }]
+                    }, {
+                        id: 'layout-2',
+                        rows: [{ cells: [{ id: 'dashboard-cell-2' }] }]
+                    }]
+                },
+                components: [{
+                    renderTo: 'dashboard-cell-1',
+                    type: 'HTML',
+                    elements: [{ tagName: 'p', textContent: 'Layout 1' }]
+                }, {
+                    renderTo: 'dashboard-cell-2',
+                    type: 'HTML',
+                    elements: [{ tagName: 'p', textContent: 'Layout 2' }]
+                }]
+            }, true);
+
+            const layoutsBefore = board.layouts.length;
+
+            let error: string | null = null;
+            try {
+                board.destroy();
+            } catch (e) {
+                error = (e as Error).message;
+            }
+
+            return {
+                layoutsBefore,
+                error,
+                // `destroy` deletes all board properties, so `layouts`
+                // becomes undefined when fully destroyed.
+                layoutsAfter: board.layouts
+            };
+        });
+
+        expect(result.layoutsBefore, 'Board created with two layouts').toBe(2);
+        expect(
+            result.error,
+            'destroy() should not throw with multiple layouts'
+        ).toBeNull();
+        expect(
+            result.layoutsAfter,
+            'Board fully destroyed, all layouts removed'
+        ).toBeUndefined();
+    });
+});

--- a/ts/Dashboards/Board.ts
+++ b/ts/Dashboards/Board.ts
@@ -426,10 +426,11 @@ class Board {
         // Cancel all data connectors pending requests.
         this.dataPool.cancelPendingRequests();
 
-        // Destroy layouts.
+        // Destroy layouts. Iterate over a copy, since each layout removes
+        // itself from `board.layouts` on destroy (#24857).
         if (this.guiEnabled) {
-            for (let i = 0, iEnd = board.layouts?.length; i < iEnd; ++i) {
-                board.layouts[i].destroy();
+            for (const layout of (board.layouts || []).slice()) {
+                layout.destroy();
             }
         } else {
             for (const mountedComponent of board.mountedComponents) {
@@ -515,8 +516,10 @@ class Board {
 
         // Destroy existing layouts if GUI is enabled
         if (board.guiEnabled && board.layouts) {
-            for (let i = 0, iEnd = board.layouts.length; i < iEnd; ++i) {
-                board.layouts[i].destroy();
+            // Iterate over a copy, since each layout removes itself from
+            // `board.layouts` on destroy (#24857).
+            for (const layout of board.layouts.slice()) {
+                layout.destroy();
             }
             board.layouts = [];
 


### PR DESCRIPTION
Fixed #24857, destroying a dashboard with multiple layouts failed.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216394940030174