### PR TITLE
Fixed #25043, iOS text glitch in org charts, iOS Safari

### DIFF
--- a/ts/Series/Organization/OrganizationSeriesDefaults.ts
+++ b/ts/Series/Organization/OrganizationSeriesDefaults.ts
@@ -240,8 +240,12 @@ const OrganizationSeriesDefaults: OrganizationSeriesOptions = {
             }
 
             if (title) {
-                html += '<p ' + styleAttr(titleStyle) + '>' +
-                    (title || '') + '</p>';
+                html += '<p ' + styleAttr(titleStyle) + '>' + title + '</p>';
+            } else {
+                // Required to prevent a glitch in iOS Safari, where text would
+                // flow outside the box if the title is missing (#25043)
+                html += '<p style="line-height: 0;font-size:1px;opacity: 0">.' +
+                    '</p>';
             }
 
             if (description) {

--- a/ts/Series/Organization/OrganizationSeriesDefaults.ts
+++ b/ts/Series/Organization/OrganizationSeriesDefaults.ts
@@ -244,8 +244,9 @@ const OrganizationSeriesDefaults: OrganizationSeriesOptions = {
             } else {
                 // Required to prevent a glitch in iOS Safari, where text would
                 // flow outside the box if the title is missing (#25043)
-                html += '<p style="line-height: 0;font-size:1px;opacity: 0">.' +
-                    '</p>';
+                html += `<p aria-hidden="true"
+                        style="line-height:0;margin:1px;font-size:1px;opacity:0"
+                    >.</p>`;
             }
 
             if (description) {


### PR DESCRIPTION
Fixed #25043, a temporary regression in org charts, causing text misplacement in iOS Safari