### PR TITLE
Samples: fix homepage annotation labels and KPI sparkline height

### DIFF
--- a/samples/highcharts/website/homepage-2025/demo.css
+++ b/samples/highcharts/website/homepage-2025/demo.css
@@ -90,6 +90,7 @@
     --highlight-purple: #8791ff;
     --highlight-red: #f87171;
     --text-primary: var(--primitives-neutral-900);
+    --annotation-label-background: #fffc;
     --text-secondary: var(--primitives-neutral-700);
     --text-tertiary: var(--primitives-neutral-500);
     --unimportant: #e3e3e8;
@@ -206,6 +207,7 @@
     --button-colors-transparent-stroke-outer-pressed: var(--primitives-neutral-800);
     --background: var(--primitives-neutral-900);
     --text-primary: var(--primitives-neutral-25);
+    --annotation-label-background: transparent;
     --text-secondary: var(--primitives-neutral-200);
     --text-tertiary: var(--primitives-neutral-400);
     --border-100: var(--primitives-neutral-700);
@@ -289,6 +291,7 @@
         --button-colors-transparent-stroke-outer-pressed: var(--primitives-neutral-800);
         --background: var(--primitives-neutral-900);
         --text-primary: var(--primitives-neutral-25);
+        --annotation-label-background: transparent;
         --text-secondary: var(--primitives-neutral-200);
         --text-tertiary: var(--primitives-neutral-400);
         --border-100: var(--primitives-neutral-700);
@@ -883,8 +886,16 @@ button.dot {
     stroke: #c00;
 }
 
-.events-annotations .highcharts-annotation-label span {
-    background-color: light-dark(#fffc, transparent);
+/* useHTML renders these labels as foreignObject > body > div, with no
+   span, so the old selector matched nothing and the chip never appeared.
+   Content inside foreignObject also starts from the UA default black
+   rather than inheriting the page colour, which left the text invisible
+   on a dark card, so set both explicitly.
+   light-dark() is avoided here because it needs color-scheme declared,
+   which would change UA form and scrollbar rendering page-wide. */
+.events-annotations .highcharts-annotation-label div {
+    background-color: var(--annotation-label-background);
+    color: var(--text-primary);
     font-size: 0.9em;
 }
 
@@ -1054,6 +1065,20 @@ button.dot {
 .highcharts-dashboards-component-kpi-value {
     padding-left: 20px;
     font-weight: bold;
+}
+
+/* The KPI components pass chartOptions without a chart.height and nothing
+   constrained this container, so every sparkline fell back to Highcharts'
+   400px default inside a ~148px card and painted outside it -- the strip
+   of stray graph visible between the KPI row and the row below.
+   Kept off the shared component rule so tooltips elsewhere in the
+   dashboard are not clipped; the KPI charts disable mouse tracking. */
+.highcharts-dashboards-component-kpi {
+    overflow: hidden;
+}
+
+.highcharts-dashboards-component-kpi-chart-container {
+    height: 64px;
 }
 
 /* Grid theme */


### PR DESCRIPTION
Two pre-existing defects in the 2025 homepage carousel, both CSS-only, both reported from looking at the live sample. Independent of #25018 and #25019.

## 1. Annotation labels are black on dark

The seven `events-annotations` labels on the stock slide ("Record earnings in Q1 2021", "Stock Sale by Elon Musk", …) render `rgb(0,0,0)` on `rgb(20,20,20)` — **1.17:1**, barely legible in dark mode.

Two causes compound:

- `labelOptions.useHTML` renders each label as `foreignObject > body > div`. The rule written for them targets `.highcharts-annotation-label span` — **there is no `span`**, so it matched 0 elements and the intended chip never rendered.
- Nothing set `color`. Content inside `foreignObject` starts from the UA default black instead of inheriting the page colour, so the text was black in both themes — invisible once the chip was missing.

Now sets both `background-color` and `color` on the element that actually exists. **1.17:1 → 17.07:1** in dark; light unchanged.

I used a theme token rather than `light-dark()`, because `light-dark()` needs `color-scheme` declared on `:root`, and that would change UA form-control and scrollbar rendering page-wide — too broad a side effect for this fix. (Worth noting the existing `light-dark(#fffc, transparent)` was inert for the same reason: `color-scheme` is `normal`, so it always resolved to the light value.)

## 2. KPI sparklines overflow their cards

The KPI components pass `chartOptions` with no `chart.height`, and nothing constrained `.highcharts-dashboards-component-kpi-chart-container`. With no definite container height Highcharts falls back to its **400 px default** — inside a **148 px** card, overflowing by **352 px**.

The card had no `overflow` rule, so the excess painted outside the rounded card and was then covered by the next dashboard row, leaving the ~17 px strip of stray graph visible under the KPI cards.

Constrained to 64 px. `overflow: hidden` is scoped to `.highcharts-dashboards-component-kpi` rather than the shared component rule, so tooltips elsewhere in the dashboard aren't clipped — the KPI charts set `enableMouseTracking: false`, so they have none to clip.

Verified: card 148 px, chart 64 px, `overflow: hidden`, sparklines sit inside their cards in both themes, no console errors, `stylelint` clean.

## Still open, deliberately not touched

Both are design calls rather than bugs:

- **Light-mode chart contrast.** Candlestick up-candles are `#a3edba` = **1.37:1** on white; Grid sparkline yellow `#ebcb3b` = **1.60:1**; Dashboards green `#20d17e` = **2.00:1**, orange `#feaa61` = **1.89:1**. Non-text graphics need 3:1. The palette already has usable steps — `--primitives-success-600` is 3.77:1 and `--primitives-danger-600` is 4.83:1 — but picking them is a design decision.
- **Dashboards green/orange don't flip per theme.** `--highcharts-dashboards-green` and `--highcharts-dashboards-orange` are declared only in the `:root`/`.highcharts-light` block, so dark mode reuses the light values. Meanwhile `--highlight-green` does flip to `#34d399`, so dark mode shows two different greens across demos.