### PR TITLE
Fixed afterSetExtremes being fired on unchanged extremes (#22780)

### DIFF
--- a/samples/unit-tests/axis/events/demo.js
+++ b/samples/unit-tests/axis/events/demo.js
@@ -149,6 +149,13 @@ QUnit.test(
             'No events should be fired on initial render'
         );
 
+        chart.redraw();
+        assert.deepEqual(
+            [calls.x, calls.y],
+            [0, 0],
+            'No events should be fired on a redraw where extremes do not change'
+        );
+
         chart.xAxis[0].setExtremes(1, 4);
         assert.deepEqual(
             [calls.x, calls.y],
@@ -175,5 +182,50 @@ QUnit.test(
             [calls.x, calls.y],
             [1, 1],
             'The y axis should fire when its own extremes change'
+        );
+    });
+
+QUnit.test(
+    'afterSetExtremes should not fire on an added axis (#22780)',
+    function (assert) {
+        const calls = {
+            added: 0
+        };
+
+        const chart = Highcharts.chart('container', {
+            chart: {
+                animation: false
+            },
+            series: [
+                {
+                    data: [1, 2, 3, 4, 5],
+                    animation: false
+                }
+            ]
+        });
+
+        chart.addAxis({
+            title: {
+                text: 'extra'
+            },
+            events: {
+                afterSetExtremes: function () {
+                    calls.added++;
+                }
+            }
+        }, true, false);
+
+        chart.redraw();
+        assert.deepEqual(
+            [calls.added],
+            [0],
+            'No events should be fired on the first redraw of an added axis'
+        );
+
+        chart.xAxis[1].setExtremes(0, 10);
+        assert.deepEqual(
+            [calls.added],
+            [1],
+            'The added axis should fire when its own extremes change'
         );
     });

--- a/samples/unit-tests/axis/events/demo.js
+++ b/samples/unit-tests/axis/events/demo.js
@@ -107,3 +107,73 @@ QUnit.test('Axis events', function (assert) {
         'Event handler should be removed after updating to undefined (#15983)'
     );
 });
+
+QUnit.test(
+    'afterSetExtremes should not fire on axes whose extremes have ' +
+        'not changed (#22780)',
+    function (assert) {
+        const calls = {
+            x: 0,
+            y: 0
+        };
+
+        const chart = Highcharts.chart('container', {
+            chart: {
+                animation: false
+            },
+            xAxis: {
+                events: {
+                    afterSetExtremes: function () {
+                        calls.x++;
+                    }
+                }
+            },
+            yAxis: {
+                events: {
+                    afterSetExtremes: function () {
+                        calls.y++;
+                    }
+                }
+            },
+            series: [
+                {
+                    data: [1, 2, 3, 4, 5],
+                    animation: false
+                }
+            ]
+        });
+
+        assert.deepEqual(
+            [calls.x, calls.y],
+            [0, 0],
+            'No events should be fired on initial render'
+        );
+
+        chart.xAxis[0].setExtremes(1, 4);
+        assert.deepEqual(
+            [calls.x, calls.y],
+            [1, 0],
+            'Only the x axis should fire when its own extremes change'
+        );
+
+        chart.xAxis[0].setExtremes(2, 3);
+        assert.deepEqual(
+            [calls.x, calls.y],
+            [1, 0],
+            'The y axis should stay silent when only x extremes change'
+        );
+
+        chart.xAxis[0].setExtremes(2, 3);
+        assert.deepEqual(
+            [calls.x, calls.y],
+            [1, 0],
+            'No event should be fired when extremes are set to the same values'
+        );
+
+        chart.yAxis[0].setExtremes(0, 5);
+        assert.deepEqual(
+            [calls.x, calls.y],
+            [1, 1],
+            'The y axis should fire when its own extremes change'
+        );
+    });

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -2988,6 +2988,13 @@ class Axis {
             delete axis.allExtremes;
         }
 
+        // Initialize the extKey on the first scale computation, so that the
+        // first redraw of an axis added after the initial render does not
+        // trigger a spurious afterSetExtremes event (#22780)
+        if (axis.extKey === void 0) {
+            axis.extKey = axis.min + ',' + axis.max;
+        }
+
         fireEvent(this, 'afterSetScale');
     }
 

--- a/ts/Core/Axis/AxisDefaults.ts
+++ b/ts/Core/Axis/AxisDefaults.ts
@@ -836,7 +836,8 @@ namespace AxisDefaults {
 
         /**
          * As opposed to the `setExtremes` event, this event fires after the
-         * final min and max values are computed and corrected for `minRange`.
+         * final min and max values are computed and corrected for `minRange`,
+         * and only when the extremes have changed since the previous redraw.
          *
          * Fires when the minimum and maximum is set for the axis, either by
          * calling the `.setExtremes()` method or by selecting an area in the

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -3133,12 +3133,11 @@ class Chart {
             chart.setResponsive();
         }
 
-        // Initialize the extKey for each axis, so that the first redraw does
-        // not trigger a spurious afterSetExtremes event (#22780)
+        // Initialize each axis extKey so the first redraw does not trigger
+        // a spurious afterSetExtremes event (#22780). Unconditional, as
+        // setScale() may have pinned preliminary extremes during layout.
         axes.forEach((axis): void => {
-            if (axis.extKey === void 0) {
-                axis.extKey = axis.min + ',' + axis.max;
-            }
+            axis.extKey = axis.min + ',' + axis.max;
         });
 
         // Set flag

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -3133,6 +3133,14 @@ class Chart {
             chart.setResponsive();
         }
 
+        // Initialize the extKey for each axis, so that the first redraw does
+        // not trigger a spurious afterSetExtremes event (#22780)
+        axes.forEach((axis): void => {
+            if (axis.extKey === void 0) {
+                axis.extKey = axis.min + ',' + axis.max;
+            }
+        });
+
         // Set flag
         chart.hasRendered = true;
     }


### PR DESCRIPTION
Fixes #22780

`afterSetExtremes` is now fired only when an axis's computed extremes actually change. Previously, the first redraw after chart creation fired the event on every axis, because `axis.extKey` stayed uninitialized until that redraw. An untouched axis (for example the y axis when zooming the x axis) therefore received one spurious event with no extremes change, and behavior differed between the first and subsequent redraws.

The event baseline is now established at the initial render in `Chart.render()`, and axes added later via `chart.addAxis()` get theirs from their first scale computation in `Axis.setScale()`. The `afterSetExtremes` doclet now states that the event fires only when the extremes change.

Session-settled decisions carried from planning: `extKey` initialized at render time per maintainer confirmation (user-approved); doclet clarification included (user-approved); scope limited to issue #22780 (user-directed).

## Testing

- New QUnit regression tests in `samples/unit-tests/axis/events/demo.js`: initial render silence, no-change redraw, unrelated-axis silence on x zoom, same-extremes setExtremes, added-axis first redraw. Verified red before the fix.
- 144 related unit tests pass (axis, navigator, rangeselector, scrollbar, scroller, stockchart, tooltip, zoom, drilldown, chart suites).
- Real-browser verification: 8/8 behavior assertions pass, zero console errors.
- Pre-commit hooks (lint, sample generation check, `test --modified`, node tests) green.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
