### PR TITLE
tools/dispatch-changelog-workflow

### DIFF
--- a/.github/workflows/sync-changelog.yml
+++ b/.github/workflows/sync-changelog.yml
@@ -1,0 +1,26 @@
+name: Sync changelog
+
+on:
+  push:
+    branches: [ 'master' ]
+    paths:
+      - 'changelog/**'
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch changelog sync
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.CHANGELOG_WORKFLOW_DISPATCH_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'highsoft-corp',
+              repo: 'highcharts-changelog',
+              workflow_id: 'sync-changelog.yml',
+              ref: 'main'
+            });


### PR DESCRIPTION
Adds a workflow dispatch to the highsoft-corp/highcharts-changelog repo whenever a file in `/changelog` is updated on master.

Todo:
- [x] Wait on PAT to be approved