### PR TITLE
bugfix/25099-isolate-mouse-wheel-timers

### DIFF
--- a/samples/unit-tests/chart/mouse-wheel/demo.js
+++ b/samples/unit-tests/chart/mouse-wheel/demo.js
@@ -83,3 +83,56 @@ QUnit.test('Mouse wheel zoom on chart', function (assert) {
 
     TestUtilities.lolexRunAndUninstall(clock);
 });
+
+QUnit.test('Mouse wheel drop timers are isolated per chart', function (assert) {
+    const clock = TestUtilities.lolexInstall(),
+        firstContainer = document.createElement('div'),
+        secondContainer = document.createElement('div'),
+        getOptions = () => ({
+            chart: {
+                zooming: {
+                    mouseWheel: {
+                        type: 'x'
+                    }
+                }
+            },
+            navigator: {
+                enabled: false
+            },
+            series: [{
+                data: [1, 2, 3, 4, 5]
+            }]
+        });
+
+    document.body.append(firstContainer, secondContainer);
+
+    const firstChart = Highcharts.stockChart(firstContainer, getOptions()),
+        secondChart = Highcharts.stockChart(secondContainer, getOptions()),
+        firstController = new TestController(firstChart),
+        secondController = new TestController(secondChart);
+
+    let firstDrops = 0,
+        secondDrops = 0;
+
+    firstChart.pointer.drop = () => ++firstDrops;
+    secondChart.pointer.drop = () => ++secondDrops;
+
+    firstController.mouseWheel(200, 100, {
+        deltaY: -1000,
+        target: firstChart.container
+    });
+    secondController.mouseWheel(200, 100, {
+        deltaY: -1000,
+        target: secondChart.container
+    });
+    clock.tick(401);
+
+    assert.strictEqual(firstDrops, 1, 'The first chart should run drop');
+    assert.strictEqual(secondDrops, 1, 'The second chart should run drop');
+
+    firstChart.destroy();
+    secondChart.destroy();
+    firstContainer.remove();
+    secondContainer.remove();
+    TestUtilities.lolexRunAndUninstall(clock);
+});

--- a/ts/Extensions/MouseWheelZoom/MouseWheelZoom.ts
+++ b/ts/Extensions/MouseWheelZoom/MouseWheelZoom.ts
@@ -46,9 +46,8 @@ const composedClasses: Array<(Function|GlobalsBase)> = [],
         enabled: true,
         sensitivity: 1.1,
         showResetButton: false
-    };
-
-let wheelTimer: number;
+    },
+    wheelTimers = new WeakMap<Chart, number>();
 
 /* *
  *
@@ -113,6 +112,8 @@ const zoomBy = function (
     });
 
     if (hasZoomed) {
+        const wheelTimer = wheelTimers.get(chart);
+
         if (defined(wheelTimer)) {
             internalClearTimeout(wheelTimer);
         }
@@ -120,9 +121,13 @@ const zoomBy = function (
         // Some time after the last mousewheel event, run drop. In case any of
         // the affected axes had `startOnTick` or `endOnTick`, they will be
         // re-adjusted now.
-        wheelTimer = setTimeout((): void => {
-            chart.pointer?.drop();
-        }, 400);
+        wheelTimers.set(
+            chart,
+            setTimeout((): void => {
+                chart.pointer?.drop();
+                wheelTimers.delete(chart);
+            }, 400)
+        );
     }
 
     return hasZoomed;


### PR DESCRIPTION
Fixed #25099, mouse-wheel zoom on one chart no longer cancels the delayed pointer drop for another chart.

The mouse-wheel composition previously stored one module-level timeout. This change stores timeouts per chart, preserving debounce behavior within each chart while isolating multiple charts. The callback also removes its completed timer entry.

A two-chart QUnit regression test reproduces the original 0/1 drop result and verifies both charts now complete their delayed drop.

Verification:
- Focused mouse-wheel QUnit suite in Chromium
- Highcharts TypeScript and ES5 build
- ESLint for the changed TypeScript source
- Generated-sample validation
- Highcharts pre-commit hook, including 418 Node tests
- git diff --check