### PR TITLE
Fixed and improved panning when startOnTick or endOnTick is enabled

### DIFF
--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -4252,7 +4252,8 @@ class Chart {
                     len,
                     minPointOffset = 0,
                     options,
-                    reversed
+                    reversed,
+                    tickInterval
                 } = axis,
                 wh = horiz ? 'width' : 'height',
                 xy = horiz ? 'x' : 'y',
@@ -4357,22 +4358,41 @@ class Chart {
                     range,
                     safeDataMax - safeDataMin
                 ),
-                paddedMin = safeDataMin - padRange * (
-                    defined(optionsMin) ? 0 : options.minPadding
-                ),
-                paddedMax = safeDataMax + padRange * (
-                    defined(optionsMax) ? 0 : options.maxPadding
-                ),
 
                 // We're allowed to zoom outside the data extremes if we're
                 // dealing with a bubble chart, if we're panning, or if we're
                 // pinching or mousewheeling in.
                 allowZoomOutside = axis.allowZoomOutside ||
                     scale === 1 ||
-                    (trigger !== 'zoom' && scale > 1),
+                    (trigger !== 'zoom' && scale > 1);
 
-                // Calculate the floor and the ceiling
-                floor = Math.min(
+            let paddedMin = safeDataMin - padRange * (
+                    defined(optionsMin) ? 0 : options.minPadding
+                ),
+                paddedMax = safeDataMax + padRange * (
+                    defined(optionsMax) ? 0 : options.maxPadding
+                );
+
+            if (!axis.categories) {
+                const previousTick = (val: number): number => {
+                    const intv = tickInterval;
+                    if (val < 0) {
+                        val -= intv;
+                    }
+                    return Math.trunc(val / intv) * intv;
+                };
+
+                if (options.startOnTick) {
+                    paddedMin = previousTick(paddedMin);
+                }
+
+                if (options.endOnTick) {
+                    paddedMax = previousTick(paddedMax) + tickInterval;
+                }
+            }
+
+            // Calculate the floor and the ceiling
+            const floor = Math.min(
                     optionsMin ?? paddedMin,
                     paddedMin,
                     allowZoomOutside ? min : paddedMin

--- a/ts/Core/Pointer.ts
+++ b/ts/Core/Pointer.ts
@@ -589,15 +589,43 @@ class Pointer {
         // block it. After the touch has ended, we undo this and render again.
         let redraw: true|undefined;
         for (const axis of chart.axes) {
+            const { startOnTick, endOnTick } = axis.options;
+
             if (axis.isPanning) {
                 axis.isPanning = false;
+
                 if (
-                    axis.options.startOnTick ||
-                    axis.options.endOnTick ||
+                    startOnTick ||
+                    endOnTick ||
                     axis.series.some((s): boolean|undefined => s.boosted)
                 ) {
+                    const { tickInterval } = axis,
+                        userMin = axis.userMin ?? 0,
+                        userMax = axis.userMax ?? 0,
+                        round = (val: number): number =>
+                            Math.round(val / tickInterval) * tickInterval;
+
+                    let newMin = userMin,
+                        newMax = userMax;
+
+                    if (startOnTick) {
+                        newMin = round(userMin);
+
+                        if (!endOnTick) {
+                            newMax += newMin - userMin;
+                        }
+                    }
+
+                    if (endOnTick) {
+                        newMax = round(userMax);
+
+                        if (!startOnTick) {
+                            newMin += newMax - userMax;
+                        }
+                    }
+
                     axis.forceRedraw = true;
-                    axis.setExtremes(axis.userMin, axis.userMax, false);
+                    axis.setExtremes(newMin, newMax, false);
                     redraw = true;
                 }
             }

--- a/ts/Core/Pointer.ts
+++ b/ts/Core/Pointer.ts
@@ -600,8 +600,8 @@ class Pointer {
                     axis.series.some((s): boolean|undefined => s.boosted)
                 ) {
                     const { tickInterval } = axis,
-                        userMin = axis.userMin ?? 0,
-                        userMax = axis.userMax ?? 0,
+                        userMin = axis.userMin ?? NaN,
+                        userMax = axis.userMax ?? NaN,
                         round = (val: number): number =>
                             Math.round(val / tickInterval) * tickInterval;
 


### PR DESCRIPTION
Fixed #4183, enabling `startOnTick` or/and `endOnTick` for axis caused the chart to gradually zoom out while panning.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216955330722717