### PR TITLE
Fixed #24872, chart.update with null points didn't remove points

### DIFF
--- a/samples/unit-tests/series/setdata/demo.js
+++ b/samples/unit-tests/series/setdata/demo.js
@@ -549,6 +549,30 @@ QUnit.test('Series.setData with updatePoints', function (assert) {
         'Setting data on a updated series with cropped dataset should keep ' +
         'correct x-values (#12696).'
     );
+
+    chart.update({
+        xAxis: {
+            min: undefined
+        }
+    });
+    assert.deepEqual(
+        chart.series[0].data.map(p => p.y),
+        [2, 1, 2, 1, 2, 1],
+        'Initial y values'
+    );
+    chart.series[0].setData([
+        [0, 2],
+        [2, 1],
+        [4, null],
+        [6, 1],
+        [8, 2],
+        [10, 1]
+    ]);
+    assert.deepEqual(
+        chart.series[0].data.map(p => p.y),
+        [2, 1, null, 1, 2, 1],
+        'Null y-value should be applied (#24872)'
+    );
 });
 
 QUnit.test('Boosted series with updatePoints', function (assert) {

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -1678,11 +1678,10 @@ class Series {
                 if (!oldData[i].destroyed && !oldData[i].condemned) {
                     const pOptions = dataTable.getRowObject(i);
                     if (pOptions) {
+                        // Remove undefined properties, but preserve explicit
+                        // nulls (#24872)
                         Object.keys(pOptions).forEach((key): void => {
-                            if (
-                                !defined(pOptions[key]) /* ||
-                                pOptions[key] === oldData[i].options[key]*/
-                            ) {
+                            if (pOptions[key] === void 0) {
                                 delete pOptions[key];
                             }
                         });


### PR DESCRIPTION
Fixed #24872, a regression in v13.0.0 causing `chart.update` with null y-values to fail removing points