### PR TITLE
Fixed #24976, error on chart.destroy during fill animation

### DIFF
--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -711,8 +711,13 @@ class Point {
      *
      * @internal
      * @function Highcharts.Point#destroy
+     *
+     * @param {boolean} [sync]
+     *        Whether to destroy the point synchronously. Used internally from
+     *        series.destroy, where condemned points may cause animation errors
+     *        (#24976).
      */
-    public destroy(): void {
+    public destroy(sync?: boolean): void {
         if (!this.destroyed && !this.condemned) {
             const point = this,
                 series = point.series,
@@ -762,7 +767,7 @@ class Point {
             }
 
             // Remove properties after animation
-            if (duration && series.condemnedPoints) {
+            if (duration && !sync && series.condemnedPoints) {
                 series.condemnedPoints.push(this);
                 this.graphic?.addClass('highcharts-point-condemned');
                 setTimeout(destroyPoint, duration);

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -3479,7 +3479,7 @@ class Series {
         // Destroy all points with their elements
         i = data.length;
         while (i--) {
-            data[i]?.destroy?.();
+            data[i]?.destroy?.(true);
         }
 
         for (const zone of series.zones || []) {

--- a/ts/Series/Dumbbell/DumbbellPoint.ts
+++ b/ts/Series/Dumbbell/DumbbellPoint.ts
@@ -114,7 +114,7 @@ class DumbbellPoint extends AreaRangePoint {
         point.connector?.[verb](series.getConnectorAttribs(point));
     }
 
-    public destroy(): void {
+    public destroy(sync?: boolean): void {
         const point = this;
 
         // #15560
@@ -122,7 +122,7 @@ class DumbbellPoint extends AreaRangePoint {
             point.graphic = point.connector;
             point.connector = void 0 as any;
         }
-        return super.destroy();
+        return super.destroy(sync);
     }
 }
 


### PR DESCRIPTION
Fixed #24976, a v13.0.0 regression causing error on `chart.destroy` during fill animation