### PR TITLE
fix: inherit uniqueNames in the Gantt navigator

### DIFF
--- a/samples/unit-tests/gantt/gantt/demo.js
+++ b/samples/unit-tests/gantt/gantt/demo.js
@@ -821,9 +821,11 @@
 
     QUnit.test('Navigator inherits Gantt uniqueNames (#24975)', assert => {
         const chart = Highcharts.ganttChart('container', {
-                yAxis: {
+                yAxis: [{
+                    uniqueNames: false
+                }, {
                     uniqueNames: true
-                },
+                }],
                 navigator: {
                     enabled: true,
                     series: {
@@ -836,6 +838,7 @@
                     }
                 },
                 series: [{
+                    yAxis: 1,
                     data: [
                         'Prototyping',
                         'Development',
@@ -859,7 +862,7 @@
         assert.strictEqual(
             navigator.yAxis.uniqueNames,
             true,
-            'Navigator should inherit uniqueNames from the main axis.'
+            'Navigator should inherit uniqueNames from the base series axis.'
         );
         assert.deepEqual(
             navigatorSeries.dataTable.getColumn('y'),

--- a/samples/unit-tests/gantt/gantt/demo.js
+++ b/samples/unit-tests/gantt/gantt/demo.js
@@ -819,6 +819,82 @@
         });
     });
 
+    QUnit.test('Navigator inherits Gantt uniqueNames (#24975)', assert => {
+        const chart = Highcharts.ganttChart('container', {
+                yAxis: {
+                    uniqueNames: true
+                },
+                navigator: {
+                    enabled: true,
+                    series: {
+                        type: 'gantt'
+                    },
+                    yAxis: {
+                        min: 0,
+                        max: 3,
+                        type: 'treegrid'
+                    }
+                },
+                series: [{
+                    data: [
+                        'Prototyping',
+                        'Development',
+                        'Testing',
+                        'Development',
+                        'Testing',
+                        'Release'
+                    ].map((name, i) => ({
+                        name,
+                        start: i + 1,
+                        end: i + 2
+                    }))
+                }]
+            }),
+            navigator = chart.navigator,
+            navigatorSeries = navigator.series[0],
+            repeatedPoints = navigatorSeries.points.filter(point => (
+                point.name === 'Development' || point.name === 'Testing'
+            ));
+
+        assert.strictEqual(
+            navigator.yAxis.uniqueNames,
+            true,
+            'Navigator should inherit uniqueNames from the main axis.'
+        );
+        assert.deepEqual(
+            navigatorSeries.dataTable.getColumn('y'),
+            chart.series[0].dataTable.getColumn('y'),
+            'Navigator and main series should use the same Y positions.'
+        );
+        assert.strictEqual(
+            repeatedPoints.length,
+            4,
+            'Every repeated-name point should exist in the navigator.'
+        );
+        assert.ok(
+            repeatedPoints.every(point => (
+                point.y >= navigator.yAxis.min &&
+                point.y <= navigator.yAxis.max
+            )),
+            'Repeated-name navigator points should remain inside the range.'
+        );
+
+        chart.update({
+            navigator: {
+                enabled: true,
+                yAxis: {
+                    uniqueNames: false
+                }
+            }
+        });
+
+        assert.strictEqual(
+            chart.navigator.yAxis.uniqueNames,
+            false,
+            'Explicit navigator uniqueNames should override the main axis.'
+        );
+    });
+
     QUnit.test('Gantt using the keys feature #13768', function (assert) {
         var chart = Highcharts.ganttChart('container', {
             series: [

--- a/ts/Stock/Navigator/Navigator.ts
+++ b/ts/Stock/Navigator/Navigator.ts
@@ -1384,6 +1384,14 @@ class Navigator {
                     offset: 0,
                     index: yAxisIndex,
                     isInternal: true,
+                    uniqueNames: (
+                        (
+                            navigatorOptions.yAxis &&
+                            navigatorOptions.yAxis.uniqueNames
+                        ) ??
+                        (chart.yAxis[0] && chart.yAxis[0].uniqueNames) ??
+                        false
+                    ),
                     reversed: (
                         (
                             navigatorOptions.yAxis &&

--- a/ts/Stock/Navigator/Navigator.ts
+++ b/ts/Stock/Navigator/Navigator.ts
@@ -1342,7 +1342,9 @@ class Navigator {
             xAxisIndex = chart.xAxis.length,
             yAxisIndex = chart.yAxis.length,
             baseXaxis = baseSeries && baseSeries[0] && baseSeries[0].xAxis ||
-                chart.xAxis[0] || { options: {} };
+                chart.xAxis[0] || { options: {} },
+            baseYaxis = baseSeries && baseSeries[0] && baseSeries[0].yAxis ||
+                chart.yAxis[0];
 
         chart.isDirtyBox = true;
 
@@ -1389,7 +1391,7 @@ class Navigator {
                             navigatorOptions.yAxis &&
                             navigatorOptions.yAxis.uniqueNames
                         ) ??
-                        (chart.yAxis[0] && chart.yAxis[0].uniqueNames) ??
+                        (baseYaxis && baseYaxis.uniqueNames) ??
                         false
                     ),
                     reversed: (


### PR DESCRIPTION
Extend the existing navigator Y-axis option inheritance in `Navigator.init`: resolve `uniqueNames` from an explicit `navigator.yAxis.uniqueNames` value first, then fall back to the main chart Y axis, mirroring the precedence already used there for `reversed`. When a Gantt chart's treegrid Y axis enables `uniqueNames`, its generated navigator Y axis does not inherit that setting.

Create a Gantt chart with `yAxis.uniqueNames: true`, repeated sibling task names, and a treegrid navigator that omits `uniqueNames`; assert the navigator axis resolves the option to true and the navigator series Y values match the corresponding main-series Y values; Constrain the navigator Y-axis range to the grouped rows and assert every repeated-name navigator point remains represented within that range, preventing the reported clipped-point regression.

Fixes #24975
