### PR TITLE
Samples: build homepage carousel demos only while visible, plus carousel fixes

### DIFF
--- a/samples/highcharts/website/homepage-2025/demo.js
+++ b/samples/highcharts/website/homepage-2025/demo.js
@@ -3219,38 +3219,35 @@ function announceChange(announcement) {
    containers, and the Grid kept re-rendering its 30 rows of sparklines
    off-screen, which cost roughly half the frame budget on every other
    slide. */
+// A board owns its components, their charts and their DOM, so destroying
+// it is the entire teardown -- verified to take the container from 5
+// charts / 502 nodes to 0 / 102. Nothing else may touch that DOM first,
+// or the components have nothing left to clean up.
+// Dashboards.board() is async, so the resolved board is kept separately
+// from the in-flight promise; that way the common case (already built)
+// tears down synchronously.
 let dashBoard = null;
+let dashPending = null;
 
 function buildDashboards() {
-    if (dashBoard) {
+    if (dashBoard || dashPending) {
         return;
     }
-    // dashboards() resolves asynchronously
-    dashBoard = Promise.resolve(dashboards());
+    dashPending = Promise.resolve(dashboards()).then(board => {
+        dashPending = null;
+        dashBoard = board;
+    });
 }
 
 function destroyDashboards() {
-    if (!dashBoard) {
-        return;
+    if (dashBoard) {
+        dashBoard.destroy();
+        dashBoard = null;
+    } else if (dashPending) {
+        // left the slide before the board finished loading; dashPending
+        // stays set so buildDashboards() cannot start a second board
+        dashPending.then(destroyDashboards);
     }
-    const container = document.getElementById('dash-container');
-
-    dashBoard.then(board => {
-        if (board) {
-            board.destroy();
-        }
-    }).catch(() => {
-        // nothing to tear down
-    });
-
-    Highcharts.charts.filter(Boolean).forEach(chart => {
-        if (container.contains(chart.renderTo)) {
-            chart.destroy();
-        }
-    });
-
-    container.innerHTML = '';
-    dashBoard = null;
 }
 
 function buildGrid() {
@@ -3264,29 +3261,16 @@ function destroyGrid() {
     if (!gridControls) {
         return;
     }
-    const container = document.getElementById('grid-container');
-
-    // stops the per-row update timers
+    // stops the per-row update timers, and tags the container as paused
     gridControls.clearGridUpdates();
 
-    Promise.resolve(gridControls.gridInstance).then(gridInstance => {
-        if (gridInstance) {
-            gridInstance.destroy();
-        }
-    }).catch(() => {
-        // nothing to tear down
-    });
+    // Grid.grid() is synchronous, and the Grid owns its 90 sparkline
+    // charts and their DOM the same way the board does
+    gridControls.gridInstance.destroy();
 
-    Highcharts.charts.filter(Boolean).forEach(chart => {
-        if (container.contains(chart.renderTo)) {
-            chart.destroy();
-        }
-    });
-
-    container.innerHTML = '';
-    // clearGridUpdates() above tags the container as paused; drop the
-    // class so a rebuilt grid does not start out marked as paused
-    container.classList.remove('paused-grid');
+    // drop the paused tag so a rebuilt grid does not start out paused
+    document.getElementById('grid-container')
+        .classList.remove('paused-grid');
     gridControls = null;
 }
 

--- a/samples/highcharts/website/homepage-2025/demo.js
+++ b/samples/highcharts/website/homepage-2025/demo.js
@@ -271,7 +271,22 @@ function cs() {
         },
 
         yAxis: {
-            visible: false,
+            // Kept in the layout rather than visible: false. The lastPrice
+            // label is a crosshair label anchored to this axis, and on a
+            // hidden axis it has no x to anchor to: it rendered as
+            // transform="translate(NaN,<price>)", logged an SVG attribute
+            // error on every redraw, and fell back to x=0 so the price
+            // badge sat in the top left instead of beside the series.
+            // Switching the parts off individually looks the same.
+            visible: true,
+            labels: {
+                enabled: false
+            },
+            lineWidth: 0,
+            gridLineWidth: 0,
+            title: {
+                text: null
+            },
             height: '80%'
         },
         credits: {

--- a/samples/highcharts/website/homepage-2025/demo.js
+++ b/samples/highcharts/website/homepage-2025/demo.js
@@ -3284,6 +3284,9 @@ function destroyGrid() {
     });
 
     container.innerHTML = '';
+    // clearGridUpdates() above tags the container as paused; drop the
+    // class so a rebuilt grid does not start out marked as paused
+    container.classList.remove('paused-grid');
     gridControls = null;
 }
 

--- a/samples/highcharts/website/homepage-2025/demo.js
+++ b/samples/highcharts/website/homepage-2025/demo.js
@@ -188,6 +188,16 @@ function getNewPoint(i, data) {
     ];
 }
 
+// csSeries is captured in the chart's load event and goes stale as soon as
+// that chart is destroyed. A destroyed series keeps its options object, so
+// the options check below does not notice, and pushing data into it renders
+// at NaN coordinates -- which the price indicator then tries to draw a
+// crosshair at. Detached from its chart is the reliable signal.
+function csIsDestroyed() {
+    const chart = csSeries && csSeries.chart;
+    return !chart || chart.series.indexOf(csSeries) === -1;
+}
+
 function animateCS() {
     if (!csSeries || !csSeries.options || !csSeries.options.data) {
         return;
@@ -195,8 +205,18 @@ function animateCS() {
 
     let i = 0;
     csInterval = setInterval(() => {
-        if (!csSeries || !csSeries.options || !csSeries.options.data) {
+        if (
+            !csSeries || !csSeries.options || !csSeries.options.data ||
+            csIsDestroyed()
+        ) {
             clearInterval(csInterval);
+            return;
+        }
+
+        // Mid-rebuild, or the slide is hidden, so there is nothing to
+        // measure against yet. Skip the tick rather than stopping, since
+        // this state is transient.
+        if (csSeries.chart.plotWidth <= 0) {
             return;
         }
 

--- a/samples/highcharts/website/homepage-2025/demo.js
+++ b/samples/highcharts/website/homepage-2025/demo.js
@@ -1303,7 +1303,7 @@ function stockWithAnnotations() {
         const name = Array.from(Object.keys(cols).filter(k => k !== 'Date'))[0];
         const data = cols[name].map((value, i) => [cols.Date[i], value]);
 
-        Highcharts.chart('container', {
+        currentChart = Highcharts.chart('container', {
             chart: {
                 type: 'area',
                 zooming: {
@@ -2752,7 +2752,7 @@ function grid() {
 
 /* DEMO VIEWER */
 // product info for demo viewer
-const products = [
+let products = [
     {
         name: 'Highcharts Stock',
         tagline: 'Financial visualization and analysis tools',
@@ -2879,6 +2879,15 @@ const products = [
     }
 ];
 
+// The Grid demo renders 30 rows of sparklines, which is 90 charts built in
+// one go. Small screens only ever see its first two columns anyway, and
+// building it there has been enough to crash mobile browsers, so drop that
+// slide below the tablet breakpoint.
+const isSmallScreen = window.matchMedia('(max-width: 767px)').matches;
+if (isSmallScreen) {
+    products = products.filter(p => p.chart !== grid);
+}
+
 const carousel = document.getElementById('carousel');
 const chartWrapper = document.getElementById('chart-wrapper');
 
@@ -2905,7 +2914,8 @@ products.forEach((p, index) => {
     titleInner.appendChild(item);
 });
 const clone = titleInner.firstElementChild.cloneNode(true);
-clone.id = 'title-6';
+clone.id = 'title-clone';
+clone.setAttribute('aria-hidden', 'true');
 titleInner.appendChild(clone);
 
 // --- Footer + pagination setup ---
@@ -2923,6 +2933,11 @@ let isResetting = false;
 const dots = document.querySelectorAll('.dot');
 
 dots.forEach((dot, i) => {
+    if (i >= products.length) {
+        dot.style.display = 'none';
+        return;
+    }
+
     dot.addEventListener('click', function () {
         goTo(i);
         if (!isPaused) {
@@ -2959,7 +2974,8 @@ function updateView() {
     if (currentIndex === products.length) {
         currentIndex = 0;
         isResetting = true;
-        titleInner.style.transform = 'translateY(-240px)';
+        titleInner.style.transform =
+            `translateY(-${products.length * 40}px)`;
         titleInner.style.opacity = 1;
 
         updateFooter(currentIndex);
@@ -3156,12 +3172,19 @@ function stopMapAnimation() {
     logAnim('Map animation stopped');
 }
 // --- Animation Failsafe ---
+// Looked up rather than hardcoded: every one of these indices was stale,
+// and the order shifts again when a demo is dropped on small screens. A
+// wrong number here starts the wrong chart's interval.
+function slideIndexOf(chartFn) {
+    return products.findIndex(p => p.chart === chartFn);
+}
+
 function ensureCorrectAnimationState() {
     // When resuming, respect each chart's individual animation preference
     Object.keys(chartAnimationState).forEach(key => {
         const isActive = chartAnimationState[key];
-        // stock chart
-        if (key === 'stock' && currentIndex === 0) { // stock index is 0
+        // Candlestick chart
+        if (key === 'stock' && currentIndex === slideIndexOf(cs)) {
             if (isActive) {
                 startStockChartAnimation();
                 logAnim('Stock animation resumed');
@@ -3170,8 +3193,8 @@ function ensureCorrectAnimationState() {
                 logAnim('Stock animation paused');
             }
         }
-        // map chart
-        if (key === 'maps' && currentIndex === 4) { // maps index is 4
+        // Map chart
+        if (key === 'maps' && currentIndex === slideIndexOf(animatedMap)) {
             if (isActive) {
                 startMapAnimation();
                 logAnim('Map animation resumed');
@@ -3180,9 +3203,9 @@ function ensureCorrectAnimationState() {
                 logAnim('Map animation paused');
             }
         }
-        // grid
-        // eslint-disable-next-line max-len
-        if (key === 'grid' && gridControls && currentIndex === 1) { // grid index is 1
+        // Grid sparklines, absent on small screens
+        const onGridSlide = currentIndex === slideIndexOf(grid);
+        if (key === 'grid' && gridControls && onGridSlide) {
             if (isActive) {
                 if (typeof gridControls.resumeGridUpdates === 'function') {
                     gridControls.resumeGridUpdates();

--- a/samples/highcharts/website/homepage-2025/demo.js
+++ b/samples/highcharts/website/homepage-2025/demo.js
@@ -2009,12 +2009,7 @@ const gantt = {
 // Dashboards personal finance
 function dashboards() {
 
-    Highcharts.setOptions({
-        chart: {
-            styledMode: true
-        }
-    });
-    Dashboards.board('dash-container', {
+    return Dashboards.board('dash-container', {
         dataPool: {
             connectors: [{
                 id: 'transactions',
@@ -3218,6 +3213,80 @@ function announceChange(announcement) {
     }
 }
 
+
+/* The Dashboards and Grid demos are only built while their slide is
+   showing. Building them up front left ~95 charts alive in hidden
+   containers, and the Grid kept re-rendering its 30 rows of sparklines
+   off-screen, which cost roughly half the frame budget on every other
+   slide. */
+let dashBoard = null;
+
+function buildDashboards() {
+    if (dashBoard) {
+        return;
+    }
+    // dashboards() resolves asynchronously
+    dashBoard = Promise.resolve(dashboards());
+}
+
+function destroyDashboards() {
+    if (!dashBoard) {
+        return;
+    }
+    const container = document.getElementById('dash-container');
+
+    dashBoard.then(board => {
+        if (board) {
+            board.destroy();
+        }
+    }).catch(() => {
+        // nothing to tear down
+    });
+
+    Highcharts.charts.filter(Boolean).forEach(chart => {
+        if (container.contains(chart.renderTo)) {
+            chart.destroy();
+        }
+    });
+
+    container.innerHTML = '';
+    dashBoard = null;
+}
+
+function buildGrid() {
+    if (gridControls) {
+        return;
+    }
+    gridControls = grid();
+}
+
+function destroyGrid() {
+    if (!gridControls) {
+        return;
+    }
+    const container = document.getElementById('grid-container');
+
+    // stops the per-row update timers
+    gridControls.clearGridUpdates();
+
+    Promise.resolve(gridControls.gridInstance).then(gridInstance => {
+        if (gridInstance) {
+            gridInstance.destroy();
+        }
+    }).catch(() => {
+        // nothing to tear down
+    });
+
+    Highcharts.charts.filter(Boolean).forEach(chart => {
+        if (container.contains(chart.renderTo)) {
+            chart.destroy();
+        }
+    });
+
+    container.innerHTML = '';
+    gridControls = null;
+}
+
 function updateChart(i) {
 
     const p = products[i];
@@ -3256,13 +3325,19 @@ function updateChart(i) {
                     document.getElementById('grid-container').style.display = 'none';
                     // eslint-disable-next-line max-len
                     document.getElementById('dash-container').style.display = 'block';
+                    destroyGrid();
+                    buildDashboards();
                 } else if (p.chart === grid) {
                     document.getElementById('container').style.display = 'none';
                     // eslint-disable-next-line max-len
                     document.getElementById('dash-container').style.display = 'none';
                     // eslint-disable-next-line max-len
                     document.getElementById('grid-container').style.display = 'block';
+                    destroyDashboards();
+                    buildGrid();
                 } else {
+                    destroyDashboards();
+                    destroyGrid();
                     // eslint-disable-next-line max-len
                     document.getElementById('dash-container').style.display = 'none';
                     // eslint-disable-next-line max-len
@@ -3272,6 +3347,8 @@ function updateChart(i) {
                     p.chart();
                 }
             } else {
+                destroyDashboards();
+                destroyGrid();
                 // eslint-disable-next-line max-len
                 document.getElementById('dash-container').style.display = 'none';
                 // eslint-disable-next-line max-len
@@ -3490,8 +3567,14 @@ document.addEventListener('DOMContentLoaded', function () {
     initializePauseButtonState();
 
     // --- Start carousel setup ---
-    dashboards();
-    gridControls = grid();
+    // Dashboards and Grid are built when their slide is first shown.
+    // dashboards() used to apply this as a side effect of running at
+    // load, and every demo relies on it, so it is set here instead.
+    Highcharts.setOptions({
+        chart: {
+            styledMode: true
+        }
+    });
 
     // create the first chart
     document.querySelector('.demo-title-inner').style.opacity = 1;


### PR DESCRIPTION
Supersedes #25017 — this carries nasin's correctness fixes across, so only one of the two lands. Independent of #25019 (styling/assets); verified 0 conflicts, either can merge first.

## The performance problem

`dashboards()` and `grid()` were called at `DOMContentLoaded`, so **95 charts were created into `display: none` containers** and kept alive for the life of the page: 5 for Dashboards, 90 sparklines for the Grid demo. Only one demo is ever on screen.

The charts themselves were not the problem — 96 idle charts cost no measurable CPU. The Grid demo's per-row update timers were, and they kept running while `grid-container` was `display: none`, re-rendering 30 rows off-screen. Measured in Chrome on a 120 Hz display, carousel paused so each slide is a steady state:

| Slide showing | fps | frame p95 | worst frame | frames > 50 ms / 8 s |
|---|---|---|---|---|
| Stock (Grid off-screen) | **46.1** | 80 ms | 124 ms | 36 |
| **Grid (on-screen)** | **120** | 10.2 ms | 13.7 ms | 0 |
| Dashboards | 56.3 | 47 ms | 123 ms | 21 |

The Grid slide is the only smooth one, and it's the demo doing the work. Stopping just those timers, with all 96 charts still alive, restored a steady 120 fps — which is what identified them as the cause rather than the chart count.

## What changes

Both heavy demos are built when their slide is first shown and torn down on leave, so only the visible demo is live.

| | before | after |
|---|---|---|
| Charts at load | 96 | **1** |
| DOM nodes at load | 3 774 | **192** |
| Long tasks during load | 66 (12 477 ms) | **1 (410 ms)** |
| fps, non-Grid slides | 46–56 | **120** |
| fps, Grid slide | 120 | **120** |

Cycling repeatedly returns to 1 chart and 271 nodes, so nothing accumulates.

`dashboards()` also set `chart.styledMode` as a side effect of running at load, which every demo depends on, so that moves to the init block. Without it the remaining demos lose their styling — the Stock navigator falls back to Highcharts' default green/blue.

## Carousel fixes, from #25017

Credit for finding these is nasin's; they're carried over as-is:

- the loop clone was given `id="title-6"`, duplicating the real Gantt slide's id
- the wrap-around transform hardcoded `translateY(-240px)` — position 6 of a 7-product strip, so the loop landed on the wrong title
- slide 0's chart was never assigned to `currentChart`, so `updateChart` couldn't fade it out before swapping
- `demo.html` hardcodes seven dots, so any without a product are now hidden

The hardcoded slide indices in `ensureCorrectAnimationState` are replaced with **lookups** rather than corrected numbers. All three were stale on master — stock said `0` when the animated candlestick is `1`, maps said `4` when maps is `5`, grid said `1` when grid is `2`. `pause()` calls this, so pausing on the annotations slide could start the candlestick's 100 ms interval for a chart that wasn't on screen. Fixed numbers would go stale again as soon as the slide order changes, which the next section does.

## The mobile crash

This is where the approach differs from #25017, which removed the Grid and Dashboards demos outright.

**Lazy building alone does not fix mobile — it defers it.** I measured at a 375 px viewport: reaching the Grid slide still builds all 90 charts and 3 184 DOM nodes, and the carousel gets there on its own within ~12 s. So dropping the removal without replacing it would have regressed exactly what #25017 set out to fix.

Instead the Grid slide is dropped below the tablet breakpoint (`max-width: 767px`), where it only ever showed its first two columns anyway — the Disk Usage column is off-screen entirely at that width. Dashboards is five charts and stays.

Emulated Pixel 8, full auto-cycle, no manual driving:

| | master | this PR (mobile) |
|---|---|---|
| Charts at load | 96 | **1** |
| **Peak** charts across a full cycle | 96 | **5** |
| Peak DOM nodes | 3 774 | **507** |

## Review feedback applied

Both teardown helpers originally cleared their container and destroyed the charts inside it synchronously, while the owning instance was destroyed later in a microtask — backwards, since components expect their `renderTo` to still exist when `destroy()` runs, and a blanket `.catch()` was swallowing the consequences.

Measured what the owners clean up unaided: `board.destroy()` takes its container from 5 charts / 502 nodes to **0 / 102**; `gridInstance.destroy()` from 90 charts / 3 184 nodes to **0 / 103**. So the chart sweep and the `innerHTML` wipe were redundant as well as mis-ordered, and both are gone. `Grid.grid()` is synchronous, so its destroy is now a plain call; `Dashboards.board()` is async, so the resolved board is tracked separately from the in-flight promise, making the common path synchronous too.

## Verification

Verified at both widths: 7 slides / 7 dots on desktop with indices `cs=1 grid=2 maps=5`; 6 slides / 6 dots below 768 px with the Grid absent; no duplicate ids; clone hidden from screen readers. Full auto-cycle including the wrap-around, plus 11 rapid transitions with 120 ms gaps (shorter than the fade, to hit the teardown ordering window) — no errors, no unhandled rejections. `eslint` clean, 387 pre-commit tests pass, `highsoft-bot` reports no visual diff and no file-size change.

## One open question

The 768 px threshold, and dropping the Grid entirely versus shrinking it to ~8 rows, are product calls rather than mine — shrinking would keep Grid on phones, which may matter more than the memory saving. And emulation isn't a real device: the peak numbers are strong evidence, not proof the crash is gone.
