### PR TITLE
fix: keep boosted columnrange series visible after zooming

### DIFF
--- a/samples/unit-tests/boost/general/demo.js
+++ b/samples/unit-tests/boost/general/demo.js
@@ -176,6 +176,79 @@ QUnit[Highcharts.hasWebGLSupport() ? 'test' : 'skip'](
     }
 );
 
+QUnit[Highcharts.hasWebGLSupport() ? 'test' : 'skip'](
+    'Boosted columnrange should stay visible after zooming (#24986)',
+    async function (assert) {
+        const data = Array.from({ length: 12 }, (_, x) => (
+                x < 5 ? [x, 10 + x, 15 + x] : [x, 60 + x, 65 + x]
+            )),
+            chart = Highcharts.chart('container', {
+                chart: {
+                    type: 'columnrange'
+                },
+                xAxis: {
+                    minRange: 0.1
+                },
+                yAxis: {
+                    min: 0,
+                    max: 80
+                },
+                series: [{
+                    boostThreshold: 6,
+                    cropThreshold: 1,
+                    data
+                }]
+            }),
+            series = chart.series[0];
+
+        chart.xAxis[0].setExtremes(5, 11);
+
+        assert.ok(series.boosted, 'The zoomed series should remain boosted');
+
+        let svg = chart.renderTo.querySelector('svg'),
+            imageEl = svg.querySelector('.highcharts-boost-canvas'),
+            pixel = await sampleImagePixelAtSVGPoint(
+                svg,
+                imageEl,
+                chart.xAxis[0].toPixels(8),
+                chart.yAxis[0].toPixels(70.5)
+            );
+
+        assert.strictEqual(
+            pixel.hex,
+            '#2caffe',
+            'The cropped point should use its matching low and high values'
+        );
+
+        chart.xAxis[0].setExtremes(8, 9);
+
+        assert.notOk(series.boosted, 'A closer zoom should exit boost mode');
+        assert.ok(
+            series.points.some(point => point.graphic),
+            'The zoomed points should be visible in SVG mode'
+        );
+
+        chart.xAxis[0].setExtremes();
+
+        assert.ok(series.boosted, 'Resetting zoom should restore boost mode');
+
+        svg = chart.renderTo.querySelector('svg');
+        imageEl = svg.querySelector('.highcharts-boost-canvas');
+        pixel = await sampleImagePixelAtSVGPoint(
+            svg,
+            imageEl,
+            chart.xAxis[0].toPixels(2),
+            chart.yAxis[0].toPixels(14.5)
+        );
+
+        assert.strictEqual(
+            pixel.hex,
+            '#2caffe',
+            'The full boosted series should be restored after reset'
+        );
+    }
+);
+
 QUnit.test(
     'Boost enabled false and boostThreshold conflict (#9052)',
     function (assert) {

--- a/ts/Extensions/Boost/WGLRenderer.ts
+++ b/ts/Extensions/Boost/WGLRenderer.ts
@@ -449,6 +449,18 @@ class WGLRenderer {
             yData = (
                 series.getColumn('y').length ? series.getColumn('y') : void 0
             ) || (options as any).yData || series.getColumn('y', true),
+            lowData = isRange ? (
+                (
+                    series.getColumn('low').length ?
+                        series.getColumn('low') : void 0
+                ) || series.getColumn('low', true)
+            ) : void 0,
+            highData = isRange ? (
+                (
+                    series.getColumn('high').length ?
+                        series.getColumn('high') : void 0
+                ) || series.getColumn('high', true)
+            ) : void 0,
             zData = (
                 series.getColumn('z').length ? series.getColumn('z') : void 0
             ) || (options as any).zData || series.getColumn('z', true),
@@ -934,8 +946,8 @@ class WGLRenderer {
                     y = (d as any).slice(1, 3);
                 }
 
-                low = series.getColumn('low', true)?.[i];
-                y = series.getColumn('high', true)?.[i] || 0;
+                low = lowData?.[i];
+                y = highData?.[i] || 0;
 
             } else if (isStacked) {
                 x = (d as any).x;


### PR DESCRIPTION
As reported in #24986, a boosted `columnrange` series can disappear after
zooming.

In `WGLRenderer.pushSeriesData`, `xData` and `yData` are resolved once up front
with a defined precedence: use the series' own column when it is non-empty,
otherwise fall back to `getColumn(..., true)`. The per-point loop then indexes
those resolved arrays with `i`.

The `low`/`high` pair did not follow that path. It called
`series.getColumn('low', true)?.[i]` and `series.getColumn('high', true)?.[i]`
inside the loop, so the range values were read from a differently-resolved
column than the one `i` was derived against. When the zoomed window produces a
nonzero crop start, the two bases no longer line up and the range values are
taken from the wrong points.

This hoists `lowData` and `highData` alongside `xData`/`yData`, resolved with
the same precedence and computed only when `isRange` is set, and the loop now
indexes those arrays instead of re-fetching the column per point.

A unit test in `samples/unit-tests/boost/general/demo.js` covers the reported
scenario: it builds a 12-point `columnrange` series above `boostThreshold`,
zooms to an x-window with a nonzero crop start, asserts the series stays
boosted, and samples the rendered Boost canvas pixel at the expected column to
confirm it is painted with the series colour. It also asserts that zooming in
far enough exits boost mode and renders real SVG points, and that resetting the
zoom restores boost mode.

Fixes #24986

AI was used for assistance.
