### PR TITLE
Jitter the same direction on vertical as horizontal axis

### DIFF
--- a/ts/Series/Scatter/ScatterSeries.ts
+++ b/ts/Series/Scatter/ScatterSeries.ts
@@ -120,7 +120,8 @@ class ScatterSeries extends LineSeries {
 
                             // Identify the outer bounds of the jitter range
                             // (#25054)
-                            const translatedJitter = jitter[dim] * axis.transA,
+                            const translatedJitter = jitter[dim] * axis.transA *
+                                    (axis.reversed ? 1 : -1),
                                 min = (point[plotProp] || 0) - translatedJitter,
                                 max = (point[plotProp] || 0) + translatedJitter;
 

--- a/ts/Series/Scatter/ScatterSeries.ts
+++ b/ts/Series/Scatter/ScatterSeries.ts
@@ -121,7 +121,7 @@ class ScatterSeries extends LineSeries {
                             // Identify the outer bounds of the jitter range
                             // (#25054)
                             const translatedJitter = jitter[dim] * axis.transA *
-                                    (axis.reversed ? 1 : -1),
+                                    (axis.reversed ? -1 : 1),
                                 min = (point[plotProp] || 0) - translatedJitter,
                                 max = (point[plotProp] || 0) + translatedJitter;
 


### PR DESCRIPTION
Jittering should work in the same axis direction per point whether the axis is horizontal or vertical. This provides a predictable animation when flipping between non-inverted and inverted chart.