### PR TITLE
bugfix/24858-data-grouping-initial-render

### DIFF
--- a/samples/unit-tests/series/datagrouping/demo.js
+++ b/samples/unit-tests/series/datagrouping/demo.js
@@ -1131,6 +1131,19 @@
                 `After zooming to a point where groupinng is no longer needed,
                 it should not be applied.`
             );
+
+            assert.strictEqual(
+                chart.series[0].closestPointRange,
+                1,
+                `After zooming out of grouping, closestPointRange should reflect
+                the cropped data spacing, not the stale grouped value (#24858).`
+            );
+            assert.strictEqual(
+                chart.series[1].closestPointRange,
+                1,
+                `After zooming out of grouping, closestPointRange should reflect
+                the cropped data spacing, not the stale grouped value (#24858).`
+            );
         }
     );
 })();

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -2270,8 +2270,12 @@ class Series {
             }
         }
 
-        // Find the closest distance between processed points
-        xData = this.getColumn('x', true);
+        // Find the closest distance between processed points. When the data was
+        // cropped (or set out of range), read x from the freshly cropped local
+        // `modified` table, #24858.
+        if (modified !== table) {
+            xData = modified.getColumn('x', true) as Array<number> || [];
+        }
         const closestPointRange = getClosestDistance(
             [
                 logarithmic ?


### PR DESCRIPTION
Fixed #24858, initial rendering of grouped data was incorrect.