### PR TITLE
docs/10833-pan-event-docs

### DIFF
--- a/samples/unit-tests/chart/panning/demo.js
+++ b/samples/unit-tests/chart/panning/demo.js
@@ -872,7 +872,6 @@ QUnit.test('The chart.events.pan event (#10833)', function (assert) {
 
     const chart = Highcharts.chart('container', {
             chart: {
-                animation: false,
                 events: {
                     pan: function (e) {
                         panEvents.push(e);
@@ -883,8 +882,7 @@ QUnit.test('The chart.events.pan event (#10833)', function (assert) {
                 },
                 height: 400,
                 panning: {
-                    enabled: true,
-                    type: 'x'
+                    enabled: true
                 },
                 width: 600
             },
@@ -894,7 +892,6 @@ QUnit.test('The chart.events.pan event (#10833)', function (assert) {
             },
             series: [
                 {
-                    animation: false,
                     data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
                 }
             ]

--- a/samples/unit-tests/chart/panning/demo.js
+++ b/samples/unit-tests/chart/panning/demo.js
@@ -880,11 +880,9 @@ QUnit.test('The chart.events.pan event (#10833)', function (assert) {
                         }
                     }
                 },
-                height: 400,
                 panning: {
                     enabled: true
-                },
-                width: 600
+                }
             },
             xAxis: {
                 max: 6,

--- a/samples/unit-tests/chart/panning/demo.js
+++ b/samples/unit-tests/chart/panning/demo.js
@@ -865,3 +865,70 @@ QUnit.test(
         assert.strictEqual(actualMin, -75, 'Min must be -75; not panning');
     }
 );
+
+QUnit.test('The chart.events.pan event (#10833)', function (assert) {
+    const panEvents = [];
+    let prevented = false;
+
+    const chart = Highcharts.chart('container', {
+            chart: {
+                animation: false,
+                events: {
+                    pan: function (e) {
+                        panEvents.push(e);
+                        if (prevented) {
+                            e.preventDefault();
+                        }
+                    }
+                },
+                height: 400,
+                panning: {
+                    enabled: true,
+                    type: 'x'
+                },
+                width: 600
+            },
+            xAxis: {
+                max: 6,
+                min: 3
+            },
+            series: [
+                {
+                    animation: false,
+                    data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+                }
+            ]
+        }),
+        controller = new TestController(chart);
+
+    controller.pan([400, 200], [300, 200]);
+
+    assert.ok(
+        panEvents.length > 0,
+        'The event should fire while dragging'
+    );
+    assert.strictEqual(
+        panEvents[0].target,
+        chart,
+        'The event target should be the chart'
+    );
+    assert.ok(
+        Highcharts.isNumber(panEvents[0].originalEvent.chartX),
+        'The event should expose the originating pointer event'
+    );
+    assert.ok(
+        chart.xAxis[0].min > 3,
+        'The default action should pan the axis'
+    );
+
+    const panned = chart.xAxis[0].getExtremes();
+
+    prevented = true;
+    controller.pan([400, 200], [300, 200]);
+
+    assert.deepEqual(
+        [chart.xAxis[0].min, chart.xAxis[0].max],
+        [panned.min, panned.max],
+        'Calling preventDefault should leave the extremes unchanged'
+    );
+});

--- a/ts/Core/Chart/ChartDefaults.ts
+++ b/ts/Core/Chart/ChartDefaults.ts
@@ -260,7 +260,10 @@ const ChartDefaults: ChartOptions = {
      * in Highcharts Stock, the panning is applied outside the default
      * action and is not prevented.
      *
-     * Panning by touch does not fire this event.
+     * Panning by touch does not fire this event, unless
+     * [chart.zooming.singleTouch](#chart.zooming.singleTouch) is enabled and
+     * no zoom type is set. Single-finger drags are then handled as mouse
+     * drags and fire this event.
      *
      * @type      {Highcharts.ChartPanCallbackFunction}
      * @since     7.0.2

--- a/ts/Core/Chart/ChartDefaults.ts
+++ b/ts/Core/Chart/ChartDefaults.ts
@@ -248,6 +248,27 @@ const ChartDefaults: ChartOptions = {
      */
 
     /**
+     * Fires while the chart is panned by mouse drag. Panning must be
+     * enabled through [chart.panning](#chart.panning). One parameter,
+     * `event`, is passed to the function, containing common event
+     * information as well as `event.originalEvent`, the underlying pointer
+     * event. Note that the event fires for every mouse move during the
+     * drag, not once per gesture.
+     *
+     * Calling `event.preventDefault()` or returning false prevents the
+     * default panning of the axes. In Highcharts Maps, and on ordinal axes
+     * in Highcharts Stock, the panning is applied outside the default
+     * action and is not prevented.
+     *
+     * Panning by touch does not fire this event.
+     *
+     * @type      {Highcharts.ChartPanCallbackFunction}
+     * @since     7.0.2
+     * @context   Highcharts.Chart
+     * @apioption chart.events.pan
+     */
+
+    /**
      * Fires when the chart is redrawn, either after a call to
      * `chart.redraw()` or after an axis, series or point is modified with
      * the `redraw` option set to `true`. One parameter, `event`, is passed

--- a/ts/Core/Chart/ChartOptions.ts
+++ b/ts/Core/Chart/ChartOptions.ts
@@ -25,7 +25,7 @@ import type CSSObject from '../Renderer/CSSObject';
 import type { GeoJSON, TopoJSON } from '../../Maps/GeoJSON';
 import type { HTMLDOMElement } from '../Renderer/DOMElementType';
 import type { NumberFormatterCallbackFunction } from '../Options';
-import type { PointerEvent as PointerEventImport } from '../PointerEvent';
+import type { PointerEvent } from '../PointerEvent';
 import type Series from '../Series/Series';
 import type { SeriesTypeOptions } from '../Series/SeriesType';
 import type ShadowOptionsObject from '../Renderer/ShadowOptionsObject';
@@ -178,7 +178,10 @@ export interface ChartEventsOptions {
      * in Highcharts Stock, the panning is applied outside the default
      * action and is not prevented.
      *
-     * Panning by touch does not fire this event.
+     * Panning by touch does not fire this event, unless
+     * [chart.zooming.singleTouch](#chart.zooming.singleTouch) is enabled and
+     * no zoom type is set. Single-finger drags are then handled as mouse
+     * drags and fire this event.
      *
      * @since     7.0.2
      */
@@ -1194,7 +1197,7 @@ export interface ChartPanCallbackFunction {
 }
 
 export interface ChartPanEventObject {
-    originalEvent: PointerEventImport;
+    originalEvent: PointerEvent;
     preventDefault: Function;
     target: Chart;
     type: 'pan';

--- a/ts/Core/Chart/ChartOptions.ts
+++ b/ts/Core/Chart/ChartOptions.ts
@@ -25,6 +25,7 @@ import type CSSObject from '../Renderer/CSSObject';
 import type { GeoJSON, TopoJSON } from '../../Maps/GeoJSON';
 import type { HTMLDOMElement } from '../Renderer/DOMElementType';
 import type { NumberFormatterCallbackFunction } from '../Options';
+import type { PointerEvent as PointerEventImport } from '../PointerEvent';
 import type Series from '../Series/Series';
 import type { SeriesTypeOptions } from '../Series/SeriesType';
 import type ShadowOptionsObject from '../Renderer/ShadowOptionsObject';
@@ -164,6 +165,24 @@ export interface ChartEventsOptions {
      *         Add series on chart load
      */
     load?: ChartLoadCallbackFunction;
+    /**
+     * Fires while the chart is panned by mouse drag. Panning must be
+     * enabled through [chart.panning](#chart.panning). One parameter,
+     * `event`, is passed to the function, containing common event
+     * information as well as `event.originalEvent`, the underlying pointer
+     * event. Note that the event fires for every mouse move during the
+     * drag, not once per gesture.
+     *
+     * Calling `event.preventDefault()` or returning false prevents the
+     * default panning of the axes. In Highcharts Maps, and on ordinal axes
+     * in Highcharts Stock, the panning is applied outside the default
+     * action and is not prevented.
+     *
+     * Panning by touch does not fire this event.
+     *
+     * @since     7.0.2
+     */
+    pan?: ChartPanCallbackFunction;
     /**
      * Fires when the chart is redrawn, either after a call to
      * `chart.redraw()` or after an axis, series or point is modified with
@@ -1168,6 +1187,17 @@ export interface ChartOptions {
      * @deprecated 10.2.1
      */
     zoomType?: ('x'|'xy'|'y');
+}
+
+export interface ChartPanCallbackFunction {
+    (this: Chart, event: ChartPanEventObject): void;
+}
+
+export interface ChartPanEventObject {
+    originalEvent: PointerEventImport;
+    preventDefault: Function;
+    target: Chart;
+    type: 'pan';
 }
 
 export interface ChartPanningOptions {

--- a/ts/Core/Defaults.ts
+++ b/ts/Core/Defaults.ts
@@ -3343,6 +3343,43 @@ export default DefaultOptions;
  */
 
 /**
+ * Gets fired while the chart is panned by mouse drag. Calling
+ * `event.preventDefault()` or returning `false` prevents the default panning
+ * of the axes.
+ *
+ * @callback Highcharts.ChartPanCallbackFunction
+ *
+ * @param {Highcharts.Chart} this
+ *        The chart on which the event occurred.
+ *
+ * @param {Highcharts.ChartPanEventObject} event
+ *        The event that occurred.
+ */
+
+/**
+ * Contains common event information. Through the `originalEvent` property you
+ * can access the pointer event that triggered the panning.
+ *
+ * @interface Highcharts.ChartPanEventObject
+ *//**
+ * The pointer event that triggered the panning.
+ * @name Highcharts.ChartPanEventObject#originalEvent
+ * @type {Highcharts.PointerEventObject}
+ *//**
+ * Prevents the default behavior of the event.
+ * @name Highcharts.ChartPanEventObject#preventDefault
+ * @type {Function}
+ *//**
+ * The event target.
+ * @name Highcharts.ChartPanEventObject#target
+ * @type {Highcharts.Chart}
+ *//**
+ * The event type.
+ * @name Highcharts.ChartPanEventObject#type
+ * @type {"pan"}
+ */
+
+/**
  * Fires when the chart is redrawn, either after a call to `chart.redraw()` or
  * after an axis, series or point is modified with the `redraw` option set to
  * `true`.


### PR DESCRIPTION
Fixed #10833, `chart.events.pan` was missing from the API documentation.