### PR TITLE
bugfix/25101-isolate-map-wheel-deltas

### DIFF
--- a/samples/unit-tests/maps/map-navigation/demo.js
+++ b/samples/unit-tests/maps/map-navigation/demo.js
@@ -217,6 +217,55 @@ QUnit.test('Map navigation button alignment', assert => {
     );
 });
 
+QUnit.test('Mouse wheel deltas are isolated per map', assert => {
+    const clock = TestUtilities.lolexInstall(),
+        firstContainer = document.createElement('div'),
+        secondContainer = document.createElement('div'),
+        getOptions = () => ({
+            chart: {
+                height: 300,
+                width: 400
+            },
+            mapNavigation: {
+                enabled: true
+            },
+            series: []
+        });
+
+    document.body.append(firstContainer, secondContainer);
+
+    const firstChart = Highcharts.mapChart(firstContainer, getOptions()),
+        secondChart = Highcharts.mapChart(secondContainer, getOptions()),
+        firstController = new TestController(firstChart),
+        secondController = new TestController(secondChart);
+
+    let firstZooms = 0,
+        secondZooms = 0;
+
+    firstChart.mapView.zoomBy = () => ++firstZooms;
+    secondChart.mapView.zoomBy = () => ++secondZooms;
+
+    for (let i = 0; i < 9; ++i) {
+        firstController.mouseWheel(200, 150, {
+            deltaY: 1,
+            target: firstChart.container
+        });
+    }
+    secondController.mouseWheel(200, 150, {
+        deltaY: 1,
+        target: secondChart.container
+    });
+
+    assert.strictEqual(firstZooms, 9, 'The first map should zoom nine times');
+    assert.strictEqual(secondZooms, 1, 'The second map should zoom once');
+
+    firstChart.destroy();
+    secondChart.destroy();
+    firstContainer.remove();
+    secondContainer.remove();
+    TestUtilities.lolexRunAndUninstall(clock);
+});
+
 QUnit.test('Orthographic map rotation and panning.', assert => {
 
     const getGraticule = partial => {

--- a/ts/Maps/MapPointer.ts
+++ b/ts/Maps/MapPointer.ts
@@ -48,6 +48,8 @@ declare module '../Core/PointerEvent' {
 /** @internal */
 interface MapPointer extends Pointer {
     chart: MapChart;
+    mapWheelDelta?: number;
+    mapWheelDeltaTimer?: number;
     mapNavigation: MapNavigation;
     onContainerDblClick(e: PointerEvent): void;
     onContainerMouseWheel(e: PointerEvent): void;
@@ -61,15 +63,6 @@ interface MapPointer extends Pointer {
 
 /** @internal */
 namespace MapPointer {
-
-    /* *
-     *
-     *  Variables
-     *
-     * */
-
-    let totalWheelDelta = 0;
-    let totalWheelDeltaTimer: number;
 
     /* *
      *
@@ -156,16 +149,17 @@ namespace MapPointer {
         // WebKit however, the delta is < 1, so we simply disable animation in
         // the `chart.mapZoom` call below.
         if (Math.abs(delta) >= 1) {
-            totalWheelDelta += Math.abs(delta);
-            if (totalWheelDeltaTimer) {
-                internalClearTimeout(totalWheelDeltaTimer);
+            this.mapWheelDelta = (this.mapWheelDelta || 0) + Math.abs(delta);
+            if (defined(this.mapWheelDeltaTimer)) {
+                internalClearTimeout(this.mapWheelDeltaTimer);
             }
-            totalWheelDeltaTimer = setTimeout((): void => {
-                totalWheelDelta = 0;
+            this.mapWheelDeltaTimer = setTimeout((): void => {
+                this.mapWheelDelta = 0;
+                this.mapWheelDeltaTimer = void 0;
             }, 50);
         }
 
-        if (totalWheelDelta < 10 && chart.isInsidePlot(
+        if ((this.mapWheelDelta || 0) < 10 && chart.isInsidePlot(
             e.chartX - chart.plotLeft,
             e.chartY - chart.plotTop
         ) && chart.mapView) {


### PR DESCRIPTION
Fixed #25101, rapid mouse-wheel input on one map no longer suppresses wheel zoom on another map.

The map pointer previously shared its wheel-delta accumulator and reset timeout across every chart. This change keeps both values on the receiving pointer instance, preserving the existing 50 ms throttle within each map while isolating multiple maps. Completed timers also clear their handle.

A deterministic two-map QUnit regression sends nine unit deltas to map A and one to map B. The original code records 9/0 zoom calls; the fix records 9/1.

Verification:
- Focused map-navigation QUnit suite in Chromium
- Modified maps/accessibility/color-axis Playwright suite: 50 files passed
- Highcharts TypeScript and ES5 build
- Changed-source ESLint
- Generated-sample validation
- Full pre-commit hook, including 418 Node tests
- git diff --check