### PR TITLE
bugfix/6257-linearGradient-in-plotBand-overspill

### DIFF
--- a/samples/unit-tests/axis/plotlines-and-plotbands/demo.js
+++ b/samples/unit-tests/axis/plotlines-and-plotbands/demo.js
@@ -1066,3 +1066,89 @@ QUnit.test(
         opacityTester([1, 1, 1]);
     }
 );
+
+QUnit.test(
+    '#6257: Gradient on a plot band reaching outside the axis',
+    function (assert) {
+        // Deliberately shared between the bands, like in the issue
+        const linearGrad = {
+                linearGradient: { x1: 0, x2: 1, y1: 0, y2: 0 },
+                stops: [[0, '#04A6DB'], [1, '#006D91']]
+            },
+            chart = Highcharts.chart('container', {
+                xAxis: {
+                    max: 8,
+                    min: 0,
+                    plotBands: [{
+                        color: linearGrad,
+                        from: 2,
+                        to: 5
+                    }, {
+                        color: linearGrad,
+                        from: 7,
+                        to: 10
+                    }, {
+                        color: linearGrad,
+                        from: -2,
+                        to: 1
+                    }]
+                },
+                yAxis: {
+                    max: 8,
+                    min: 0,
+                    plotBands: [{
+                        color: linearGrad,
+                        from: 7,
+                        to: 10
+                    }]
+                },
+                series: [{
+                    data: [1, 2, 3, 4, 5, 6, 7, 8, 9]
+                }]
+            }),
+            bands = chart.xAxis[0].plotLinesAndBands,
+            transformOf = band => document.getElementById(
+                band.svgElem.element.getAttribute('fill')
+                    .replace(/^.*#|\)$/g, '')
+            ).getAttribute('gradientTransform');
+
+        assert.strictEqual(
+            transformOf(bands[0]),
+            null,
+            'A band inside the axis should keep the gradient untransformed'
+        );
+
+        assert.strictEqual(
+            transformOf(bands[1]),
+            'translate(0 0) scale(3 1)',
+            'A band reaching past the max should scale the gradient up to its' +
+                ' full range'
+        );
+
+        assert.strictEqual(
+            transformOf(bands[2]),
+            'translate(-2 0) scale(3 1)',
+            'A band reaching past the min should also shift the gradient'
+        );
+
+        assert.strictEqual(
+            transformOf(chart.yAxis[0].plotLinesAndBands[0]),
+            'translate(0 -2) scale(1 3)',
+            'A band on a vertical axis should be transformed along the y axis'
+        );
+
+        assert.strictEqual(
+            linearGrad.linearGradient.gradientTransform,
+            undefined,
+            'The color object given in the options should not be mutated'
+        );
+
+        chart.xAxis[0].setExtremes(-5, 15);
+
+        assert.strictEqual(
+            transformOf(bands[1]),
+            null,
+            'The transform should be removed when the band no longer is cut'
+        );
+    }
+);

--- a/samples/unit-tests/axis/plotlines-and-plotbands/demo.js
+++ b/samples/unit-tests/axis/plotlines-and-plotbands/demo.js
@@ -1103,18 +1103,20 @@ QUnit.test(
                     }]
                 },
                 series: [{
-                    data: [1, 2, 3, 4, 5, 6, 7, 8, 9]
+                    data: [1, 2, 3]
                 }]
             }),
             bands = chart.xAxis[0].plotLinesAndBands,
             transformOf = band => document.getElementById(
                 band.svgElem.element.getAttribute('fill')
                     .replace(/^.*#|\)$/g, '')
-            ).getAttribute('gradientTransform');
+            ).getAttribute('gradientTransform'),
+            gradientCount = () => chart.container
+                .querySelectorAll('defs linearGradient').length;
 
         assert.strictEqual(
             transformOf(bands[0]),
-            null,
+            'translate(0 0) scale(1 1)',
             'A band inside the axis should keep the gradient untransformed'
         );
 
@@ -1143,12 +1145,36 @@ QUnit.test(
             'The color object given in the options should not be mutated'
         );
 
+        const gradientsBefore = gradientCount();
+
+        chart.xAxis[0].setExtremes(3, 9);
         chart.xAxis[0].setExtremes(-5, 15);
 
         assert.strictEqual(
+            gradientCount(),
+            gradientsBefore,
+            'Redrawing should transform the gradient in place, not add a new' +
+                ' element to the defs on each redraw'
+        );
+
+        assert.strictEqual(
             transformOf(bands[1]),
-            null,
-            'The transform should be removed when the band no longer is cut'
+            'translate(0 0) scale(1 1)',
+            'The transform should be reset when the band no longer is cut'
+        );
+
+        chart.xAxis[0].addPlotBand({
+            color: linearGrad,
+            from: 7,
+            id: 'added',
+            to: 10
+        });
+        chart.xAxis[0].removePlotBand('added');
+
+        assert.strictEqual(
+            gradientCount(),
+            gradientsBefore,
+            'Removing a band should release its gradient element'
         );
     }
 );

--- a/samples/unit-tests/axis/plotlines-and-plotbands/demo.js
+++ b/samples/unit-tests/axis/plotlines-and-plotbands/demo.js
@@ -1160,7 +1160,7 @@ QUnit.test(
         assert.strictEqual(
             transformOf(bands[1]),
             'translate(0 0) scale(1 1)',
-            'The transform should be reset when the band no longer is cut'
+            'The transform should be reset when the band is no longer cut'
         );
 
         chart.xAxis[0].addPlotBand({

--- a/samples/unit-tests/axis/plotlines-and-plotbands/demo.js
+++ b/samples/unit-tests/axis/plotlines-and-plotbands/demo.js
@@ -949,7 +949,14 @@ QUnit.test('#14254: plotBands.acrossPanes', function (assert) {
         ],
         yAxis: [
             {
-                height: '50%'
+                height: '50%',
+                // Reaches below the pane (#6257)
+                plotBands: [
+                    {
+                        from: -100,
+                        to: 1
+                    }
+                ]
             },
             {
                 height: '50%',
@@ -987,6 +994,14 @@ QUnit.test('#14254: plotBands.acrossPanes', function (assert) {
     assert.ok(
         bands[1].height > bands[0].height,
         'plotBand with acrossPanes = true has greater height'
+    );
+
+    assert.close(
+        Number(chart.yAxis[0].plotBandClip.attr('height')),
+        chart.yAxis[0].len,
+        1,
+        '#6257: a band should be clipped to its own pane, not to the whole ' +
+            'plot area'
     );
 });
 
@@ -1068,113 +1083,105 @@ QUnit.test(
 );
 
 QUnit.test(
-    '#6257: Gradient on a plot band reaching outside the axis',
+    '#6257: Plot band reaching outside the axis is clipped, not fitted',
     function (assert) {
-        // Deliberately shared between the bands, like in the issue
-        const linearGrad = {
-                linearGradient: { x1: 0, x2: 1, y1: 0, y2: 0 },
-                stops: [[0, '#04A6DB'], [1, '#006D91']]
-            },
-            chart = Highcharts.chart('container', {
+        const chart = Highcharts.chart('container', {
                 xAxis: {
                     max: 8,
                     min: 0,
                     plotBands: [{
-                        color: linearGrad,
-                        from: 2,
-                        to: 5
-                    }, {
-                        color: linearGrad,
                         from: 7,
-                        to: 10
-                    }, {
-                        color: linearGrad,
-                        from: -2,
-                        to: 1
+                        label: {
+                            text: 'Cut'
+                        },
+                        to: 12
                     }]
                 },
                 yAxis: {
                     max: 8,
                     min: 0,
                     plotBands: [{
-                        color: linearGrad,
-                        from: 7,
-                        to: 10
+                        from: -5,
+                        to: 3
                     }]
                 },
                 series: [{
                     data: [1, 2, 3]
                 }]
             }),
-            bands = chart.xAxis[0].plotLinesAndBands,
-            transformOf = band => document.getElementById(
-                band.svgElem.element.getAttribute('fill')
-                    .replace(/^.*#|\)$/g, '')
-            ).getAttribute('gradientTransform'),
-            gradientCount = () => chart.container
-                .querySelectorAll('defs linearGradient').length;
+            xAxis = chart.xAxis[0],
+            yAxis = chart.yAxis[0],
+            bands = xAxis.plotLinesAndBands,
+            // Rendered band corners, index 1 for x and 2 for y
+            corners = (band, index) => band.svgElem.pathArray
+                .filter(segment => segment.length === 3)
+                .map(segment => segment[index]);
 
-        assert.strictEqual(
-            transformOf(bands[0]),
-            'translate(0 0) scale(1 1)',
-            'A band inside the axis should keep the gradient untransformed'
+        assert.close(
+            Math.max(...corners(bands[0], 1)),
+            xAxis.toPixels(12),
+            1,
+            'A band reaching past the max should keep its real coordinates, ' +
+                'so that a gradient fill spans the full band'
         );
 
-        assert.strictEqual(
-            transformOf(bands[1]),
-            'translate(0 0) scale(3 1)',
-            'A band reaching past the max should scale the gradient up to its' +
-                ' full range'
+        assert.ok(
+            bands[0].svgElem.element.getAttribute('clip-path'),
+            'The band should be clipped to the axis instead of being fitted'
         );
 
-        assert.strictEqual(
-            transformOf(bands[2]),
-            'translate(-2 0) scale(3 1)',
-            'A band reaching past the min should also shift the gradient'
+        const labelBox = bands[0].label.getBBox();
+
+        assert.ok(
+            labelBox.x + labelBox.width / 2 < xAxis.pos + xAxis.len,
+            'The label of a cut band should stay within the visible part'
         );
 
-        assert.strictEqual(
-            transformOf(chart.yAxis[0].plotLinesAndBands[0]),
-            'translate(0 -2) scale(1 3)',
-            'A band on a vertical axis should be transformed along the y axis'
+        assert.close(
+            Math.max(...corners(yAxis.plotLinesAndBands[0], 2)),
+            yAxis.toPixels(-5),
+            1,
+            'A band on a vertical axis should keep its real coordinates too'
         );
 
-        assert.strictEqual(
-            linearGrad.linearGradient.gradientTransform,
-            undefined,
-            'The color object given in the options should not be mutated'
+        chart.setSize(400, 300, false);
+
+        assert.close(
+            Number(xAxis.plotBandClip.attr('width')),
+            xAxis.len,
+            1,
+            'The clip should follow the axis when the chart is resized'
         );
+    }
+);
 
-        const gradientsBefore = gradientCount();
+QUnit.test(
+    '#6257: Plot band clip across a scrollable plot area',
+    function (assert) {
+        const chart = Highcharts.chart('container', {
+                chart: {
+                    height: 300,
+                    scrollablePlotArea: {
+                        minHeight: 500
+                    }
+                },
+                xAxis: {
+                    plotBands: [{
+                        from: 1,
+                        to: 2
+                    }]
+                },
+                series: [{
+                    data: [1, 2, 3]
+                }]
+            }),
+            axis = chart.xAxis[0];
 
-        chart.xAxis[0].setExtremes(3, 9);
-        chart.xAxis[0].setExtremes(-5, 15);
-
-        assert.strictEqual(
-            gradientCount(),
-            gradientsBefore,
-            'Redrawing should transform the gradient in place, not add a new' +
-                ' element to the defs on each redraw'
-        );
-
-        assert.strictEqual(
-            transformOf(bands[1]),
-            'translate(0 0) scale(1 1)',
-            'The transform should be reset when the band is no longer cut'
-        );
-
-        chart.xAxis[0].addPlotBand({
-            color: linearGrad,
-            from: 7,
-            id: 'added',
-            to: 10
-        });
-        chart.xAxis[0].removePlotBand('added');
-
-        assert.strictEqual(
-            gradientCount(),
-            gradientsBefore,
-            'Removing a band should release its gradient element'
+        assert.ok(
+            Number(axis.plotBandClip.attr('height')) >=
+                chart.plotTop + chart.plotHeight,
+            'The clip should not cut the band where the plot area reaches ' +
+                'below the chart height'
         );
     }
 );

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -4512,8 +4512,8 @@ class Axis {
 
         // Destroy elements
         [
-            'axisLine', 'axisTitle', 'axisGroup',
-            'gridGroup', 'labelGroup', 'cross', 'scrollbar'
+            'axisLine', 'axisTitle', 'axisGroup', 'gridGroup', 'labelGroup',
+            'cross', 'plotBandClip', 'scrollbar'
         ].forEach(
             function (prop: string): void {
                 if ((axis as any)[prop]) {

--- a/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
+++ b/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
@@ -49,6 +49,7 @@ import {
     merge,
     objectEach
 } from '../../../Shared/Utilities.js';
+import { uniqueKey } from '../../Utilities.js';
 
 /* *
  *
@@ -171,7 +172,7 @@ class PlotLineOrBand {
     public eventsAdded?: boolean;
 
     /** @internal */
-    public gradientTransform?: string;
+    public gradientClass?: string;
 
     /**
      * SVG element of the label.
@@ -374,49 +375,59 @@ class PlotLineOrBand {
             { color } = this.options,
             { horiz, len, pos } = axis;
 
-        let fill = color,
-            gradientTransform: (string|undefined);
+        let fill = color;
 
         if (typeof color === 'object' && 'stops' in color && !axis.isRadial) {
-            const gradName = color.radialGradient ?
+            const gradientName = color.radialGradient ?
                     'radialGradient' :
                     'linearGradient',
-                grad = color[gradName];
+                gradient = color[gradientName];
 
             // Only relative units without a transform of their own can be
             // remapped
             if (
-                grad &&
-                !isArray(grad) &&
-                !grad.gradientUnits &&
-                !grad.gradientTransform
+                gradient &&
+                !isArray(gradient) &&
+                !gradient.gradientUnits &&
+                !gradient.gradientTransform
             ) {
                 const fromPx = axis.toPixels(from),
                     toPx = axis.toPixels(to),
-                    lo = Math.min(fromPx, toPx),
-                    hi = Math.max(fromPx, toPx),
-                    span = hi - lo,
+                    low = Math.min(fromPx, toPx),
+                    high = Math.max(fromPx, toPx),
+                    span = high - low,
                     // The bounding box of the cut band
-                    boxLo = clamp(lo, pos, pos + len),
-                    boxLen = clamp(hi, pos, pos + len) - boxLo;
+                    boxLow = clamp(low, pos, pos + len),
+                    boxLength = clamp(high, pos, pos + len) - boxLow;
 
-                if (isNumber(span) && boxLen > 0 && span > boxLen) {
-                    const scale = correctFloat(span / boxLen),
-                        shift = correctFloat((lo - boxLo) / boxLen);
+                // Identity keeps the config stable across redraws
+                let gradientTransform = 'translate(0 0) scale(1 1)';
+
+                if (isNumber(span) && boxLength > 0 && span > boxLength) {
+                    const scale = correctFloat(span / boxLength),
+                        shift = correctFloat((low - boxLow) / boxLength);
 
                     gradientTransform = horiz ?
                         `translate(${shift} 0) scale(${scale} 1)` :
                         `translate(0 ${shift}) scale(1 ${scale})`;
-                    fill = merge(color, { [gradName]: { gradientTransform } });
+                }
+
+                // Gradients are cached by config, so claim one for this band
+                // alone (#1282)
+                fill = merge(color, {
+                    [gradientName]: {
+                        'class': this.gradientClass ||= uniqueKey(),
+                        gradientTransform
+                    }
+                });
+
+                // The fill is only applied on creation, so update in place
+                const gradientKey = svgElem?.element.gradient;
+                if (gradientKey) {
+                    axis.chart.renderer.gradients[gradientKey]
+                        ?.attr({ gradientTransform });
                 }
             }
-        }
-
-        // The attributes are only applied on creation, so reapply the fill
-        // when the cut changes
-        if (gradientTransform !== this.gradientTransform) {
-            this.gradientTransform = gradientTransform;
-            svgElem?.attr({ fill });
         }
 
         return fill;
@@ -549,6 +560,15 @@ class PlotLineOrBand {
     public destroy(): void {
         // Remove it from the lookup
         erase(this.axis.plotLinesAndBands, this);
+
+        // No other band can reuse the claimed gradient (#6257)
+        const gradients = this.axis.chart.renderer.gradients,
+            gradientKey = this.gradientClass && this.svgElem?.element.gradient;
+
+        if (gradientKey && gradients) {
+            gradients[gradientKey]?.destroy();
+            delete gradients[gradientKey];
+        }
 
         delete (this as Partial<this>).axis;
         destroyObjectProperties(this);

--- a/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
+++ b/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
@@ -19,6 +19,7 @@
  * */
 
 import type Chart from '../../Chart/Chart';
+import type ColorType from '../../Color/ColorType';
 import type {
     PlotBandLabelOptions,
     PlotBandOptions
@@ -37,10 +38,14 @@ import {
     addEvent,
     arrayMax,
     arrayMin,
+    clamp,
+    correctFloat,
     defined,
     destroyObjectProperties,
     erase,
     fireEvent,
+    isArray,
+    isNumber,
     merge,
     objectEach
 } from '../../../Shared/Utilities.js';
@@ -165,6 +170,9 @@ class PlotLineOrBand {
     /** @internal */
     public eventsAdded?: boolean;
 
+    /** @internal */
+    public gradientTransform?: string;
+
     /**
      * SVG element of the label.
      *
@@ -244,7 +252,8 @@ class PlotLineOrBand {
                 }
 
             } else if (isBand) { // Plot band
-                attribs.fill = color || 'var(--highcharts-highlight-color-10)';
+                attribs.fill = this.getBandFill(from, to) ||
+                    'var(--highcharts-highlight-color-10)';
                 if (borderWidth) {
                     attribs.stroke = (options as PlotBandOptions).borderColor;
                     attribs['stroke-width'] = borderWidth;
@@ -351,6 +360,66 @@ class PlotLineOrBand {
 
         // Chainable
         return this;
+    }
+
+    /**
+     * Get the fill for a plot band. A gradient is relative to the bounding box
+     * of the band, so when the band is cut at the edge of the plot area, the
+     * gradient must be transformed to keep spanning the full range (#6257).
+     * @internal
+     * @function Highcharts.PlotLineOrBand#getBandFill
+     */
+    public getBandFill(from: number, to: number): (ColorType|undefined) {
+        const { axis, svgElem } = this,
+            { color } = this.options,
+            { horiz, len, pos } = axis;
+
+        let fill = color,
+            gradientTransform: (string|undefined);
+
+        if (typeof color === 'object' && 'stops' in color && !axis.isRadial) {
+            const gradName = color.radialGradient ?
+                    'radialGradient' :
+                    'linearGradient',
+                grad = color[gradName];
+
+            // Only relative units without a transform of their own can be
+            // remapped
+            if (
+                grad &&
+                !isArray(grad) &&
+                !grad.gradientUnits &&
+                !grad.gradientTransform
+            ) {
+                const fromPx = axis.toPixels(from),
+                    toPx = axis.toPixels(to),
+                    lo = Math.min(fromPx, toPx),
+                    hi = Math.max(fromPx, toPx),
+                    span = hi - lo,
+                    // The bounding box of the cut band
+                    boxLo = clamp(lo, pos, pos + len),
+                    boxLen = clamp(hi, pos, pos + len) - boxLo;
+
+                if (isNumber(span) && boxLen > 0 && span > boxLen) {
+                    const scale = correctFloat(span / boxLen),
+                        shift = correctFloat((lo - boxLo) / boxLen);
+
+                    gradientTransform = horiz ?
+                        `translate(${shift} 0) scale(${scale} 1)` :
+                        `translate(0 ${shift}) scale(1 ${scale})`;
+                    fill = merge(color, { [gradName]: { gradientTransform } });
+                }
+            }
+        }
+
+        // The attributes are only applied on creation, so reapply the fill
+        // when the cut changes
+        if (gradientTransform !== this.gradientTransform) {
+            this.gradientTransform = gradientTransform;
+            svgElem?.attr({ fill });
+        }
+
+        return fill;
     }
 
     /**

--- a/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
+++ b/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
@@ -19,7 +19,6 @@
  * */
 
 import type Chart from '../../Chart/Chart';
-import type ColorType from '../../Color/ColorType';
 import type {
     PlotBandLabelOptions,
     PlotBandOptions
@@ -39,17 +38,13 @@ import {
     arrayMax,
     arrayMin,
     clamp,
-    correctFloat,
     defined,
     destroyObjectProperties,
     erase,
     fireEvent,
-    isArray,
-    isNumber,
     merge,
     objectEach
 } from '../../../Shared/Utilities.js';
-import { uniqueKey } from '../../Utilities.js';
 
 /* *
  *
@@ -172,12 +167,6 @@ class PlotLineOrBand {
     public eventsAdded?: boolean;
 
     /**
-     * Unique token that keeps this band's gradient out of the shared cache.
-     * @internal
-     */
-    public gradientKey?: string;
-
-    /**
      * SVG element of the label.
      *
      * @name Highcharts.PlotLineOrBand#label
@@ -256,8 +245,7 @@ class PlotLineOrBand {
                 }
 
             } else if (isBand) { // Plot band
-                attribs.fill = this.getBandFill(from, to) ||
-                    'var(--highcharts-highlight-color-10)';
+                attribs.fill = color || 'var(--highcharts-highlight-color-10)';
                 if (borderWidth) {
                     attribs.stroke = (options as PlotBandOptions).borderColor;
                     attribs['stroke-width'] = borderWidth;
@@ -289,6 +277,23 @@ class PlotLineOrBand {
                 .path()
                 .attr(attribs)
                 .add(group);
+        }
+
+        // Clip the band to the axis, as it isn't fitted to it. Only along the
+        // axis, to leave `acrossPanes` bands and the navigator alone (#6257).
+        if (isBand) {
+            const { len, pos } = axis,
+                // Left wide open across the axis, so that a scrollable plot
+                // area isn't cut off
+                clipBox = horiz ?
+                    { height: 1e5, width: len, x: pos, y: 0 } :
+                    { height: len, width: 1e5, x: 0, y: pos },
+                clip = axis.plotBandClip ||= renderer.clipRect(clipBox);
+
+            clip.attr(clipBox);
+            if (isNew) {
+                svgElem.clip(clip);
+            }
         }
 
         // Set the path or return
@@ -367,78 +372,6 @@ class PlotLineOrBand {
     }
 
     /**
-     * Get the fill for a plot band. A gradient is relative to the bounding box
-     * of the band, so when the band is cut at the edge of the plot area, the
-     * gradient must be transformed to keep spanning the full range (#6257).
-     * @internal
-     * @function Highcharts.PlotLineOrBand#getBandFill
-     */
-    public getBandFill(from: number, to: number): (ColorType|undefined) {
-        const { axis, svgElem } = this,
-            { color } = this.options,
-            { horiz, len, pos } = axis;
-
-        let fill = color;
-
-        if (typeof color === 'object' && 'stops' in color && !axis.isRadial) {
-            const gradientName = color.radialGradient ?
-                    'radialGradient' :
-                    'linearGradient',
-                gradient = color[gradientName];
-
-            // Only relative units without a transform of their own can be
-            // remapped
-            if (
-                gradient &&
-                !isArray(gradient) &&
-                !gradient.gradientUnits &&
-                !gradient.gradientTransform
-            ) {
-                const fromPx = axis.toPixels(from),
-                    toPx = axis.toPixels(to),
-                    low = Math.min(fromPx, toPx),
-                    high = Math.max(fromPx, toPx),
-                    span = high - low,
-                    // The bounding box of the cut band
-                    boxLow = clamp(low, pos, pos + len),
-                    boxLength = clamp(high, pos, pos + len) - boxLow;
-
-                // Identity keeps the config stable across redraws
-                let gradientTransform = 'translate(0 0) scale(1 1)';
-
-                if (isNumber(span) && boxLength > 0 && span > boxLength) {
-                    const scale = correctFloat(span / boxLength),
-                        shift = correctFloat((low - boxLow) / boxLength);
-
-                    gradientTransform = horiz ?
-                        `translate(${shift} 0) scale(${scale} 1)` :
-                        `translate(0 ${shift}) scale(1 ${scale})`;
-                }
-
-                // Gradients are cached by config, so claim one for this band
-                // alone (#1282)
-                fill = merge(color, {
-                    [gradientName]: {
-                        'data-highcharts-band':
-                            this.gradientKey ||= uniqueKey(),
-                        gradientTransform
-                    }
-                });
-
-                // The fill is only applied on creation, so update the gradient
-                // element directly
-                const cacheKey = svgElem?.element.gradient;
-                if (cacheKey) {
-                    axis.chart.renderer.gradients[cacheKey]
-                        ?.attr({ gradientTransform });
-                }
-            }
-        }
-
-        return fill;
-    }
-
-    /**
      * Render and align label for plot line or band.
      * @internal
      * @function Highcharts.PlotLineOrBand#renderLabel
@@ -496,19 +429,24 @@ class PlotLineOrBand {
 
         // Get the bounding box and align the label
         // #3000 changed to better handle choice between plotband or plotline
-        const xBounds = path.xBounds ||
+        const { horiz, len, pos } = axis,
+            xBounds = path.xBounds ||
                 [path[0][1], path[1][1], (isBand ? path[2][1] : path[0][1])],
             yBounds = path.yBounds ||
                 [path[0][2], path[1][2], (isBand ? path[2][2] : path[0][2])],
-            x = arrayMin(xBounds),
-            y = arrayMin(yBounds),
-            bBoxWidth = arrayMax(xBounds) - x;
+            // Align within the visible part of a clipped band (#6257)
+            bounds = horiz ? xBounds : yBounds,
+            low = clamp(arrayMin(bounds), pos, pos + len),
+            high = clamp(arrayMax(bounds), pos, pos + len),
+            x = horiz ? low : arrayMin(xBounds),
+            y = horiz ? arrayMin(yBounds) : low,
+            bBoxWidth = horiz ? high - low : arrayMax(xBounds) - x;
 
         label.align(optionsLabel, false, {
             x,
             y,
             width: bBoxWidth,
-            height: arrayMax(yBounds) - y
+            height: horiz ? arrayMax(yBounds) - y : high - low
         });
 
         label.alignAttr.y -= renderer.fontMetrics(label).b;
@@ -565,15 +503,6 @@ class PlotLineOrBand {
     public destroy(): void {
         // Remove it from the lookup
         erase(this.axis.plotLinesAndBands, this);
-
-        // No other band can reuse the claimed gradient (#6257)
-        const gradients = this.axis.chart.renderer.gradients,
-            cacheKey = this.gradientKey && this.svgElem?.element.gradient;
-
-        if (cacheKey && gradients) {
-            gradients[cacheKey]?.destroy();
-            delete gradients[cacheKey];
-        }
 
         delete (this as Partial<this>).axis;
         destroyObjectProperties(this);

--- a/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
+++ b/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
@@ -421,7 +421,8 @@ class PlotLineOrBand {
                     }
                 });
 
-                // The fill is only applied on creation, so update in place
+                // The fill is only applied on creation, so update the gradient
+                // element directly
                 const gradientKey = svgElem?.element.gradient;
                 if (gradientKey) {
                     axis.chart.renderer.gradients[gradientKey]

--- a/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
+++ b/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
@@ -171,8 +171,11 @@ class PlotLineOrBand {
     /** @internal */
     public eventsAdded?: boolean;
 
-    /** @internal */
-    public gradientClass?: string;
+    /**
+     * Unique token that keeps this band's gradient out of the shared cache.
+     * @internal
+     */
+    public gradientKey?: string;
 
     /**
      * SVG element of the label.
@@ -416,16 +419,17 @@ class PlotLineOrBand {
                 // alone (#1282)
                 fill = merge(color, {
                     [gradientName]: {
-                        'class': this.gradientClass ||= uniqueKey(),
+                        'data-highcharts-band':
+                            this.gradientKey ||= uniqueKey(),
                         gradientTransform
                     }
                 });
 
                 // The fill is only applied on creation, so update the gradient
                 // element directly
-                const gradientKey = svgElem?.element.gradient;
-                if (gradientKey) {
-                    axis.chart.renderer.gradients[gradientKey]
+                const cacheKey = svgElem?.element.gradient;
+                if (cacheKey) {
+                    axis.chart.renderer.gradients[cacheKey]
                         ?.attr({ gradientTransform });
                 }
             }
@@ -564,11 +568,11 @@ class PlotLineOrBand {
 
         // No other band can reuse the claimed gradient (#6257)
         const gradients = this.axis.chart.renderer.gradients,
-            gradientKey = this.gradientClass && this.svgElem?.element.gradient;
+            cacheKey = this.gradientKey && this.svgElem?.element.gradient;
 
-        if (gradientKey && gradients) {
-            gradients[gradientKey]?.destroy();
-            delete gradients[gradientKey];
+        if (cacheKey && gradients) {
+            gradients[cacheKey]?.destroy();
+            delete gradients[cacheKey];
         }
 
         delete (this as Partial<this>).axis;

--- a/ts/Core/Axis/PlotLineOrBand/PlotLineOrBandAxis.ts
+++ b/ts/Core/Axis/PlotLineOrBand/PlotLineOrBandAxis.ts
@@ -22,6 +22,7 @@ import type Axis from '../Axis';
 import type PlotBandOptions from './PlotBandOptions';
 import type PlotLineOptions from './PlotLineOptions';
 import type PlotLineOrBand from './PlotLineOrBand';
+import type SVGElement from '../../Renderer/SVG/SVGElement';
 import type SVGPath from '../../Renderer/SVG/SVGPath';
 
 import { erase, extend, isNumber } from '../../../Shared/Utilities.js';
@@ -134,6 +135,12 @@ namespace PlotLineOrBandAxis {
             to: number,
             options?: (PlotBandOptions|PlotLineOptions)
         ): SVGPath;
+
+        /**
+         * Clip rectangle keeping plot bands within the axis (#6257).
+         * @internal
+         */
+        plotBandClip?: SVGElement;
 
         /**
          * Remove a plot band by its id.
@@ -337,9 +344,11 @@ namespace PlotLineOrBandAxis {
         options?: (PlotBandOptions|PlotLineOptions)
     ): SVGPath {
         options = options || this.options;
+        // Keep real coordinates so a gradient spans the full band. The band is
+        // clipped to the axis in `PlotLineOrBand.render` (#6257).
         const toPath = this.getPlotLinePath({
                 value: to,
-                force: true,
+                force: 'pass',
                 acrossPanes: options.acrossPanes
             }),
             result = [] as SVGPath,
@@ -351,25 +360,14 @@ namespace PlotLineOrBandAxis {
                 (from > this.max && to > this.max),
             path = this.getPlotLinePath({
                 value: from,
-                force: true,
+                force: 'pass',
                 acrossPanes: options.acrossPanes
             });
 
-        let i,
-            // #4964 check if chart is inverted or plot band is on yAxis
-            plus = 1,
-            isFlat: (boolean|undefined);
-
         if (path && toPath) {
 
-            // Flat paths don't need labels (#3836)
-            if (outside) {
-                isFlat = path.toString() === toPath.toString();
-                plus = 0;
-            }
-
             // Go over each subpath - for panes in Highcharts Stock
-            for (i = 0; i < path.length; i += 2) {
+            for (let i = 0; i < path.length; i += 2) {
                 const pathStart = path[i],
                     pathEnd = path[i + 1],
                     toPathStart = toPath[i],
@@ -383,13 +381,14 @@ namespace PlotLineOrBandAxis {
                     (toPathStart[0] === 'M' || toPathStart[0] === 'L') &&
                     (toPathEnd[0] === 'M' || toPathEnd[0] === 'L')
                 ) {
-                    // Add 1 pixel when coordinates are the same
+                    // Add 1 pixel when coordinates are the same, also when
+                    // inverted or on the yAxis (#4964)
                     if (horiz && toPathStart[1] === pathStart[1]) {
-                        toPathStart[1] += plus;
-                        toPathEnd[1] += plus;
+                        toPathStart[1]++;
+                        toPathEnd[1]++;
                     } else if (!horiz && toPathStart[2] === pathStart[2]) {
-                        toPathStart[2] += plus;
-                        toPathEnd[2] += plus;
+                        toPathStart[2]++;
+                        toPathEnd[2]++;
                     }
 
                     result.push(
@@ -400,7 +399,10 @@ namespace PlotLineOrBandAxis {
                         ['Z']
                     );
                 }
-                result.isFlat = isFlat;
+
+                // Flat paths don't need labels (#3836), neither do bands
+                // clipped away entirely (#6257)
+                result.isFlat = outside;
             }
 
         }

--- a/ts/Core/Color/GradientColor.ts
+++ b/ts/Core/Color/GradientColor.ts
@@ -37,14 +37,20 @@ export interface GradientColorStop {
     color?: Color;
 }
 
-export interface LinearGradientColor {
+/** @internal */
+export interface GradientAttributes {
+    gradientTransform?: string;
+    gradientUnits?: 'userSpaceOnUse';
+}
+
+export interface LinearGradientColor extends GradientAttributes {
     x1: number;
     x2: number;
     y1: number;
     y2: number;
 }
 
-export interface RadialGradientColor {
+export interface RadialGradientColor extends GradientAttributes {
     cx: number;
     cy: number;
     r: number;

--- a/ts/Core/Color/GradientColor.ts
+++ b/ts/Core/Color/GradientColor.ts
@@ -39,6 +39,7 @@ export interface GradientColorStop {
 
 /** @internal */
 export interface GradientAttributes {
+    'class'?: string;
     gradientTransform?: string;
     gradientUnits?: 'userSpaceOnUse';
 }

--- a/ts/Core/Color/GradientColor.ts
+++ b/ts/Core/Color/GradientColor.ts
@@ -37,21 +37,14 @@ export interface GradientColorStop {
     color?: Color;
 }
 
-/** @internal */
-export interface GradientAttributes {
-    'data-highcharts-band'?: string;
-    gradientTransform?: string;
-    gradientUnits?: 'userSpaceOnUse';
-}
-
-export interface LinearGradientColor extends GradientAttributes {
+export interface LinearGradientColor {
     x1: number;
     x2: number;
     y1: number;
     y2: number;
 }
 
-export interface RadialGradientColor extends GradientAttributes {
+export interface RadialGradientColor {
     cx: number;
     cy: number;
     r: number;

--- a/ts/Core/Color/GradientColor.ts
+++ b/ts/Core/Color/GradientColor.ts
@@ -39,7 +39,7 @@ export interface GradientColorStop {
 
 /** @internal */
 export interface GradientAttributes {
-    'class'?: string;
+    'data-highcharts-band'?: string;
     gradientTransform?: string;
     gradientUnits?: 'userSpaceOnUse';
 }

--- a/ts/Core/Renderer/SVG/SVGAttributes.ts
+++ b/ts/Core/Renderer/SVG/SVGAttributes.ts
@@ -64,6 +64,7 @@ export interface SVGAttributes {
     filterUnits?: string;
     'flood-color'?: string;
     'flood-opacity'?: number;
+    gradientTransform?: string;
     gradientUnits?: 'userSpaceOnUse';
     height?: number;
     href?: string;

--- a/ts/Core/Renderer/SVG/SVGAttributes.ts
+++ b/ts/Core/Renderer/SVG/SVGAttributes.ts
@@ -64,7 +64,6 @@ export interface SVGAttributes {
     filterUnits?: string;
     'flood-color'?: string;
     'flood-opacity'?: number;
-    gradientTransform?: string;
     gradientUnits?: 'userSpaceOnUse';
     height?: number;
     href?: string;


### PR DESCRIPTION
Fixed #6257, a gradient in a plot band that extends outside the axis was squeezed into the visible part of the band.