### PR TITLE
Fixed issue with disappearing grid line in polar chart

### DIFF
--- a/ts/Core/Axis/RadialAxis.ts
+++ b/ts/Core/Axis/RadialAxis.ts
@@ -48,6 +48,7 @@ const {
 } = H;
 import {
     addEvent,
+    clamp,
     correctFloat,
     defined,
     extend,
@@ -983,18 +984,12 @@ namespace RadialAxis {
 
         // Concentric circles
         } else {
-            // Pick the right values depending if it is grid line or crosshair
-            let transValue = this.translate(value);
-
-            // This is required in case when xAxis is non-circular to
-            // prevent grid lines (or crosshairs, if enabled) from
-            // rendering above the center after they supposed to be
-            // displayed below the center point
-            if (transValue) {
-                if (transValue < 0 || transValue > height) {
-                    transValue = 0;
-                }
-            }
+            // Pick the right values depending if it is grid line or crosshair.
+            // Clamp is required in case when xAxis is non-circular to prevent
+            // grid lines (or crosshairs, if enabled) from rendering above the
+            // center after they supposed to be displayed below the center
+            // point.
+            let transValue = clamp(this.translate(value), 0, height);
 
             if (this.options.gridLineInterpolation === 'circle') {
                 // A value of 0 is in the center, so it won't be


### PR DESCRIPTION
Fixed #25034, outer grid line disappeared in polar charts in edge case due to float errors

Demo: https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/demo/polar-spider/
Version: Visible only in v13.0.0, but likely present before that, given the precise dimensions to trigger the float error. Visible in Chrome, not in Firefox.

<img width="702" height="413" alt="Skjermbilde 2026-08-13 kl  07 59 02" src="https://github.com/user-attachments/assets/91f71788-9cfa-4800-8897-0d3d34dc0fcf" />