### PR TITLE
chores/samples jquery

### DIFF
--- a/samples/highcharts/blog/area-motion/demo.html
+++ b/samples/highcharts/blog/area-motion/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/modules/exporting.js"></script>
 <script src="https://code.highcharts.com/modules/accessibility.js"></script>

--- a/samples/highcharts/series-scatter/scatter-cluster/demo.js
+++ b/samples/highcharts/series-scatter/scatter-cluster/demo.js
@@ -273,7 +273,7 @@ function updateChart() {
     drawChart(datasets[dataset], clusterIds[d][clustering]);
 }
 
-fetch('https://www.highcharts.com/samples/data/cluster-data.json')
+fetch('https://cdn.jsdelivr.net/gh/highcharts/highcharts@367ad88/samples/data/cluster-data.json')
     .then(response => response.json())
     .then(data => {
         datasets = data;

--- a/samples/issues/highcharts-4.0.4/3197-drilldown-hidden/demo.html
+++ b/samples/issues/highcharts-4.0.4/3197-drilldown-hidden/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/modules/drilldown.js"></script>
 

--- a/samples/issues/highcharts-4.0.4/3329-tooltip-xdateformat/demo.html
+++ b/samples/issues/highcharts-4.0.4/3329-tooltip-xdateformat/demo.html
@@ -1,2 +1,3 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <div id="container"></div>

--- a/samples/issues/highcharts-4.0.4/areastack-missing-points/demo.html
+++ b/samples/issues/highcharts-4.0.4/areastack-missing-points/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
 <div id="container"></div>

--- a/samples/issues/highcharts-4.0.4/areastack-null-connect-false-reversed-false/demo.html
+++ b/samples/issues/highcharts-4.0.4/areastack-null-connect-false-reversed-false/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
 <div id="container"></div>

--- a/samples/issues/highcharts-4.0.4/areastack-null-connect-false/demo.html
+++ b/samples/issues/highcharts-4.0.4/areastack-null-connect-false/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
 <div id="container"></div>

--- a/samples/issues/highcharts-4.0.4/areastack-null-connect-true/demo.html
+++ b/samples/issues/highcharts-4.0.4/areastack-null-connect-true/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
 <div id="container"></div>

--- a/samples/issues/highcharts-4.1.3/3952-waterfall-negative-sum/demo.html
+++ b/samples/issues/highcharts-4.1.3/3952-waterfall-negative-sum/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 <div id="container"></div>

--- a/samples/issues/highcharts-4.1.4/3355-bar-threshold/demo.html
+++ b/samples/issues/highcharts-4.1.4/3355-bar-threshold/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
 <div id="container"></div>

--- a/samples/issues/highcharts-4.1.4/3938-axis-labels-ellipsis/demo.html
+++ b/samples/issues/highcharts-4.1.4/3938-axis-labels-ellipsis/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
 <div id="container"></div>

--- a/samples/issues/highcharts-4.1.4/3976-legend-item-height/demo.html
+++ b/samples/issues/highcharts-4.1.4/3976-legend-item-height/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
 <div id="container"></div>

--- a/samples/issues/highcharts-4.1.5/3975-overflow-ellipsis/demo.html
+++ b/samples/issues/highcharts-4.1.5/3975-overflow-ellipsis/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/issues/highcharts-4.1.5/4221-zones-logarithmic/demo.html
+++ b/samples/issues/highcharts-4.1.5/4221-zones-logarithmic/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
 

--- a/samples/issues/highcharts-4.1.7/3372-columnrange-tooltip-position/demo.html
+++ b/samples/issues/highcharts-4.1.7/3372-columnrange-tooltip-position/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/issues/highcharts-4.1.9/2822-pointrange/demo.html
+++ b/samples/issues/highcharts-4.1.9/2822-pointrange/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 
 

--- a/samples/issues/highcharts-4.1.9/3140-rotated-labels-vertical-axis/demo.html
+++ b/samples/issues/highcharts-4.1.9/3140-rotated-labels-vertical-axis/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
 <div id="container"></div>

--- a/samples/issues/highcharts-4.1.9/3745-3d-pie-startangle/demo.html
+++ b/samples/issues/highcharts-4.1.9/3745-3d-pie-startangle/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-3d.js"></script>
 

--- a/samples/issues/highcharts-4.1.9/4391-area-fills-below-point-stacks/demo.html
+++ b/samples/issues/highcharts-4.1.9/4391-area-fills-below-point-stacks/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
 <div id="container"></div>

--- a/samples/issues/highcharts-4.2.5/5416-connectends-null/demo.html
+++ b/samples/issues/highcharts-4.2.5/5416-connectends-null/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/issues/highcharts-4.2.6/1041-stacked-areaspline-gaps/demo.html
+++ b/samples/issues/highcharts-4.2.6/1041-stacked-areaspline-gaps/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/issues/highcharts-4.2.6/5186-areasplinerange-fill-gap/demo.html
+++ b/samples/issues/highcharts-4.2.6/5186-areasplinerange-fill-gap/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/issues/highcharts-5.0.2/5889-point-placement-range/demo.html
+++ b/samples/issues/highcharts-5.0.2/5889-point-placement-range/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
 <div id="container"></div>

--- a/samples/issues/highmaps-1.0.4/3190-reversed-coloraxis/demo.html
+++ b/samples/issues/highmaps-1.0.4/3190-reversed-coloraxis/demo.html
@@ -1,2 +1,3 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/maps/highmaps.js"></script>
 <div id="container"></div>

--- a/samples/issues/highmaps-1.0.4/3314-negative-coordinates/demo.html
+++ b/samples/issues/highmaps-1.0.4/3314-negative-coordinates/demo.html
@@ -1,2 +1,3 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/maps/highmaps.js"></script>
 <div id="container"></div>

--- a/samples/issues/highmaps-1.1.3/3917-maps-and-3d/demo.html
+++ b/samples/issues/highmaps-1.1.3/3917-maps-and-3d/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-3d.js"></script>
 <script src="https://code.highcharts.com/maps/modules/map.js"></script>

--- a/samples/issues/highstock-1.3.10/2796-addaxis-gridlines/demo.html
+++ b/samples/issues/highstock-1.3.10/2796-addaxis-gridlines/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <div id="container"></div>
 
 <script src="https://code.highcharts.com/stock/highstock.js"></script>

--- a/samples/issues/highstock-2.0.1/2975-plotarea-clipping-resize/demo.html
+++ b/samples/issues/highstock-2.0.1/2975-plotarea-clipping-resize/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <div id="container"></div>
 
 <button id="resize" class="autocompare highcharts-demo-button">Resize</button>

--- a/samples/issues/highstock-2.0.3/3299-axis-labels-panes/demo.html
+++ b/samples/issues/highstock-2.0.3/3299-axis-labels-panes/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <div id="container"></div>
 
 <button id="resize" class="autocompare highcharts-demo-button">Resize</button>

--- a/samples/issues/highstock-2.0.4/3451-pane-clipping-update/demo.html
+++ b/samples/issues/highstock-2.0.4/3451-pane-clipping-update/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 
 <div id="container"></div>

--- a/samples/issues/highstock-2.0.4/3519-panes-marker-overflow/demo.html
+++ b/samples/issues/highstock-2.0.4/3519-panes-marker-overflow/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 
 <div id="container"></div>

--- a/samples/issues/highstock-2.1.1/3882-plotbands-on-edge/demo.html
+++ b/samples/issues/highstock-2.1.1/3882-plotbands-on-edge/demo.html
@@ -1,2 +1,3 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 <div id="container"></div>

--- a/samples/issues/highstock-2.1.5/1417-linked-ordinal-axis/demo.html
+++ b/samples/issues/highstock-2.1.5/1417-linked-ordinal-axis/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 
 

--- a/samples/issues/highstock-2.1.6/4285-flags/demo.html
+++ b/samples/issues/highstock-2.1.6/4285-flags/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 
 

--- a/samples/issues/highstock-5.x-visuals/5706-compare-arearange/demo.html
+++ b/samples/issues/highstock-5.x-visuals/5706-compare-arearange/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 <script src="https://code.highcharts.com/stock/highcharts-more.js"></script>
 

--- a/samples/issues/highstock-5.x-visuals/5924-setextremes-exporting/demo.html
+++ b/samples/issues/highstock-5.x-visuals/5924-setextremes-exporting/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 
 <div id="container"></div>

--- a/samples/issues/older/1109/demo.html
+++ b/samples/issues/older/1109/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
 <div id="container"></div>

--- a/samples/issues/older/1282/demo.html
+++ b/samples/issues/older/1282/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
 <div id="container"></div>

--- a/samples/issues/older/1314/demo.html
+++ b/samples/issues/older/1314/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
 <div id="container"></div>

--- a/samples/issues/older/1480,1687/demo.html
+++ b/samples/issues/older/1480,1687/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
 <div id="container"></div>

--- a/samples/issues/older/1619/demo.html
+++ b/samples/issues/older/1619/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/issues/older/1703/demo.html
+++ b/samples/issues/older/1703/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/issues/older/1734/demo.html
+++ b/samples/issues/older/1734/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <div id="container"></div>
 
 <script src="https://code.highcharts.com/highcharts.js"></script>

--- a/samples/issues/older/1784/demo.html
+++ b/samples/issues/older/1784/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script>
 Highcharts.setOptions({

--- a/samples/issues/older/1910/demo.html
+++ b/samples/issues/older/1910/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/issues/older/1930/demo.html
+++ b/samples/issues/older/1930/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/issues/older/2104,2181/demo.html
+++ b/samples/issues/older/2104,2181/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/issues/older/2117/demo.html
+++ b/samples/issues/older/2117/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/issues/older/2197,2375/demo.html
+++ b/samples/issues/older/2197,2375/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/issues/older/2219/demo.html
+++ b/samples/issues/older/2219/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/issues/older/2282/demo.html
+++ b/samples/issues/older/2282/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/issues/older/2357/demo.html
+++ b/samples/issues/older/2357/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/issues/older/2399/demo.html
+++ b/samples/issues/older/2399/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/issues/older/2440/demo.html
+++ b/samples/issues/older/2440/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/issues/older/2444/demo.html
+++ b/samples/issues/older/2444/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <div id="container"></div>
 
 <script src="https://code.highcharts.com/highcharts.js"></script>

--- a/samples/issues/older/2456/demo.html
+++ b/samples/issues/older/2456/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/modules/exporting.js"></script>
 

--- a/samples/issues/older/2469/demo.html
+++ b/samples/issues/older/2469/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script>
 Highcharts.setOptions({

--- a/samples/issues/older/2546/demo.html
+++ b/samples/issues/older/2546/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
 <div id="container"></div>

--- a/samples/issues/older/2568/demo.html
+++ b/samples/issues/older/2568/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <div id="container"></div>
 
 <script src="https://code.highcharts.com/highcharts.js"></script>

--- a/samples/issues/older/2570/demo.html
+++ b/samples/issues/older/2570/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <div id="container"></div>
 
 <script src="https://code.highcharts.com/highcharts.js"></script>

--- a/samples/issues/older/2574/demo.html
+++ b/samples/issues/older/2574/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/issues/older/2576/demo.html
+++ b/samples/issues/older/2576/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/issues/older/2579/demo.html
+++ b/samples/issues/older/2579/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/issues/older/2593/demo.html
+++ b/samples/issues/older/2593/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <div id="container"></div>
 
 <script src="https://code.highcharts.com/highcharts.js"></script>

--- a/samples/issues/older/2610/demo.html
+++ b/samples/issues/older/2610/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <div id="container"></div>
 
 <script src="https://code.highcharts.com/highcharts.js"></script>

--- a/samples/issues/older/2617/demo.html
+++ b/samples/issues/older/2617/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <div id="container"></div>
 
 <script src="https://code.highcharts.com/highcharts.js"></script>

--- a/samples/issues/older/2619/demo.html
+++ b/samples/issues/older/2619/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <div id="container"></div>
 
 <script src="https://code.highcharts.com/highcharts.js"></script>

--- a/samples/issues/older/2645/demo.html
+++ b/samples/issues/older/2645/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <div id="container"></div>
 
 <script src="https://code.highcharts.com/highcharts.js"></script>

--- a/samples/issues/older/2649/demo.html
+++ b/samples/issues/older/2649/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <div id="container"></div>
 
 <script src="https://code.highcharts.com/highcharts.js"></script>

--- a/samples/issues/older/2650/demo.html
+++ b/samples/issues/older/2650/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <div id="container"></div>
 
 <script src="https://code.highcharts.com/highcharts.js"></script>

--- a/samples/issues/older/2651/demo.html
+++ b/samples/issues/older/2651/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <div id="container"></div>
 
 <script src="https://code.highcharts.com/highcharts.js"></script>

--- a/samples/issues/older/2656/demo.html
+++ b/samples/issues/older/2656/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <div id="container"></div>
 
 <script src="https://code.highcharts.com/highcharts.js"></script>

--- a/samples/issues/older/2665/demo.html
+++ b/samples/issues/older/2665/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <div id="container"></div>
 
 <script src="https://code.highcharts.com/highcharts.js"></script>

--- a/samples/issues/older/2682/demo.html
+++ b/samples/issues/older/2682/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <div id="container"></div>
 
 <script src="https://code.highcharts.com/highcharts.js"></script>

--- a/samples/issues/older/2683/demo.html
+++ b/samples/issues/older/2683/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <div id="container"></div>
 
 <script src="https://code.highcharts.com/highcharts.js"></script>

--- a/samples/issues/older/2687/demo.html
+++ b/samples/issues/older/2687/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <div id="container"></div>
 
 <script src="https://code.highcharts.com/highcharts.js"></script>

--- a/samples/issues/older/2700/demo.html
+++ b/samples/issues/older/2700/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <div id="container"></div>
 
 <script src="https://code.highcharts.com/highcharts.js"></script>

--- a/samples/issues/older/2744/demo.html
+++ b/samples/issues/older/2744/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <div id="container"></div>
 
 <script src="https://code.highcharts.com/highcharts.js"></script>

--- a/samples/issues/older/2755/demo.html
+++ b/samples/issues/older/2755/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <div id="container"></div>
 
 <script src="https://code.highcharts.com/highcharts.js"></script>

--- a/samples/issues/older/2760/demo.html
+++ b/samples/issues/older/2760/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <div id="container"></div>
 
 <script src="https://code.highcharts.com/highcharts.js"></script>

--- a/samples/issues/older/2763/demo.html
+++ b/samples/issues/older/2763/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <div id="container"></div>
 
 <script src="https://code.highcharts.com/highcharts.js"></script>

--- a/samples/issues/older/978/demo.html
+++ b/samples/issues/older/978/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
 <div id="container"></div>

--- a/samples/unit-tests/3d/series-pie/demo.html
+++ b/samples/unit-tests/3d/series-pie/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-3d.js"></script>
 <script src="https://code.highcharts.com/modules/drilldown.js"></script>

--- a/samples/unit-tests/3d/zaxis-update/demo.html
+++ b/samples/unit-tests/3d/zaxis-update/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-3d.js"></script>
 

--- a/samples/unit-tests/annotations/annotations-cropthreshold/demo.html
+++ b/samples/unit-tests/annotations/annotations-cropthreshold/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/modules/annotations.js"></script>
 

--- a/samples/unit-tests/axis/alternategridcolor/demo.html
+++ b/samples/unit-tests/axis/alternategridcolor/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
 <div id="qunit"></div>

--- a/samples/unit-tests/axis/crosshairs/demo.html
+++ b/samples/unit-tests/axis/crosshairs/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/unit-tests/axis/extremes/demo.html
+++ b/samples/unit-tests/axis/extremes/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 
 

--- a/samples/unit-tests/axis/labels-usehtml/demo.html
+++ b/samples/unit-tests/axis/labels-usehtml/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 <script src="https://code.highcharts.com/modules/data.js"></script>

--- a/samples/unit-tests/axis/labels/demo.html
+++ b/samples/unit-tests/axis/labels/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 <script src="https://code.highcharts.com/modules/data.js"></script>

--- a/samples/unit-tests/axis/offset/demo.html
+++ b/samples/unit-tests/axis/offset/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
 

--- a/samples/unit-tests/axis/plotlines-and-plotbands/demo.html
+++ b/samples/unit-tests/axis/plotlines-and-plotbands/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 <script src="https://code.highcharts.com/modules/solid-gauge.js"></script>

--- a/samples/unit-tests/axis/ticks/demo.html
+++ b/samples/unit-tests/axis/ticks/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 
 

--- a/samples/unit-tests/axis/title/demo.html
+++ b/samples/unit-tests/axis/title/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
 

--- a/samples/unit-tests/axis/type-logarithmic/demo.html
+++ b/samples/unit-tests/axis/type-logarithmic/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
 <div id="qunit"></div>

--- a/samples/unit-tests/axis/update/demo.html
+++ b/samples/unit-tests/axis/update/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 
 

--- a/samples/unit-tests/boost/enter-exit/demo.html
+++ b/samples/unit-tests/boost/enter-exit/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/modules/boost-canvas.js"></script>
 <script src="https://code.highcharts.com/modules/boost.js"></script>

--- a/samples/unit-tests/chart/polar/demo.html
+++ b/samples/unit-tests/chart/polar/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/unit-tests/chart/setsize/demo.html
+++ b/samples/unit-tests/chart/setsize/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 <script src="https://code.highcharts.com/highcharts-3d.js"></script>

--- a/samples/unit-tests/color/null-color/demo.html
+++ b/samples/unit-tests/color/null-color/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
 

--- a/samples/unit-tests/coloraxis/update/demo.html
+++ b/samples/unit-tests/coloraxis/update/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/maps/highmaps.js"></script>
 <script src="https://code.highcharts.com/modules/exporting.js"></script>
 

--- a/samples/unit-tests/data/general/demo.html
+++ b/samples/unit-tests/data/general/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 <script src="https://code.highcharts.com/modules/sankey.js"></script>

--- a/samples/unit-tests/datalabels/inside/demo.html
+++ b/samples/unit-tests/datalabels/inside/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/unit-tests/drilldown/pie/demo.html
+++ b/samples/unit-tests/drilldown/pie/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/modules/drilldown.js"></script>
 <script src="https://code.highcharts.com/highcharts-3d.js"></script>

--- a/samples/unit-tests/legend/checkbox/demo.html
+++ b/samples/unit-tests/legend/checkbox/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 
 

--- a/samples/unit-tests/legend/legend-itemwidth/demo.html
+++ b/samples/unit-tests/legend/legend-itemwidth/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 
 

--- a/samples/unit-tests/navigator/navigator/demo.html
+++ b/samples/unit-tests/navigator/navigator/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 <script src="https://code.highcharts.com/stock/highcharts-more.js"></script>
 

--- a/samples/unit-tests/pane/pane-update/demo.html
+++ b/samples/unit-tests/pane/pane-update/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/unit-tests/point/point-update/demo.html
+++ b/samples/unit-tests/point/point-update/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 
 

--- a/samples/unit-tests/point/point/demo.html
+++ b/samples/unit-tests/point/point/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 <script src="https://code.highcharts.com/modules/networkgraph.js"></script>
 

--- a/samples/unit-tests/pointer/hover/demo.html
+++ b/samples/unit-tests/pointer/hover/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/unit-tests/rangeselector/input-range/demo.html
+++ b/samples/unit-tests/rangeselector/input-range/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 
 <div id="qunit"></div>

--- a/samples/unit-tests/rangeselector/setdata/demo.html
+++ b/samples/unit-tests/rangeselector/setdata/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 
 

--- a/samples/unit-tests/series-boxplot/boxplot/demo.html
+++ b/samples/unit-tests/series-boxplot/boxplot/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 <script src="https://code.highcharts.com/modules/draggable-points.js"></script>

--- a/samples/unit-tests/series-boxplot/stacking/demo.html
+++ b/samples/unit-tests/series-boxplot/stacking/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/unit-tests/series-bubble/minmaxsize/demo.html
+++ b/samples/unit-tests/series-bubble/minmaxsize/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/unit-tests/series-bubble/null-bubble/demo.html
+++ b/samples/unit-tests/series-bubble/null-bubble/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/unit-tests/series-candlestick/color/demo.html
+++ b/samples/unit-tests/series-candlestick/color/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 
 

--- a/samples/unit-tests/series-column/column-width/demo.html
+++ b/samples/unit-tests/series-column/column-width/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 
 

--- a/samples/unit-tests/series-column/grouping/demo.html
+++ b/samples/unit-tests/series-column/grouping/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
 <div id="qunit"></div>

--- a/samples/unit-tests/series-column/maxpointwidth/demo.html
+++ b/samples/unit-tests/series-column/maxpointwidth/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 
 <div id="qunit"></div>

--- a/samples/unit-tests/series-column/tooltip/demo.html
+++ b/samples/unit-tests/series-column/tooltip/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
 <div id="qunit"></div>

--- a/samples/unit-tests/series-columnrange/datalabels/demo.html
+++ b/samples/unit-tests/series-columnrange/datalabels/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/unit-tests/series-errorbar/stacking/demo.html
+++ b/samples/unit-tests/series-errorbar/stacking/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/unit-tests/series-flags/flag-update/demo.html
+++ b/samples/unit-tests/series-flags/flag-update/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 
 

--- a/samples/unit-tests/series-flags/general/demo.html
+++ b/samples/unit-tests/series-flags/general/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 
 <div id="qunit"></div>

--- a/samples/unit-tests/series-flags/position/demo.html
+++ b/samples/unit-tests/series-flags/position/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/unit-tests/series-gauge/addpoint/demo.html
+++ b/samples/unit-tests/series-gauge/addpoint/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/unit-tests/series-gauge/background/demo.html
+++ b/samples/unit-tests/series-gauge/background/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/unit-tests/series-gauge/reversed/demo.html
+++ b/samples/unit-tests/series-gauge/reversed/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 <script src="https://code.highcharts.com/modules/solid-gauge.js"></script>

--- a/samples/unit-tests/series-heatmap/members/demo.html
+++ b/samples/unit-tests/series-heatmap/members/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/modules/heatmap.js"></script>
 

--- a/samples/unit-tests/series-packedbubble/tooltip/demo.html
+++ b/samples/unit-tests/series-packedbubble/tooltip/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/unit-tests/series-pie/datalabel/demo.html
+++ b/samples/unit-tests/series-pie/datalabel/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
 

--- a/samples/unit-tests/series-pie/gradient/demo.html
+++ b/samples/unit-tests/series-pie/gradient/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
 

--- a/samples/unit-tests/series-pie/hide-connector/demo.html
+++ b/samples/unit-tests/series-pie/hide-connector/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
 

--- a/samples/unit-tests/series-pie/nulls/demo.html
+++ b/samples/unit-tests/series-pie/nulls/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
 

--- a/samples/unit-tests/series-pie/pie/demo.html
+++ b/samples/unit-tests/series-pie/pie/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/modules/stock.js"></script>
 

--- a/samples/unit-tests/series-pie/setdata/demo.html
+++ b/samples/unit-tests/series-pie/setdata/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
 <div id="qunit"></div>

--- a/samples/unit-tests/series-pie/showinlegend/demo.html
+++ b/samples/unit-tests/series-pie/showinlegend/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
 <div id="qunit"></div>

--- a/samples/unit-tests/series-pie/slice/demo.html
+++ b/samples/unit-tests/series-pie/slice/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-3d.js"></script>
 

--- a/samples/unit-tests/series-treemap/members/demo.html
+++ b/samples/unit-tests/series-treemap/members/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/modules/treemap.js"></script>
 

--- a/samples/unit-tests/series-waterfall/minpointlength/demo.html
+++ b/samples/unit-tests/series-waterfall/minpointlength/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/unit-tests/series-waterfall/states/demo.html
+++ b/samples/unit-tests/series-waterfall/states/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/unit-tests/series-waterfall/y-max/demo.html
+++ b/samples/unit-tests/series-waterfall/y-max/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/unit-tests/series-waterfall/y-min/demo.html
+++ b/samples/unit-tests/series-waterfall/y-min/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/unit-tests/series/linkedto/demo.html
+++ b/samples/unit-tests/series/linkedto/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 
 

--- a/samples/unit-tests/series/marker/demo.html
+++ b/samples/unit-tests/series/marker/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 
 

--- a/samples/unit-tests/series/negativecolor/demo.html
+++ b/samples/unit-tests/series/negativecolor/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
 

--- a/samples/unit-tests/series/update-highstock/demo.html
+++ b/samples/unit-tests/series/update-highstock/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 <script src="https://code.highcharts.com/stock/highcharts-more.js"></script>
 <script src="https://code.highcharts.com/stock/modules/exporting.js"></script>

--- a/samples/unit-tests/series/update/demo.html
+++ b/samples/unit-tests/series/update/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 <script src="https://code.highcharts.com/modules/boost.js"></script>
 <script src="https://code.highcharts.com/modules/series-on-point.js"></script>

--- a/samples/unit-tests/series/zones/demo.html
+++ b/samples/unit-tests/series/zones/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 <script src="https://code.highcharts.com/stock/highcharts-more.js"></script>
 

--- a/samples/unit-tests/stockchart/general/demo.html
+++ b/samples/unit-tests/stockchart/general/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 
 <div id="qunit"></div>

--- a/samples/unit-tests/svgrenderer/element-on/demo.html
+++ b/samples/unit-tests/svgrenderer/element-on/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
 <div id="qunit"></div>

--- a/samples/unit-tests/svgrenderer/element-tofront/demo.html
+++ b/samples/unit-tests/svgrenderer/element-tofront/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
 <div id="qunit"></div>

--- a/samples/unit-tests/svgrenderer/element-zindex/demo.html
+++ b/samples/unit-tests/svgrenderer/element-zindex/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
 <div id="qunit"></div>

--- a/samples/unit-tests/title/title/demo.html
+++ b/samples/unit-tests/title/title/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 <script src="https://code.highcharts.com/modules/accessibility.js"></script>
 

--- a/samples/unit-tests/tooltip/header-format/demo.html
+++ b/samples/unit-tests/tooltip/header-format/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/modules/stock.js"></script>
 

--- a/samples/unit-tests/tooltip/shared/demo.html
+++ b/samples/unit-tests/tooltip/shared/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/modules/data.js"></script>
 

--- a/samples/unit-tests/tooltip/update-from-column/demo.html
+++ b/samples/unit-tests/tooltip/update-from-column/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
 <div id="qunit"></div>

--- a/samples/unit-tests/tooltip/zindex/demo.html
+++ b/samples/unit-tests/tooltip/zindex/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
 <div id="qunit"></div>


### PR DESCRIPTION
Chores: include jQuery in legacy samples. Previously it was included in the utils, masking this error.
