### PR TITLE
Fixed: column stroke-width attr reset after chart.update

### DIFF
--- a/samples/unit-tests/series-column/attribute-reset/demo.details
+++ b/samples/unit-tests/series-column/attribute-reset/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/series-column/attribute-reset/demo.html
+++ b/samples/unit-tests/series-column/attribute-reset/demo.html
@@ -1,0 +1,6 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container"></div>

--- a/samples/unit-tests/series-column/attribute-reset/demo.js
+++ b/samples/unit-tests/series-column/attribute-reset/demo.js
@@ -1,0 +1,31 @@
+QUnit.test(
+    'Attributes are not deleted after updating the chart widh data (#24844)',
+    function (assert) {
+        const chart = Highcharts.chart('container', {
+            chart: {
+                type: 'column'
+            },
+            plotOptions: {
+                column: {
+                    borderWidth: 0
+                }
+            },
+            series: [{
+                data: [4, 2, 0]
+            }]
+        });
+
+        chart.update({
+            series: [{
+                data: [2, 1]
+            }]
+        });
+
+        chart.series[0].points.forEach(point => {
+            const attr = point.graphic.element.getAttribute('stroke-width');
+
+            assert.notStrictEqual(attr, null, 'Attribute should exist');
+            assert.strictEqual(attr, '0', 'Attribute value should be correct');
+        });
+    }
+);

--- a/ts/Series/Column/ColumnSeries.ts
+++ b/ts/Series/Column/ColumnSeries.ts
@@ -802,6 +802,7 @@ class ColumnSeries extends Series {
                         );
                         if (!styledMode) {
                             initialAttr.opacity = 0;
+                            initialAttr['stroke-width'] = 0;
                         }
                         shouldUpdate = true;
                         verb = 'animate';


### PR DESCRIPTION
Fixed #24844, attribute `borderWidth` in column series  was reset after updating the chart with the same options.