### PR TITLE
bugfix/24975-gantt-points-grouping-in-navigator

### DIFF
--- a/samples/unit-tests/gantt/gantt/demo.js
+++ b/samples/unit-tests/gantt/gantt/demo.js
@@ -819,6 +819,74 @@
         });
     });
 
+    QUnit.test('Navigator inherits axis uniqueNames (#24975)', assert => {
+        const chart = Highcharts.ganttChart('container', {
+                yAxis: {
+                    uniqueNames: true
+                },
+                navigator: {
+                    enabled: true,
+                    series: {
+                        type: 'gantt'
+                    },
+                    yAxis: {
+                        type: 'treegrid'
+                    }
+                },
+                series: [{
+                    name: 'Series 1',
+                    data: [{
+                        start: Date.UTC(2026, 2, 1),
+                        end: Date.UTC(2026, 6, 1),
+                        name: 'Development'
+                    }, {
+                        start: Date.UTC(2026, 6, 1),
+                        end: Date.UTC(2026, 7, 15),
+                        name: 'Testing'
+                    }, {
+                        start: Date.UTC(2026, 6, 15),
+                        end: Date.UTC(2026, 8, 30),
+                        name: 'Development'
+                    }, {
+                        start: Date.UTC(2026, 9, 1),
+                        end: Date.UTC(2026, 9, 20),
+                        name: 'Testing'
+                    }]
+                }]
+            }),
+            nav = chart.navigator,
+            series = chart.series[0],
+            navSeries = nav.series[0];
+
+        assert.strictEqual(
+            nav.yAxis.uniqueNames,
+            true,
+            'Navigator should inherit uniqueNames from the base series axis.'
+        );
+
+        navSeries.points.forEach((_, i) => {
+            assert.strictEqual(
+                navSeries.points[i].y,
+                series.points[i].y,
+                'Navigator and main series should use the same Y positions.'
+            );
+        });
+
+        chart.update({
+            navigator: {
+                yAxis: {
+                    uniqueNames: false
+                }
+            }
+        });
+
+        assert.strictEqual(
+            nav.yAxis.uniqueNames,
+            false,
+            'Explicit navigator uniqueNames should override the main axis.'
+        );
+    });
+
     QUnit.test('Gantt using the keys feature #13768', function (assert) {
         var chart = Highcharts.ganttChart('container', {
             series: [

--- a/ts/Stock/Navigator/Navigator.ts
+++ b/ts/Stock/Navigator/Navigator.ts
@@ -1342,7 +1342,9 @@ class Navigator {
             xAxisIndex = chart.xAxis.length,
             yAxisIndex = chart.yAxis.length,
             baseXaxis = baseSeries && baseSeries[0] && baseSeries[0].xAxis ||
-                chart.xAxis[0] || { options: {} };
+                chart.xAxis[0] || { options: {} },
+            baseYaxis = baseSeries && baseSeries[0] && baseSeries[0].yAxis ||
+                chart.yAxis[0];
 
         chart.isDirtyBox = true;
 
@@ -1392,6 +1394,14 @@ class Navigator {
                         (chart.yAxis[0] && chart.yAxis[0].reversed) ??
                         false
                     ), // #14060
+                    uniqueNames: (
+                        (
+                            navigatorOptions.yAxis &&
+                            navigatorOptions.yAxis.uniqueNames
+                        ) ??
+                        (baseYaxis && baseYaxis.uniqueNames) ??
+                        false
+                    ),
                     zoomEnabled: false
                 }, chart.inverted ? {
                     width: height

--- a/ts/Stock/Navigator/Navigator.ts
+++ b/ts/Stock/Navigator/Navigator.ts
@@ -1395,13 +1395,10 @@ class Navigator {
                         false
                     ), // #14060
                     uniqueNames: (
-                        (
-                            navigatorOptions.yAxis &&
-                            navigatorOptions.yAxis.uniqueNames
-                        ) ??
-                        (baseYaxis && baseYaxis.uniqueNames) ??
+                        navigatorOptions.yAxis?.uniqueNames ??
+                        baseYaxis?.userOptions.uniqueNames ??
                         false
-                    ),
+                    ), // #24975
                     zoomEnabled: false
                 }, chart.inverted ? {
                     width: height


### PR DESCRIPTION
Fixed #24975, points was not grouped correctly in navigator when `axis.uniqueNames` was enabled.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217122310157095