### PR TITLE
Bugfix / Point can be updated when it was created out of plot area

### DIFF
--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -2146,8 +2146,26 @@ class Series {
                         } else {
                             if (point) {
                                 point.update(row, false);
-                            } else {
+                            } else if (rowIndex > this.dataTable.rowCount) {
                                 this.addPoint(row, false);
+                            } else {
+                                if (this.dataTable !== dataTable) {
+                                    this.dataTable.setRow(row, rowIndex);
+                                }
+                                if (this.options.data) {
+                                    this.options.data[rowIndex] = row;
+                                }
+                                if (defined(row.x)) {
+                                    if (isString(row.x)) {
+                                        this.xColumnIsNumbers = void 0;
+                                    }
+                                    if (this.xColumn) {
+                                        this.xColumn[rowIndex] = this.getX(
+                                            (row as AnyRecord).x
+                                        );
+                                    }
+                                }
+                                this.isDirtyData = true;
                             }
                             queueRedraw();
                         }


### PR DESCRIPTION
Simplest but not the best solution to the issue with stacking candlesticks in the datatable/live-candlestick demo.