### PR TITLE
Fixed regression with scrollable plot area in v13.0.0

### DIFF
--- a/ts/Core/Pointer.ts
+++ b/ts/Core/Pointer.ts
@@ -2119,7 +2119,8 @@ class Pointer {
             // allow dragging the finger to scroll the page
             if (
                 (chart.tooltip?.options.followTouchMove ?? true) &&
-                isInside
+                isInside &&
+                !(chart.scrollablePixelsX || chart.scrollablePixelsY)
             ) {
                 e.preventDefault();
             }


### PR DESCRIPTION
Fixed #25030, a v13.0.0 regression causing scrollable plot area not to work in some cases

Demonstrated in the `highcharts/demo/arearange` sample on Safari Mobile. 