### PR TITLE
Fix #24987: Navigator loses all series after drilling up

### DIFF
--- a/samples/unit-tests/drilldown/highstock/demo.js
+++ b/samples/unit-tests/drilldown/highstock/demo.js
@@ -126,3 +126,52 @@ QUnit.test(
             'scrolling'
         );
     });
+
+QUnit.test(
+    'Navigator base series restored after drillup (#24987)',
+    function (assert) {
+        const chart = Highcharts.stockChart('container', {
+            navigator: {
+                enabled: true
+            },
+            series: [{
+                id: 'parent',
+                name: 'Parent',
+                data: [{
+                    name: 'Cars',
+                    y: 4,
+                    drilldown: 'cars'
+                }],
+                animation: false
+            }],
+            drilldown: {
+                series: [{
+                    id: 'cars',
+                    name: 'Cars',
+                    data: [
+                        ['Electric', 3],
+                        ['ICE', 4]
+                    ],
+                    animation: false
+                }]
+            }
+        });
+
+        chart.series[0].points[0].doDrilldown();
+        chart.drillUp();
+
+        assert.deepEqual(
+            chart.navigator.baseSeries.map(series => series.options.id),
+            ['parent'],
+            'Parent series should be the navigator\'s base series again ' +
+            'after drilling up'
+        );
+
+        assert.notStrictEqual(
+            chart.navigator.series.length,
+            0,
+            'Navigator should not be left without any series after ' +
+            'drilling up'
+        );
+    }
+);

--- a/ts/Stock/Navigator/ChartNavigatorComposition.ts
+++ b/ts/Stock/Navigator/ChartNavigatorComposition.ts
@@ -93,6 +93,7 @@ function compose(
         chartProto.callbacks.push(onChartCallback);
 
         addEvent(ChartClass, 'afterAddSeries', onChartAfterAddSeries);
+        addEvent(ChartClass, 'afterDrillUp', onChartAfterDrillUp);
         addEvent(ChartClass, 'afterSetChartSize', onChartAfterSetChartSize);
         addEvent(ChartClass, 'afterUpdate', onChartAfterUpdate);
         addEvent(ChartClass, 'beforeRender', onChartBeforeRender);
@@ -106,6 +107,20 @@ function compose(
  * @internal
  */
 function onChartAfterAddSeries(
+    this: Chart
+): void {
+    if (this.navigator) {
+        // Recompute which series should be shown in navigator, and add them
+        this.navigator.setBaseSeries(null as any, false);
+    }
+}
+
+/**
+ * Handle series added or removed as part of a drillup, e.g. when the parent
+ * series is restored after the drilldown series is removed (#24987).
+ * @internal
+ */
+function onChartAfterDrillUp(
     this: Chart
 ): void {
     if (this.navigator) {


### PR DESCRIPTION
## Summary

Fixes #24987. On drillup, the parent series is restored to
`chart.series`, but nothing tells the `Navigator` to recompute its
base series — unlike `afterAddSeries`, there was no equivalent hook
for series removed via drillup. So `navigator.series` /
`navigator.baseSeries` stayed empty unless `showInNavigator: true`
was set explicitly on the parent.

## Fix

Hook `Navigator` into the existing `afterDrillUp` event, mirroring the
`afterAddSeries` listener's `setBaseSeries(null, false)` recompute.

## Test plan

- [x] Added a QUnit regression test
  (`samples/unit-tests/drilldown/highstock/demo.js`) that drills down
  then up and asserts the parent series is restored as the
  navigator's base series.
- [x] Verified it fails without the fix and passes with it.