### PR TITLE
bugfix/25050-point-dropped-on-axis-extreme

### DIFF
--- a/samples/unit-tests/axis/extremes/demo.js
+++ b/samples/unit-tests/axis/extremes/demo.js
@@ -860,3 +860,38 @@ QUnit.test('Date string extremes', function (assert) {
     );
 
 });
+
+QUnit.test('Point on an axis extreme is inside (#25050)', assert => {
+    const chart = Highcharts.chart('container', {
+            chart: {
+                width: 600,
+                height: 250
+            },
+            yAxis: {
+                len: 220,
+                min: 0,
+                max: 100
+            },
+            series: [{
+                data: [0, 50, 100]
+            }]
+        }),
+        point = chart.series[0].points[2];
+
+    assert.strictEqual(
+        point.plotY,
+        0,
+        'point.plotY on the axis extreme should be exactly 0'
+    );
+
+    assert.strictEqual(
+        point.isInside,
+        true,
+        'point on the axis extreme should be inside the plot area'
+    );
+
+    assert.ok(
+        point.graphic,
+        'marker should be rendered for a point on the axis extreme'
+    );
+});

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -1247,6 +1247,10 @@ class Axis {
             if (!axis.isRadial) {
                 returnValue = correctFloat(returnValue);
             }
+
+            if (Math.abs(returnValue) < 1e-9) {
+                returnValue = 0;
+            }
         }
 
         return returnValue;


### PR DESCRIPTION
Fixed #25050, for certain combinations of axis length and axis range, the point's marker was not drawn and the point had no tooltip.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217597732513330