### PR TITLE
bugfix/6967-axis-title-offset-2

### DIFF
--- a/samples/unit-tests/axis/title/demo.js
+++ b/samples/unit-tests/axis/title/demo.js
@@ -419,3 +419,48 @@ QUnit.test('Axis title offset (#3027)', function (assert) {
         }
     );
 });
+
+QUnit.test('yAxis label space with small title.offset (#6967)', function (
+    assert
+) {
+    // Stacked left axes: a small title.offset on the outer axis must still
+    // reserve room for its labels.
+    const stacked = Highcharts.chart('container', {
+        yAxis: [
+            {},
+            {
+                title: {
+                    offset: 0
+                }
+            }
+        ],
+        series: [
+            { data: [0.0001, 0.0002, 0.0003], yAxis: 0 },
+            { data: [0.0001, 0.0002, 0.0003], yAxis: 1 }
+        ]
+    });
+
+    assert.ok(
+        stacked.yAxis[1].labelGroup.getBBox().x >= 0,
+        'Outer yAxis labels should stay inside the container.'
+    );
+
+    // At offset 0 the title sits on top of the labels, so plotLeft is just
+    // the label width (76px), with nothing added for it.
+    const single = Highcharts.chart('container', {
+        yAxis: {
+            title: {
+                offset: 0
+            }
+        },
+        series: [
+            { data: [0.0001, 0.0002, 0.0003] }
+        ]
+    });
+
+    assert.strictEqual(
+        single.plotLeft,
+        76,
+        'title.offset: 0 reserves label width only, not label + title.'
+    );
+});

--- a/samples/unit-tests/axis/title/demo.js
+++ b/samples/unit-tests/axis/title/demo.js
@@ -445,8 +445,8 @@ QUnit.test('yAxis label space with small title.offset (#6967)', function (
         'Outer yAxis labels should stay inside the container.'
     );
 
-    // At offset 0 the title sits on top of the labels, so plotLeft is just
-    // the label width (76px), with nothing added for it.
+    // At offset 0 the title overlaps the labels and reserves no space, so
+    // removing the title entirely must not change plotLeft.
     const single = Highcharts.chart('container', {
         yAxis: {
             title: {
@@ -457,10 +457,13 @@ QUnit.test('yAxis label space with small title.offset (#6967)', function (
             { data: [0.0001, 0.0002, 0.0003] }
         ]
     });
+    const offsetPlotLeft = single.plotLeft;
+
+    single.update({ yAxis: { title: { text: null } } });
 
     assert.strictEqual(
+        offsetPlotLeft,
         single.plotLeft,
-        76,
         'title.offset: 0 reserves label width only, not label + title.'
     );
 });

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -3960,8 +3960,10 @@ class Axis {
 
             axisOffset[side] = Math.max(
                 axisOffset[side],
-                (axis.axisTitleMargin || 0) + titleOffset +
-                directionFactor * axis.offset,
+                Math.max(
+                    (axis.axisTitleMargin || 0) + titleOffset,
+                    labelOffsetPadded
+                ) + directionFactor * axis.offset, // #6967
                 labelOffsetPadded, // #3027
                 tickPositions?.length && tickSize ?
                     tickSize[0] + directionFactor * axis.offset :


### PR DESCRIPTION
Fixed #6967, y-axis labels clipped by small title offset.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216955330722702