### PR TITLE
Fixed #25011, chart layout didn't respond to font size update

### DIFF
--- a/samples/unit-tests/chart/chart-update-chart-3/demo.js
+++ b/samples/unit-tests/chart/chart-update-chart-3/demo.js
@@ -109,7 +109,8 @@ QUnit.test('Chart.update with style', function (assert) {
                 chart: {
                     type: 'column',
                     animation: false,
-                    height: 300
+                    height: 300,
+                    plotBorderWidth: 1
                 },
 
                 plotOptions: {
@@ -147,10 +148,13 @@ QUnit.test('Chart.update with style', function (assert) {
         'Initial font family'
     );
 
+    const borderTop = chart.container.querySelector('.highcharts-plot-border')
+        .getAttribute('y');
     chart.update({
         chart: {
             style: {
-                fontFamily: 'monospace'
+                fontFamily: 'monospace',
+                fontSize: '3em'
             }
         }
     });
@@ -161,6 +165,13 @@ QUnit.test('Chart.update with style', function (assert) {
             .getPropertyValue('font-family'),
         'monospace',
         'Updated font family'
+    );
+
+    assert.notEqual(
+        chart.container.querySelector('.highcharts-plot-border')
+            .getAttribute('y'),
+        borderTop,
+        'Plot top should be updated after font size change (#25011)'
     );
 });
 

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -1301,7 +1301,6 @@ class Chart {
         let hasDirtyStacks: (boolean|undefined),
             hasStackedSeries: (boolean|undefined),
             i: number,
-            isDirtyBox = chart.isDirtyBox,
             redrawLegend = chart.isDirtyLegend,
             serie: Series;
 
@@ -1394,6 +1393,7 @@ class Chart {
         chart.getMargins(); // #3098
 
         // If one axis is dirty, all axes must be redrawn (#792, #2169)
+        let isDirtyBox = chart.isDirtyBox;
         axes.forEach(function (axis): void {
             if (axis.isDirty) {
                 isDirtyBox = true;

--- a/ts/Extensions/OfflineExporting/OfflineExporting.ts
+++ b/ts/Extensions/OfflineExporting/OfflineExporting.ts
@@ -619,8 +619,7 @@ namespace OfflineExporting {
 
         // Work around jsPDF's missing support for color(srgb r g b) format
         // (#25001)
-        const srgbColorRegex =
-            /color\(\s*srgb\s+([\d.]+)[, ]+([\d.]+)[, ]+([\d.]+)(?:\s*\/\s*([\d.]+))?\s*\)/;
+        const srgbColorRegex = /color\(\s*srgb\s+([\d.]+)[, ]+([\d.]+)[, ]+([\d.]+)(?:\s*\/\s*([\d.]+))?\s*\)/; // eslint-disable-line max-len
 
         const convertColorSRGBToRGB = (
             srgbColor?: string|null


### PR DESCRIPTION
Fixed #25011, a v13.0.0 regression causing axis and series layout not to respond to chart font size update