### PR TITLE
fix(axis): snap on-extreme point translate to 0 to keep inside plot area

### DIFF
--- a/samples/unit-tests/axis/extremes-point-inside/demo.css
+++ b/samples/unit-tests/axis/extremes-point-inside/demo.css
@@ -1,0 +1,5 @@
+#container {
+    width: 600px;
+    height: 250px;
+    margin: 0 auto;
+}

--- a/samples/unit-tests/axis/extremes-point-inside/demo.details
+++ b/samples/unit-tests/axis/extremes-point-inside/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/axis/extremes-point-inside/demo.html
+++ b/samples/unit-tests/axis/extremes-point-inside/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container"></div>

--- a/samples/unit-tests/axis/extremes-point-inside/demo.js
+++ b/samples/unit-tests/axis/extremes-point-inside/demo.js
@@ -1,0 +1,42 @@
+QUnit.test('#25050: point on an axis extreme is inside', assert => {
+    var chart = Highcharts.chart('container', {
+        chart: {
+            width: 600,
+            height: 250
+        },
+        yAxis: {
+            len: 220,
+            min: 0,
+            max: 100
+        },
+        series: [{
+            type: 'line',
+            data: [0, 50, 100]
+        }]
+    });
+
+    var point = chart.series[0].points[2];
+
+    // The point sits exactly on yAxis.max. Its plotY must be exactly 0 - not a
+    // tiny negative floating-point residue (e.g. -2.8e-14) that tips both
+    // Series#isPointInside and Chart#isInsidePlot into treating it as outside
+    // the plot area.
+    assert.strictEqual(
+        point.plotY,
+        0,
+        'point.plotY on the axis extreme should be exactly 0'
+    );
+
+    assert.strictEqual(
+        point.isInside,
+        true,
+        'point on the axis extreme should be inside the plot area'
+    );
+
+    assert.ok(
+        point.graphic,
+        'marker should be rendered for a point on the axis extreme'
+    );
+
+    chart.destroy();
+});

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -1247,6 +1247,19 @@ class Axis {
             if (!axis.isRadial) {
                 returnValue = correctFloat(returnValue);
             }
+
+            // A value sitting exactly on an axis extreme translates to
+            // `-(max - min) * (len / (max - min)) + len`, which should cancel
+            // out to 0 but can land on a residue of about 1 ulp of the axis
+            // length, e.g. -2.8e-14. `correctFloat` cannot absorb it at the
+            // zero edge, where the error is the leading digit. Left in place,
+            // both `Series#isPointInside` and `Chart#isInsidePlot` read the
+            // point as outside the plot area, so it loses its marker and its
+            // tooltip while the graph path still runs to it. A sub-nanopixel
+            // offset carries no information, so snapping is safe.
+            if (Math.abs(returnValue) < 1e-9) {
+                returnValue = 0;
+            }
         }
 
         return returnValue;


### PR DESCRIPTION
### Summary

A data point whose value equals an axis extreme (e.g. a vertical/cartesian `yAxis.max` or a polar extreme) is dropped: its marker is not drawn and it has no tooltip/hover, even though the line path still runs to it.

### Root cause

In `Axis#translate()` the value-to-pixel math is `sign * (val - localMin) * localA + cvsOffset`. For a value on the far extreme this is `-(max - min) * (len / (max - min)) + len`, which should cancel to exactly `0` but lands on a binary floating-point residue of about 1 ulp of the axis length (e.g. `-2.8e-14`). `correctFloat()` keeps 14 significant digits, which absorbs the error at the far edge but not at the zero edge, where the residue is the leading digit.

That tiny negative value makes both `Series#isPointInside()` (requires `plotY >= 0`, gates marker creation in `drawPoints`) and `Chart#isInsidePlot()` (feeds `getValidPoints` / the k-d tree) classify the point as outside the plot area — so it loses its marker and its tooltip while the graph path still runs to it. The polar case fails for the same reason, even though `correctFloat()` is skipped for radial axes.

### Fix

Snap a sub-nanopixel offset to `0` at the end of the value-to-pixel branch of `Axis#translate()`. A sub-nanopixel offset carries no information, so snapping is safe, and it covers both the cartesian and polar paths (it is applied outside the `!isRadial` `correctFloat` block).

### Testing

- Added QUnit sample test `samples/unit-tests/axis/extremes-point-inside/demo.js`.
- The test fails on `master` (`point.plotY` is `1.4210854715202e-14`, expected `0`) and passes with this fix — verified red→green in Chromium.
- TypeScript build (`npx gulp scripts` / `tsc -p ts`) passes.
- Adjacent `translate`/pan QUnit sample (`axis/pointplacement`) still passes.

Fixes highcharts/highcharts#25050
