### PR TITLE
bugfix/24913 live-candlestick demo

### DIFF
--- a/samples/stock/demo/live-candlestick/demo.js
+++ b/samples/stock/demo/live-candlestick/demo.js
@@ -96,13 +96,25 @@ options.chart = {
                     lastPoint = data[data.length - 1];
 
                 // Different x-value, we need to add a new point
-                if (lastPoint[0] !== newPoint[0]) {
+                if (lastPoint[0] < newPoint[0]) {
                     series.addPoint(newPoint);
 
-                // Existing point, update it
                 } else {
-                    series.options.data[data.length - 1] = newPoint;
-                    series.setData(data);
+                    const lastSeriesPoint = series.points.at(-1);
+
+                    if (
+                        // Series in data grouping mode
+                        series.currentDataGrouping ||
+                        // The last data point is not in visible range
+                        lastSeriesPoint?.options?.x !== newPoint[0]
+                    ) {
+                        series.options.data[data.length - 1] = newPoint;
+                        series.setData(data, true, false);
+
+                    // Existing point, update it
+                    } else {
+                        lastSeriesPoint.update(newPoint, true, false);
+                    }
                 }
 
                 i++;

--- a/samples/stock/demo/live-candlestick/demo.js
+++ b/samples/stock/demo/live-candlestick/demo.js
@@ -99,14 +99,10 @@ options.chart = {
                 if (lastPoint[0] !== newPoint[0]) {
                     series.addPoint(newPoint);
 
-                // Series in data grouping mode, set the full data to regroup
-                } else if (series.currentDataGrouping) {
-                    series.options.data[data.length - 1] = newPoint;
-                    series.setData(data);
-
                 // Existing point, update it
                 } else {
-                    series.points.at(-1).update(newPoint, true, false);
+                    series.options.data[data.length - 1] = newPoint;
+                    series.setData(data);
                 }
 
                 i++;


### PR DESCRIPTION
Fixed #24913, points on `live-candlestick` demo were not updated correctly after chart scrolling.