### PR TITLE
Added explict font-family for toolbar

### DIFF
--- a/samples/highcharts/blog/line-orbit-target-vs-walmart/demo.css
+++ b/samples/highcharts/blog/line-orbit-target-vs-walmart/demo.css
@@ -1,17 +1,20 @@
+body {
+    font-family:
+        var(
+            --highcharts-font-family,
+            "Lucida Grande",
+            "Lucida Sans Unicode",
+            Arial,
+            Helvetica,
+            sans-serif
+        );
+}
+
 @media (prefers-color-scheme: dark) {
     html,
     body {
         background: transparent !important;
         color-scheme: dark !important;
-        font-family:
-            var(
-                --highcharts-font-family,
-                "Lucida Grande",
-                "Lucida Sans Unicode",
-                Arial,
-                Helvetica,
-                sans-serif
-            );
     }
 }
 
@@ -20,15 +23,6 @@
     body {
         background: transparent !important;
         color-scheme: light !important;
-        font-family:
-            var(
-                --highcharts-font-family,
-                "Lucida Grande",
-                "Lucida Sans Unicode",
-                Arial,
-                Helvetica,
-                sans-serif
-            );
     }
 }
 
@@ -45,6 +39,5 @@
     gap: 2px;
     padding: 4px 8px;
     background: var(--highcharts-background-color);
-    font-family: var(--highcharts-font-family, "Lucida Grande", "Lucida Sans Unicode", Arial, Helvetica, sans-serif);
     flex-shrink: 0;
 }

--- a/samples/highcharts/blog/line-orbit-target-vs-walmart/demo.css
+++ b/samples/highcharts/blog/line-orbit-target-vs-walmart/demo.css
@@ -3,6 +3,15 @@
     body {
         background: transparent !important;
         color-scheme: dark !important;
+        font-family:
+            var(
+                --highcharts-font-family,
+                "Lucida Grande",
+                "Lucida Sans Unicode",
+                Arial,
+                Helvetica,
+                sans-serif
+            );
     }
 }
 
@@ -11,6 +20,15 @@
     body {
         background: transparent !important;
         color-scheme: light !important;
+        font-family:
+            var(
+                --highcharts-font-family,
+                "Lucida Grande",
+                "Lucida Sans Unicode",
+                Arial,
+                Helvetica,
+                sans-serif
+            );
     }
 }
 


### PR DESCRIPTION
The Orbit chart toolbar on the Orbit product page uses the wrong font. I added "font-family" to the body selector in the CSS to try and fix it.
<img width="730" height="91" alt="image" src="https://github.com/user-attachments/assets/3e7926f4-f877-41c9-bcc7-dc5e7a33261d" />
