### PR TITLE
bugfix/25103-isolate-grid-lite-credits-observers

### DIFF
--- a/tests/grid/grid-lite/credits.spec.ts
+++ b/tests/grid/grid-lite/credits.spec.ts
@@ -57,3 +57,68 @@ test('Grid credits', async ({ page }) => {
     await expect(creditsElement, 'Credits should still be visible (not configurable in grid-lite).').toBeVisible();
 });
 
+test('Credits observers are owned by their grids', async ({ page }) => {
+    await page.evaluate(() => {
+        const NativeMutationObserver = window.MutationObserver;
+        const observers: Array<MutationObserver & { disconnected: boolean }> =
+            [];
+
+        class TrackedMutationObserver extends NativeMutationObserver {
+            public disconnected = false;
+
+            constructor(callback: MutationCallback) {
+                super(callback);
+                observers.push(this);
+            }
+
+            public override disconnect(): void {
+                this.disconnected = true;
+                super.disconnect();
+            }
+        }
+
+        (window as any).MutationObserver = TrackedMutationObserver;
+        (window as any).creditsObservers = observers;
+    });
+
+    await page.setContent(`
+        <!DOCTYPE html>
+        <html>
+            <head>
+                <script src="https://code.highcharts.com/grid/grid-lite.js"></script>
+                <link rel="stylesheet" href="https://code.highcharts.com/grid/grid-lite.css"></link>
+            </head>
+            <body>
+                <div id="first-container"></div>
+                <div id="second-container"></div>
+            </body>
+        </html>
+    `, { waitUntil: 'networkidle' });
+
+    const observerStates = await page.evaluate(async () => {
+        const Grid = (window as any).Grid,
+            data = {
+                columns: {
+                    value: [1]
+                }
+            },
+            firstGrid = await Grid.grid('first-container', { data }, true),
+            secondGrid = await Grid.grid(
+                'second-container',
+                { data },
+                true
+            );
+
+        firstGrid.destroy();
+
+        const states = (window as any).creditsObservers.map(
+            (observer: { disconnected: boolean }): boolean =>
+                observer.disconnected
+        );
+
+        secondGrid.destroy();
+        return states;
+    });
+
+    expect(observerStates).toEqual([true, false]);
+});

--- a/ts/Grid/Lite/Credits/CreditsLiteComposition.ts
+++ b/ts/Grid/Lite/Credits/CreditsLiteComposition.ts
@@ -15,7 +15,6 @@
  * */
 
 import type Grid from '../../Core/Grid';
-import Table from '../../Core/Table/Table';
 
 import Globals from '../../../Core/Globals.js';
 import Credits from '../../Core/Credits.js';
@@ -29,7 +28,7 @@ import { addEvent, pushUnique } from '../../../Shared/Utilities.js';
  *
  * */
 
-let creditsObserver: MutationObserver | undefined;
+const creditsObservers = new WeakMap<Grid, MutationObserver>();
 
 /**
  * Extends the grid classes with credits.
@@ -37,26 +36,23 @@ let creditsObserver: MutationObserver | undefined;
  * @param GridClass
  * The class to extend.
  *
- * @param TableClass
- * The class to extend.
- *
  */
 export function compose(
-    GridClass: typeof Grid,
-    TableClass: typeof Table
+    GridClass: typeof Grid
 ): void {
     if (!pushUnique(Globals.composed, 'CreditsLite')) {
         return;
     }
 
     addEvent(GridClass, 'afterRenderViewport', initCredits);
-    addEvent(TableClass, 'afterDestroy', destroyCredits);
+    addEvent(GridClass, 'beforeDestroy', destroyCredits);
+    addEvent(GridClass, 'beforeRenderViewport', destroyCredits);
 }
 
 /**
  * Callback function called before table initialization.
  */
-function initCredits(this: Grid): Credits {
+function initCredits(this: Grid): void {
     const credits = new Credits(this);
     const containerStyle = credits.containerElement.style;
 
@@ -68,7 +64,7 @@ function initCredits(this: Grid): Credits {
     );
 
     // Create an observer that check credits modifications
-    creditsObserver = new MutationObserver((): void => {
+    const creditsObserver = new MutationObserver((): void => {
         if (!credits.containerElement.querySelector('.hcg-credits')) {
             credits.render();
         }
@@ -81,14 +77,15 @@ function initCredits(this: Grid): Credits {
         subtree: true
     });
 
-    return credits;
+    creditsObservers.set(this, creditsObserver);
 }
 
 /**
  * Callback function called after credits destroy.
  */
-function destroyCredits(this: Table): void {
-    creditsObserver?.disconnect();
+function destroyCredits(this: Grid): void {
+    creditsObservers.get(this)?.disconnect();
+    creditsObservers.delete(this);
 }
 
 

--- a/ts/masters-grid/grid-lite.src.ts
+++ b/ts/masters-grid/grid-lite.src.ts
@@ -89,7 +89,7 @@ const G = {
     win: Globals.win
 };
 
-CreditsLiteComposition.compose(G.Grid, G.Table);
+CreditsLiteComposition.compose(G.Grid);
 ResponsiveComposition.compose(G.Grid);
 
 


### PR DESCRIPTION
Fixed #25103, destroying or rerendering one Grid Lite instance no longer disconnects another grid credits observer or leaves its own observer connected.

The Grid Lite composition previously stored one module-level MutationObserver and attached cleanup only to Table destruction. This change stores observers by Grid instance in a WeakMap and releases them from the Grid before-render and before-destroy lifecycle events. It also covers grids that render without a table viewport.

A two-grid Playwright regression tracks the real observer instances. The original implementation reports false/true after destroying grid A; the fix reports true/false.

Verification:
- Focused Grid Lite credits tests
- Full modified Grid Lite/shared suite: 166 passed
- Full Grid Pro suite: 153 passed
- Dashboards suite: 36 passed, one existing skip
- Accessibility QUnit suite: 15 passed
- Grid and dependent product TypeScript builds
- Changed-file ESLint
- Full pre-commit Node suite: 418 passed
- git diff --check