### PR TITLE
bugfix/6967-axis-title-offset

### DIFF
--- a/samples/unit-tests/axis/title/demo.js
+++ b/samples/unit-tests/axis/title/demo.js
@@ -419,3 +419,36 @@ QUnit.test('Axis title offset (#3027)', function (assert) {
         }
     );
 });
+
+QUnit.test(
+    'Y-axis labels not truncated with title.offset 0 on stacked axis (#6967)',
+    function (assert) {
+        // Outer axis reserves label space even when title.offset is 0.
+        const chart = Highcharts.chart('container', {
+            yAxis: [
+                {},
+                {
+                    title: {
+                        offset: 0
+                    }
+                }
+            ],
+            series: [
+                {
+                    data: [0.0001, 0.0002, 0.0003],
+                    yAxis: 0
+                },
+                {
+                    data: [0.0001, 0.0002, 0.0003],
+                    yAxis: 1
+                }
+            ]
+        });
+
+        assert.ok(
+            chart.yAxis[1].labelGroup.getBBox().x >= 0,
+            'Outer y-axis labels should stay inside the container when the ' +
+            'title offset is set to 0 (#6967).'
+        );
+    }
+);

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -3974,8 +3974,8 @@ class Axis {
 
             axisOffset[side] = Math.max(
                 axisOffset[side],
-                (axis.axisTitleMargin || 0) + titleOffset +
-                directionFactor * axis.offset,
+                Math.max(axis.axisTitleMargin || 0, labelOffsetPadded) +
+                titleOffset + directionFactor * axis.offset, // #6967
                 labelOffsetPadded, // #3027
                 tickPositions?.length && tickSize ?
                     tickSize[0] + directionFactor * axis.offset :


### PR DESCRIPTION
Fixed #6967, yAxis labels clipped by small title offset.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216955330722702