### PR TITLE
tools/visual-compare-fail-on-runtime-errors

### DIFF
--- a/.github/scripts/runVisualCompare.js
+++ b/.github/scripts/runVisualCompare.js
@@ -1,0 +1,70 @@
+/* eslint-env node,es6 */
+
+const { spawnSync } = require('node:child_process');
+const { existsSync, rmSync, appendFileSync } = require('node:fs');
+
+const completionMarker = 'test/visual-test-complete';
+const errorLog = 'test/visual-test-errors.log';
+const karma = require.resolve('karma/bin/karma');
+const usage = 'Usage: node .github/scripts/runVisualCompare.js <product> <tests-glob>';
+
+/**
+ * Runs one candidate visual comparison and records incomplete runs.
+ *
+ * @param {string} product Human-readable product name.
+ * @param {string} testsGlob Tests glob passed to Karma.
+ * @param {Object} [options] Test-only path and child runner overrides.
+ * @param {string} [options.completionPath] Completion marker path.
+ * @param {string} [options.errorPath] Execution error log path.
+ * @param {Function} [options.runChild] Child process runner.
+ * @return {number} Zero so visual test execution can continue after Karma errors.
+ */
+function runVisualCompare(product, testsGlob, options = {}) {
+    const {
+        completionPath = completionMarker,
+        errorPath = errorLog,
+        runChild = spawnSync
+    } = options;
+    const args = [
+        karma,
+        'start',
+        'test/karma-conf.js',
+        '--tests',
+        testsGlob,
+        '--ts',
+        '--single-run',
+        '--browsercount',
+        '2',
+        '--visualcompare'
+    ];
+
+    rmSync(completionPath, { force: true });
+    try {
+        runChild(process.execPath, args, { stdio: 'inherit' });
+    } catch {
+        // A missing marker below records spawn failures in the existing log.
+    }
+
+    if (!existsSync(completionPath)) {
+        appendFileSync(
+            errorPath,
+            `${product} candidate run did not reach image-capture reporter completion.\n`
+        );
+    }
+
+    return 0;
+}
+
+function main(args) {
+    if (args.length !== 2 || args.some(arg => !arg)) {
+        process.stderr.write(`${usage}\n`);
+        return 1;
+    }
+    return runVisualCompare(args[0], args[1]);
+}
+
+if (require.main === module) {
+    process.exitCode = main(process.argv.slice(2));
+}
+
+module.exports = { main, runVisualCompare };

--- a/.github/scripts/runVisualCompare.test.mjs
+++ b/.github/scripts/runVisualCompare.test.mjs
@@ -1,0 +1,130 @@
+import assert from 'node:assert/strict';
+import {
+    appendFileSync,
+    existsSync,
+    mkdtempSync,
+    readFileSync,
+    writeFileSync,
+    rmSync
+} from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+const require = createRequire(import.meta.url);
+const { main, runVisualCompare } = require('./runVisualCompare.js');
+
+function temporaryPaths() {
+    const directory = mkdtempSync(join(tmpdir(), 'visual-compare-'));
+    return {
+        directory,
+        completionPath: join(directory, 'complete'),
+        errorPath: join(directory, 'errors.log')
+    };
+}
+
+function runWithFakeChild(child) {
+    const paths = temporaryPaths();
+    try {
+        const result = runVisualCompare('Highcharts', 'highcharts/*/*', {
+            completionPath: paths.completionPath,
+            errorPath: paths.errorPath,
+            runChild: child
+        });
+        return { ...paths, result };
+    } catch (error) {
+        rmSync(paths.directory, { recursive: true, force: true });
+        throw error;
+    }
+}
+
+test('rejects missing and extra CLI arguments', () => {
+    assert.equal(main([]), 1);
+    assert.equal(main(['Highcharts']), 1);
+    assert.equal(main(['Highcharts', 'highcharts/*/*', 'extra']), 1);
+});
+
+test('runs the exact Karma command with inherited stdio', () => {
+    let invocation;
+    const result = runWithFakeChild((...args) => {
+        invocation = args;
+    });
+
+    assert.equal(result.result, 0);
+    assert.equal(invocation[0], process.execPath);
+    assert.deepEqual(invocation[1], [
+        require.resolve('karma/bin/karma'),
+        'start',
+        'test/karma-conf.js',
+        '--tests',
+        'highcharts/*/*',
+        '--ts',
+        '--single-run',
+        '--browsercount',
+        '2',
+        '--visualcompare'
+    ]);
+    assert.deepEqual(invocation[2], { stdio: 'inherit' });
+    rmSync(result.directory, { recursive: true, force: true });
+});
+
+test('removes a stale marker and accepts a fresh marker', () => {
+    const paths = temporaryPaths();
+    writeFileSync(paths.completionPath, 'stale');
+    try {
+        const result = runVisualCompare('Stock', 'stock/*/*', {
+            ...paths,
+            runChild: () => {
+                assert.equal(existsSync(paths.completionPath), false);
+                writeFileSync(paths.completionPath, 'fresh');
+            }
+        });
+        assert.equal(result, 0);
+        assert.equal(existsSync(paths.errorPath), false);
+    } finally {
+        rmSync(paths.directory, { recursive: true, force: true });
+    }
+});
+
+test('records missing completion after a nonzero child result', () => {
+    const result = runWithFakeChild(() => ({ status: 1 }));
+    assert.equal(result.result, 0);
+    assert.equal(
+        readFileSync(result.errorPath, 'utf8'),
+        'Highcharts candidate run did not reach image-capture reporter completion.\n'
+    );
+    rmSync(result.directory, { recursive: true, force: true });
+});
+
+test('records spawn failures and continues', () => {
+    const result = runWithFakeChild(() => {
+        throw new Error('spawn failed');
+    });
+    assert.equal(result.result, 0);
+    assert.match(
+        readFileSync(result.errorPath, 'utf8'),
+        /Highcharts candidate run did not reach image-capture reporter completion/u
+    );
+    rmSync(result.directory, { recursive: true, force: true });
+});
+
+test('appends product-specific errors without overwriting existing errors', () => {
+    const paths = temporaryPaths();
+    appendFileSync(paths.errorPath, 'existing error\n');
+    try {
+        assert.equal(
+            runVisualCompare('Maps', 'maps/*/*', {
+                ...paths,
+                runChild() {}
+            }),
+            0
+        );
+        assert.equal(
+            readFileSync(paths.errorPath, 'utf8'),
+            'existing error\nMaps candidate run did not reach image-capture reporter completion.\n'
+        );
+    } finally {
+        rmSync(paths.directory, { recursive: true, force: true });
+    }
+});

--- a/.github/workflows/visual-compare-changed-samples.yml
+++ b/.github/workflows/visual-compare-changed-samples.yml
@@ -1,0 +1,101 @@
+name: Highcharts Visual Comparison (Changed Samples Runtime)
+
+on:
+  pull_request:
+    branches:
+      - 'master'
+    paths:
+      - 'samples/highcharts/**'
+      - 'samples/stock/**'
+      - 'samples/maps/**'
+      - 'samples/gantt/**'
+      - '.github/workflows/visual-compare-changed-samples.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  visual_compare_changed_samples:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout pull request
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Select changed runnable samples
+        id: changed_samples
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          changed_products=()
+
+          diff_file="$RUNNER_TEMP/changed-samples-diff.txt"
+          git diff --name-status --diff-filter=ACMR -M -C "$BASE_SHA" HEAD -- \
+            samples/highcharts samples/stock samples/maps samples/gantt > "$diff_file"
+
+          while IFS=$'\t' read -r status old_path new_path; do
+            case "$status" in
+              A*|M*) path="$old_path" ;;
+              R*|C*) path="$new_path" ;;
+              *) continue ;;
+            esac
+
+            if [[ "$path" =~ ^samples/(highcharts|stock|maps|gantt)/ ]]; then
+              changed_products+=("${BASH_REMATCH[1]}")
+            fi
+          done < "$diff_file"
+
+          products_file="$RUNNER_TEMP/changed-products.txt"
+          : > "$products_file"
+          if ((${#changed_products[@]})); then
+            printf '%s\n' "${changed_products[@]}" | LC_ALL=C sort -u > "$products_file"
+          fi
+
+          product_globs=''
+          while IFS= read -r product; do
+            if [[ -n "$product_globs" ]]; then
+              product_globs+=','
+            fi
+            product_globs+="$product/*/*"
+          done < "$products_file"
+
+          has_products=false
+          if [[ -n "$product_globs" ]]; then
+            has_products=true
+            printf 'Selected changed product scopes: %s\n' "$product_globs"
+          else
+            printf '%s\n' 'No supported changed products selected.'
+          fi
+          printf 'has_products=%s\n' "$has_products" >> "$GITHUB_OUTPUT"
+          printf 'product_globs=%s\n' "$product_globs" >> "$GITHUB_OUTPUT"
+
+      - name: Use Node.js lts/*
+        if: ${{ steps.changed_samples.outputs.has_products == 'true' }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: 'lts/*'
+          cache: 'npm'
+
+      - name: Install dependencies
+        if: ${{ steps.changed_samples.outputs.has_products == 'true' }}
+        run: npm ci
+
+      - name: Build Highcharts
+        if: ${{ steps.changed_samples.outputs.has_products == 'true' }}
+        run: npx gulp scripts
+
+      - name: Generate changed samples
+        if: ${{ steps.changed_samples.outputs.has_products == 'true' }}
+        env:
+          PRODUCT_GLOBS: ${{ steps.changed_samples.outputs.product_globs }}
+        run: npx gulp generate-samples --samples "$PRODUCT_GLOBS"
+
+      - name: Render changed samples
+        if: ${{ steps.changed_samples.outputs.has_products == 'true' }}
+        env:
+          PRODUCT_GLOBS: ${{ steps.changed_samples.outputs.product_globs }}
+        run: npx karma start test/karma-conf.js --tests "$PRODUCT_GLOBS" --ts --reference --browsercount 2

--- a/.github/workflows/visual-compare.yml
+++ b/.github/workflows/visual-compare.yml
@@ -170,10 +170,49 @@ jobs:
       - name: Build Highcharts
         run: npx gulp scripts
 
-      - run: npx karma start test/karma-conf.js --tests highcharts/*/* --ts --single-run --browsercount 2 --visualcompare || true
-      - run: npx karma start test/karma-conf.js --tests stock/*/* --ts --single-run --browsercount 2 --visualcompare || true
-      - run: npx karma start test/karma-conf.js --tests maps/*/* --ts --single-run --browsercount 2 --visualcompare || true
-      - run: npx karma start test/karma-conf.js --tests gantt/*/* --ts --single-run --browsercount 2 --visualcompare || true
+      - name: Compare Highcharts visual tests
+        run: |
+          marker='test/visual-test-complete'
+          rm -f "$marker"
+          npx karma start test/karma-conf.js --tests highcharts/*/* --ts --single-run --browsercount 2 --visualcompare || true
+          if [ ! -f "$marker" ]; then
+            printf '%s\n' \
+              'Highcharts candidate run did not reach image-capture reporter completion.' \
+              >> test/visual-test-errors.log
+          fi
+
+      - name: Compare Stock visual tests
+        run: |
+          marker='test/visual-test-complete'
+          rm -f "$marker"
+          npx karma start test/karma-conf.js --tests stock/*/* --ts --single-run --browsercount 2 --visualcompare || true
+          if [ ! -f "$marker" ]; then
+            printf '%s\n' \
+              'Stock candidate run did not reach image-capture reporter completion.' \
+              >> test/visual-test-errors.log
+          fi
+
+      - name: Compare Maps visual tests
+        run: |
+          marker='test/visual-test-complete'
+          rm -f "$marker"
+          npx karma start test/karma-conf.js --tests maps/*/* --ts --single-run --browsercount 2 --visualcompare || true
+          if [ ! -f "$marker" ]; then
+            printf '%s\n' \
+              'Maps candidate run did not reach image-capture reporter completion.' \
+              >> test/visual-test-errors.log
+          fi
+
+      - name: Compare Gantt visual tests
+        run: |
+          marker='test/visual-test-complete'
+          rm -f "$marker"
+          npx karma start test/karma-conf.js --tests gantt/*/* --ts --single-run --browsercount 2 --visualcompare || true
+          if [ ! -f "$marker" ]; then
+            printf '%s\n' \
+              'Gantt candidate run did not reach image-capture reporter completion.' \
+              >> test/visual-test-errors.log
+          fi
 
       - name: Generate visual test report
         run: |
@@ -262,5 +301,16 @@ jobs:
           name: visual-test-results
           path: |
             test/visual-test-results.json
+            test/visual-test-errors.log
             test/review-pr-*.json
             tmp/pr-visual-test-comment.json
+
+      - name: Fail on visual test execution errors
+        if: ${{ always() }}
+        run: |
+          error_file=test/visual-test-errors.log
+          if [ -s "$error_file" ]; then
+            echo "Visual test execution errors:"
+            cat "$error_file"
+            exit 1
+          fi

--- a/.github/workflows/visual-compare.yml
+++ b/.github/workflows/visual-compare.yml
@@ -171,48 +171,16 @@ jobs:
         run: npx gulp scripts
 
       - name: Compare Highcharts visual tests
-        run: |
-          marker='test/visual-test-complete'
-          rm -f "$marker"
-          npx karma start test/karma-conf.js --tests highcharts/*/* --ts --single-run --browsercount 2 --visualcompare || true
-          if [ ! -f "$marker" ]; then
-            printf '%s\n' \
-              'Highcharts candidate run did not reach image-capture reporter completion.' \
-              >> test/visual-test-errors.log
-          fi
+        run: node .github/scripts/runVisualCompare.js "Highcharts" "highcharts/*/*"
 
       - name: Compare Stock visual tests
-        run: |
-          marker='test/visual-test-complete'
-          rm -f "$marker"
-          npx karma start test/karma-conf.js --tests stock/*/* --ts --single-run --browsercount 2 --visualcompare || true
-          if [ ! -f "$marker" ]; then
-            printf '%s\n' \
-              'Stock candidate run did not reach image-capture reporter completion.' \
-              >> test/visual-test-errors.log
-          fi
+        run: node .github/scripts/runVisualCompare.js "Stock" "stock/*/*"
 
       - name: Compare Maps visual tests
-        run: |
-          marker='test/visual-test-complete'
-          rm -f "$marker"
-          npx karma start test/karma-conf.js --tests maps/*/* --ts --single-run --browsercount 2 --visualcompare || true
-          if [ ! -f "$marker" ]; then
-            printf '%s\n' \
-              'Maps candidate run did not reach image-capture reporter completion.' \
-              >> test/visual-test-errors.log
-          fi
+        run: node .github/scripts/runVisualCompare.js "Maps" "maps/*/*"
 
       - name: Compare Gantt visual tests
-        run: |
-          marker='test/visual-test-complete'
-          rm -f "$marker"
-          npx karma start test/karma-conf.js --tests gantt/*/* --ts --single-run --browsercount 2 --visualcompare || true
-          if [ ! -f "$marker" ]; then
-            printf '%s\n' \
-              'Gantt candidate run did not reach image-capture reporter completion.' \
-              >> test/visual-test-errors.log
-          fi
+        run: node .github/scripts/runVisualCompare.js "Gantt" "gantt/*/*"
 
       - name: Generate visual test report
         run: |

--- a/test/karma-imagecapture-reporter.js
+++ b/test/karma-imagecapture-reporter.js
@@ -9,23 +9,31 @@
 const fs = require('fs');
 const { getLatestCommitShaSync } = require('../tools/libs/git');
 const version = require('../package.json').version;
+const {
+    classifyRunResult,
+    classifySpecResult,
+    formatRunFailure,
+    formatSpecFailure
+} = require('./karma-imagecapture-result');
 
 /* eslint-disable require-jsdoc */
 function ImageCaptureReporter(baseReporterDecorator, config, logger, emitter) {
     baseReporterDecorator(this);
     const LOG = logger.create('reporter.imagecapture');
     const gitSha = getLatestCommitShaSync();
+    const reportRunComplete = this.onRunComplete;
 
     // eslint-disable-next-line func-style
     let fileWritingFinished = function () {};
     let pendingFileWritings = 0;
 
-    const {
-        imageCapture = {
-            resultsOutputPath: 'test/visual-test-results.json'
-        },
-        referenceRun = false
-    } = config;
+    const { imageCapture = {}, referenceRun = false } = config;
+    const resultsOutputPath = imageCapture.resultsOutputPath ||
+        'test/visual-test-results.json';
+    const errorsOutputPath = imageCapture.errorsOutputPath ||
+        'test/visual-test-errors.log';
+    const completionOutputPath = imageCapture.completionOutputPath ||
+        'test/visual-test-complete';
 
 
     /**
@@ -75,16 +83,34 @@ function ImageCaptureReporter(baseReporterDecorator, config, logger, emitter) {
         if (existingFile && existingFile.length !== 0) {
             try {
                 return JSON.parse(existingFile.toString());
-            } catch (e) {
+            } catch {
                 LOG.warn('Failed to parse existing visual test results.');
             }
         }
         return {}; // empty object
     }
 
+    function appendError(error) {
+        try {
+            fs.appendFileSync(errorsOutputPath, error);
+        } catch (err) {
+            LOG.error(`Failed to write ${errorsOutputPath}\n\n${err}`);
+        }
+    }
+
+    function writeCompletionMarker() {
+        try {
+            fs.writeFileSync(completionOutputPath, '');
+        } catch (err) {
+            LOG.error(
+                `Failed to write ${completionOutputPath}\n\n${err}`
+            );
+        }
+    }
+
     // "browser_start" - a test run is beginning in _this_ browser
     this.onBrowserStart = function (browser) {
-        const filename = imageCapture.resultsOutputPath;
+        const filename = resultsOutputPath;
         LOG.info('Starting visual tests. Results stored in ' + filename);
         const now = new Date();
         const today = now.toISOString().slice(0, 10);
@@ -111,24 +137,32 @@ function ImageCaptureReporter(baseReporterDecorator, config, logger, emitter) {
             // no need to log results test results if the test run is for references/baselines
             return;
         }
-        const { log = [], skipped, success } = testResult;
-        const filename = imageCapture.resultsOutputPath;
+        const filename = resultsOutputPath;
         const diffResults = readExistingResult(filename);
+        const result = classifySpecResult(testResult);
 
-        if (skipped) {
+        if (result.type === 'skip') {
             diffResults[testResult.description] = undefined;
-        } else if (success) {
+        } else if (result.type === 'success') {
             diffResults[testResult.description] = 0;
-        } else if (!success && log.length > 0) {
-            const matches = log[0].match(/Actual: (\d+)/);
-            if (matches && matches[1]) {
-                LOG.info(`Test ${testResult.description} differs with ${matches[1]} pixels`);
-                diffResults[testResult.description] = parseInt(matches[1], 10);
-            } else {
-                LOG.warn(`Test ${testResult.description} failed, but unable to determine the diff. Has the test assert(..) changed?`);
-            }
+        } else if (result.type === 'pixel-diff') {
+            LOG.info(`Test ${testResult.description} differs with ${result.pixels} pixels`);
+            diffResults[testResult.description] = result.pixels;
+        } else {
+            appendError(formatSpecFailure(browser, testResult));
+            return;
         }
         fs.writeFileSync(filename, JSON.stringify(diffResults, null, ' '));
+    };
+
+    this.onRunComplete = function (browsers, results) {
+        reportRunComplete.call(this, browsers, results);
+        if (!referenceRun) {
+            if (classifyRunResult(results).type !== 'success') {
+                appendError(formatRunFailure(browsers, results));
+            }
+            writeCompletionMarker();
+        }
     };
 
     /**

--- a/test/karma-imagecapture-result.js
+++ b/test/karma-imagecapture-result.js
@@ -1,0 +1,117 @@
+/* eslint-env node,es6 */
+
+function stringify(value) {
+    if (value instanceof Error) {
+        return value.stack || value.message;
+    }
+    if (typeof value === 'string') {
+        return value;
+    }
+    if (value === undefined || value === null) {
+        return '';
+    }
+    try {
+        return JSON.stringify(value);
+    } catch {
+        return String(value);
+    }
+}
+
+function getLogText(log) {
+    const entries = Array.isArray(log) ? log : [log];
+    return entries.map(stringify).filter(Boolean).join('\n');
+}
+
+function getBrowserIdentity(browser) {
+    if (!browser) {
+        return 'unknown';
+    }
+    return browser.name || browser.id || String(browser);
+}
+
+function getBrowserIdentities(browsers) {
+    const identities = browsers && typeof browsers.map === 'function' ?
+        browsers.map(getBrowserIdentity) : [];
+    return identities.join(', ') || 'unknown';
+}
+
+function getSpecDescription(testResult) {
+    const suite = Array.isArray(testResult && testResult.suite) ?
+        testResult.suite : [];
+    return suite.concat(testResult && testResult.description || [])
+        .filter(Boolean)
+        .join(' ') || 'unknown';
+}
+
+function classifySpecResult(testResult) {
+    if (testResult.skipped) {
+        return { type: 'skip' };
+    }
+    if (testResult.success) {
+        return { type: 'success' };
+    }
+
+    const logText = getLogText(testResult.log);
+    const pixelDiff = logText.match(
+        /(?:^|\n)Different pixels\r?\n[\s\S]*?\bActual:\s*(\d+)\b/u
+    );
+    if (pixelDiff) {
+        return {
+            type: 'pixel-diff',
+            pixels: parseInt(pixelDiff[1], 10)
+        };
+    }
+
+    return { type: 'execution-error' };
+}
+
+function classifyRunResult(runResult) {
+    if (runResult && runResult.disconnected) {
+        return { type: 'browser-disconnect' };
+    }
+    if (runResult && runResult.error) {
+        return { type: 'browser-error' };
+    }
+    if (
+        runResult && runResult.exitCode &&
+        !runResult.failed && !runResult.skipped
+    ) {
+        return { type: 'run-error' };
+    }
+    return { type: 'success' };
+}
+
+function formatSpecFailure(browser, testResult) {
+    return [
+        'Execution error',
+        `Test: ${getSpecDescription(testResult)}`,
+        `Browser: ${getBrowserIdentity(browser)}`,
+        'Log:',
+        getLogText(testResult && testResult.log) || '(empty)'
+    ].join('\n') + '\n';
+}
+
+function formatRunFailure(browsers, runResult) {
+    const result = classifyRunResult(runResult);
+    const error = runResult && runResult.error;
+    const log = error && error !== true ? stringify(error) :
+        result.type === 'browser-disconnect' ?
+            'Browser disconnected' :
+            result.type === 'browser-error' ?
+                'Karma reported a terminal browser error' :
+                `Karma exited with code ${runResult.exitCode}`;
+
+    return [
+        result.type === 'run-error' ? 'Run error' : 'Browser error',
+        `Browser: ${getBrowserIdentities(browsers)}`,
+        'Log:',
+        log || '(empty)'
+    ].join('\n') + '\n';
+}
+
+module.exports = {
+    classifyRunResult,
+    classifySpecResult,
+    formatRunFailure,
+    formatSpecFailure
+};

--- a/test/karma-imagecapture-result.test.mjs
+++ b/test/karma-imagecapture-result.test.mjs
@@ -1,0 +1,172 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import {
+    classifyRunResult,
+    classifySpecResult,
+    formatRunFailure,
+    formatSpecFailure
+} from './karma-imagecapture-result.js';
+
+const require = createRequire(import.meta.url);
+const imageCapturePlugin = require('./karma-imagecapture-reporter.js');
+const ImageCaptureReporter = imageCapturePlugin['reporter:imagecapture'][1];
+
+function createReporter(config) {
+    return new ImageCaptureReporter(
+        reporter => {
+            reporter.onRunComplete = () => {};
+        },
+        config,
+        {
+            create: () => ({
+                info() {},
+                warn() {},
+                error() {}
+            })
+        },
+        { on() {} }
+    );
+}
+
+test('classifies successful and skipped specs', () => {
+    assert.deepEqual(classifySpecResult({ success: true }), { type: 'success' });
+    assert.deepEqual(classifySpecResult({ skipped: true }), { type: 'skip' });
+});
+
+test('classifies generated pixel differences with numeric Actual values', () => {
+    assert.deepEqual(
+        classifySpecResult({
+            log: ['Different pixels\nActual: 42']
+        }),
+        { type: 'pixel-diff', pixels: 42 }
+    );
+});
+
+test('does not classify arbitrary numeric assertion failures as pixel differences', () => {
+    assert.deepEqual(
+        classifySpecResult({ log: ['Expected: 0\nActual: 42'] }),
+        { type: 'execution-error' }
+    );
+});
+
+test('classifies TypeError-like failures as execution errors', () => {
+    assert.deepEqual(
+        classifySpecResult({
+            log: ['TypeError: can\'t access property \'series\', point is undefined']
+        }),
+        { type: 'execution-error' }
+    );
+});
+
+test('classifies an empty failure log as an execution error', () => {
+    assert.deepEqual(
+        classifySpecResult({ log: [] }),
+        { type: 'execution-error' }
+    );
+});
+
+test('formats spec failures with test, browser, and log context', () => {
+    assert.equal(
+        formatSpecFailure(
+            { name: 'ChromeHeadless' },
+            { suite: ['stock'], description: 'static-stock', log: ['TypeError'] }
+        ),
+        'Execution error\nTest: stock static-stock\nBrowser: ChromeHeadless\nLog:\nTypeError\n'
+    );
+});
+
+test('classifies terminal run outcomes after retry handling', () => {
+    assert.deepEqual(
+        classifyRunResult({
+            success: 1,
+            failed: 0,
+            error: false,
+            disconnected: false,
+            exitCode: 0
+        }),
+        { type: 'success' }
+    );
+    assert.deepEqual(
+        classifyRunResult({ disconnected: true, exitCode: 1 }),
+        { type: 'browser-disconnect' }
+    );
+    assert.deepEqual(
+        classifyRunResult({ error: true, exitCode: 1 }),
+        { type: 'browser-error' }
+    );
+    assert.deepEqual(
+        classifyRunResult({ failed: 0, exitCode: 1 }),
+        { type: 'run-error' }
+    );
+    assert.deepEqual(
+        classifyRunResult({ failed: 1, exitCode: 1 }),
+        { type: 'success' }
+    );
+    assert.deepEqual(
+        classifyRunResult({ skipped: 1, exitCode: 1 }),
+        { type: 'success' }
+    );
+});
+
+test('formats terminal browser failures with browser identity', () => {
+    assert.equal(
+        formatRunFailure(
+            [{ id: 'browser-1' }],
+            { disconnected: true, exitCode: 1 }
+        ),
+        'Browser error\nBrowser: browser-1\nLog:\nBrowser disconnected\n'
+    );
+});
+
+test('writes candidate completion markers but not reference markers', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'karma-imagecapture-'));
+    const marker = join(directory, 'complete');
+    const errors = join(directory, 'errors.log');
+    const config = {
+        imageCapture: {
+            completionOutputPath: marker,
+            errorsOutputPath: errors
+        },
+        referenceRun: false
+    };
+
+    try {
+        createReporter(config).onRunComplete([], {
+            success: 1,
+            failed: 0,
+            skipped: 0,
+            error: false,
+            disconnected: false,
+            exitCode: 0
+        });
+        assert.equal(existsSync(marker), true);
+
+        rmSync(marker);
+        createReporter({ ...config, referenceRun: true }).onRunComplete([], {
+            success: 1,
+            failed: 0,
+            skipped: 0,
+            error: false,
+            disconnected: false,
+            exitCode: 0
+        });
+        assert.equal(existsSync(marker), false);
+
+        createReporter(config).onRunComplete([], {
+            success: 0,
+            failed: 0,
+            skipped: 0,
+            error: true,
+            disconnected: false,
+            exitCode: 1
+        });
+        assert.match(readFileSync(errors, 'utf8'), /Browser error/u);
+        assert.equal(existsSync(marker), true);
+    } finally {
+        rmSync(directory, { recursive: true, force: true });
+    }
+});

--- a/test/karma-setup.js
+++ b/test/karma-setup.js
@@ -617,6 +617,7 @@ Highcharts.prepareShot = function (chart) {
                     points[i].shapeArgs.d &&
                     points[i].shapeArgs.d.length === 0
                 ) &&
+                points[i].series.options.enableMouseTracking !== false &&
                 typeof points[i].onMouseOver === 'function'
             ) {
                 points[i].onMouseOver();

--- a/tests/visual/visual-setup.js
+++ b/tests/visual/visual-setup.js
@@ -339,6 +339,7 @@
                         point.shapeArgs.d &&
                         point.shapeArgs.d.length === 0
                     ) &&
+                    point.series.options.enableMouseTracking !== false &&
                     typeof point.onMouseOver === 'function'
                 ) {
                     point.onMouseOver();


### PR DESCRIPTION
Added fix for failing hover when `enableMouseTracking` was set in a sample. Also made visual comparison fail when there is runtime errors in the candidate run.

Note: the fix must be on master for it to take effect in the visual-compare workflow