### PR TITLE
Fixed #24057, point markers didn't animate in edge case

### DIFF
--- a/samples/unit-tests/series-scatter/general/demo.js
+++ b/samples/unit-tests/series-scatter/general/demo.js
@@ -3,6 +3,13 @@ QUnit.test('Scatter series general tests.', function (assert) {
             chart: {
                 type: 'scatter'
             },
+            plotOptions: {
+                scatter: {
+                    marker: {
+                        symbol: 'circle'
+                    }
+                }
+            },
             series: [
                 {
                     lineWidth: 1,
@@ -74,5 +81,18 @@ QUnit.test('Scatter series general tests.', function (assert) {
         undefined, // Or check for falsy if preferred
         'Default series (Column) should NOT have' +
         'the allowOutsidePlotInteraction flag (#24096).'
+    );
+
+    // --- Added tests for #24057 ---
+    const graphic = series.points[0].graphic;
+    chart.update({
+        chart: {
+            inverted: true
+        }
+    });
+
+    assert.ok(
+        graphic === series.points[0].graphic,
+        'Scatter point graphic should survive update (#24057).'
     );
 });

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -1062,9 +1062,13 @@ class Series {
         oldOptions: DeepPartial<SeriesOptions>
     ): boolean | undefined {
         const marker = options.marker,
-            oldMarker = oldOptions.marker || {};
+            oldMarker = oldOptions.marker;
 
-        return marker && (
+        // Note that `marker` holds the full, merged object including
+        // `plotOptions`, while `oldMarker` is the user-defined series-level
+        // options only. We may need to refactor that in the future if more
+        // issues like #24057 arise.
+        return marker && oldMarker && (
             (oldMarker.enabled && !marker.enabled) ||
             oldMarker.symbol !== marker.symbol || // #10870, #15946
             oldMarker.height !== marker.height || // #16274


### PR DESCRIPTION
Fixed #25057, point markers failed to animate on series update when marker symbol was defined in plot options.