### PR TITLE
bugfix/legend-symbol-opacity

### DIFF
--- a/samples/unit-tests/accessibility/forced-markers/demo.js
+++ b/samples/unit-tests/accessibility/forced-markers/demo.js
@@ -28,6 +28,41 @@ QUnit.test('No series markers', function (assert) {
     assert.strictEqual(hasVisibleMarker(point), false, 'Marker hidden');
 });
 
+QUnit.test(
+    'Forced markers do not hide rectangle legend symbols',
+    function (assert) {
+        const chart = Highcharts.chart('container', {
+                plotOptions: {
+                    line: {
+                        legendSymbol: 'rectangle',
+                        marker: {
+                            enabled: false
+                        }
+                    }
+                },
+                series: [{
+                    data: [1, 2, 3]
+                }]
+            }),
+            series = chart.series[0],
+            symbol = series.legendItem.symbol;
+
+        series.hide();
+        assert.strictEqual(
+            symbol.opacity,
+            1,
+            'Legend symbol should remain visible when the series is hidden'
+        );
+
+        series.show();
+        assert.strictEqual(
+            symbol.opacity,
+            1,
+            'Legend symbol should remain visible when the series is shown'
+        );
+    }
+);
+
 QUnit.test('Too many points for markers', function (assert) {
     const chart = Highcharts.chart('container', {
             series: [

--- a/ts/Accessibility/Components/LegendComponent.ts
+++ b/ts/Accessibility/Components/LegendComponent.ts
@@ -747,6 +747,8 @@ namespace LegendComponent {
             markerOptions = series.resetA11yMarkerOptions;
 
         if (a11yOptions.enabled && series.a11yMarkersForced) {
+            // Forced accessibility markers use zero opacity. Restore the
+            // original marker opacity so rectangle legend symbols stay visible.
             series.legendItem?.symbol?.attr({
                 opacity: markerOptions?.states?.normal?.opacity ?? 1
             });

--- a/ts/Accessibility/Components/LegendComponent.ts
+++ b/ts/Accessibility/Components/LegendComponent.ts
@@ -28,6 +28,7 @@ import type { DeepPartial } from '../../Shared/Types';
 import type { LegendAccessibilityOptions } from '../Options/A11yOptions';
 import type SVGElement from '../../Core/Renderer/SVG/SVGElement';
 import type ProxyElement from '../ProxyElement';
+import type ForcedMarkers from './SeriesComponent/ForcedMarkers';
 
 import { animObject } from '../../Core/Animation/AnimationUtilities.js';
 import H from '../../Core/Globals.js';
@@ -741,7 +742,15 @@ namespace LegendComponent {
     ): void {
         const chart: Accessibility.ChartComposition = this.chart as any,
             a11yOptions = chart.options.accessibility,
-            legendItem = e.item;
+            legendItem = e.item,
+            series = legendItem as ForcedMarkers.SeriesComposition,
+            markerOptions = series.resetA11yMarkerOptions;
+
+        if (a11yOptions.enabled && series.a11yMarkersForced) {
+            series.legendItem?.symbol?.attr({
+                opacity: markerOptions?.states?.normal?.opacity ?? 1
+            });
+        }
 
         if (a11yOptions.enabled && legendItem && legendItem.a11yProxyElement) {
             legendItem.a11yProxyElement.innerElement.setAttribute(


### PR DESCRIPTION
Fixed rectangle legend symbols that didn't become visible again after users hid and showed a series with disabled markers and accessibility enabled.

## Description

When accessibility is active, Highcharts sets disabled point markers to zero opacity for keyboard navigation.

Series that use `legendSymbol: 'rectangle'` share marker attributes with the legend symbol during `Legend.colorizeItem`. This shared opacity made the legend symbol transparent after users hid or showed the series.

The accessibility legend hook now restores the original opacity after colorization. As a result, the symbol doesn't remain transparent.

## Testing

- Added a regression test for hiding and showing the affected line series.
- `QUNIT_TEST_PATH=unit-tests/accessibility/forced-markers npx playwright test --project=setup-highcharts --project=qunit`
- `npm run test:precommit`
- `npm run lint`