### PR TITLE
tools/fix-failing-visual-compare

### DIFF
--- a/.github/workflows/visual-compare.yml
+++ b/.github/workflows/visual-compare.yml
@@ -135,6 +135,11 @@ jobs:
         with:
           ref: master
 
+      - name: Use Firefox 153.0.4
+        uses: browser-actions/setup-firefox@v1
+        with:
+          firefox-version: '153.0.4'
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/visual-compare.yml
+++ b/.github/workflows/visual-compare.yml
@@ -163,6 +163,11 @@ jobs:
           clean: false
           fetch-depth: 0
 
+      - name: Use Firefox 153.0.4
+        uses: browser-actions/setup-firefox@v1
+        with:
+          firefox-version: '153.0.4'
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/visual-compare.yml
+++ b/.github/workflows/visual-compare.yml
@@ -136,9 +136,19 @@ jobs:
           ref: master
 
       - name: Use Firefox 153.0.4
+        id: reference-firefox
         uses: browser-actions/setup-firefox@v1
         with:
           firefox-version: '153.0.4'
+
+      - name: Disable Firefox updates
+        env:
+          FIREFOX_PATH: ${{ steps.reference-firefox.outputs.firefox-path }}
+        run: |
+          firefox_dir="$(dirname "$FIREFOX_PATH")"
+          mkdir -p "$firefox_dir/distribution"
+          printf '%s\n' '{ "policies": { "DisableAppUpdate": true } }' \
+            > "$firefox_dir/distribution/policies.json"
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6
@@ -164,9 +174,19 @@ jobs:
           fetch-depth: 0
 
       - name: Use Firefox 153.0.4
+        id: candidate-firefox
         uses: browser-actions/setup-firefox@v1
         with:
           firefox-version: '153.0.4'
+
+      - name: Disable Firefox updates
+        env:
+          FIREFOX_PATH: ${{ steps.candidate-firefox.outputs.firefox-path }}
+        run: |
+          firefox_dir="$(dirname "$FIREFOX_PATH")"
+          mkdir -p "$firefox_dir/distribution"
+          printf '%s\n' '{ "policies": { "DisableAppUpdate": true } }' \
+            > "$firefox_dir/distribution/policies.json"
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6


### PR DESCRIPTION
Recent visual-compare runs [have failed](https://github.com/highcharts/highcharts/actions/runs/33153791969/job/98791698538), seemingly due to a version bump of Firefox in the latest runner image. Pinning the firefox version should help, once merged to master

The bug seems to be related to the sonification module
<img width="754" height="291" alt="image" src="https://github.com/user-attachments/assets/cb28a285-c0d9-4df9-84c7-5441238a9270" />
