### PR TITLE
bugfix/25105-isolate-boost-loading-timers

### DIFF
--- a/tests/highcharts/boost/loading-overlay.spec.ts
+++ b/tests/highcharts/boost/loading-overlay.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from '~/fixtures.ts';
+
+test('Canvas boost loading timers are isolated per chart', async ({ page }) => {
+    await page.setContent(`
+        <script src="https://code.highcharts.com/highcharts.js"></script>
+        <script src="https://code.highcharts.com/modules/boost-canvas.js"></script>
+        <script>window.WebGLRenderingContext = void 0;</script>
+        <script src="https://code.highcharts.com/modules/boost.js"></script>
+        <div id="first-container"></div>
+        <div id="second-container"></div>
+    `, { waitUntil: 'networkidle' });
+
+    const result = await page.evaluate(async () => {
+        const Highcharts = (window as any).Highcharts,
+            data = Array.from({ length: 100000 }, (_, i) => i % 100);
+
+        let firstRendered: () => void;
+        const firstRenderedPromise = new Promise<void>((resolve) => {
+            firstRendered = resolve;
+        });
+        const getOptions = (rendered: () => void) => ({
+            chart: {
+                animation: false
+            },
+            plotOptions: {
+                series: {
+                    boostThreshold: 1,
+                    events: {
+                        renderedCanvas: rendered
+                    }
+                }
+            },
+            series: [{ data }]
+        });
+
+        const firstChart = Highcharts.chart(
+            'first-container',
+            getOptions(() => firstRendered())
+        );
+
+        await firstRenderedPromise;
+
+        const firstLoadingDiv = firstChart.loadingDiv,
+            secondChart = Highcharts.chart(
+                'second-container',
+                getOptions(() => void 0)
+            );
+
+        await new Promise((resolve) => setTimeout(resolve, 400));
+
+        const state = {
+            firstLoadingDivConnected: firstLoadingDiv.isConnected,
+            firstLoadingRemoved: firstChart.loadingDiv === null,
+            webGLSupported: Highcharts.hasWebGLSupport()
+        };
+
+        firstChart.destroy();
+        secondChart.destroy();
+
+        return state;
+    });
+
+    expect(result.webGLSupported).toBe(false);
+    expect(result.firstLoadingDivConnected).toBe(false);
+    expect(result.firstLoadingRemoved).toBe(true);
+});

--- a/ts/Extensions/BoostCanvas.ts
+++ b/ts/Extensions/BoostCanvas.ts
@@ -146,13 +146,7 @@ namespace BoostCanvas {
 
     const CHUNK_SIZE = 50000;
 
-    /* *
-     *
-     *  Variables
-     *
-     * */
-
-    let destroyLoadingDiv: number;
+    const loadingDestroyTimers = new WeakMap<Chart, number>();
 
     /* *
      *
@@ -583,7 +577,11 @@ namespace BoostCanvas {
                     opacity: 1
                 }
             });
-            internalClearTimeout(destroyLoadingDiv);
+            const loadingDestroyTimer = loadingDestroyTimers.get(chart);
+            if (typeof loadingDestroyTimer !== 'undefined') {
+                internalClearTimeout(loadingDestroyTimer);
+                loadingDestroyTimers.delete(chart);
+            }
             chart.showLoading('Drawing...');
             chart.options.loading = loadingOptions; // Reset
         }
@@ -907,12 +905,16 @@ namespace BoostCanvas {
                 loadingDiv.style.transition = 'opacity 250ms';
                 loadingDiv.opacity = 0 as any;
                 chart.loadingShown = false;
-                destroyLoadingDiv = setTimeout(function (): void {
-                    if (loadingDiv.parentNode) { // In exporting it is falsy
-                        loadingDiv.parentNode.removeChild(loadingDiv);
-                    }
-                    chart.loadingDiv = chart.loadingSpan = null as any;
-                }, 250);
+                loadingDestroyTimers.set(
+                    chart,
+                    setTimeout(function (): void {
+                        if (loadingDiv.parentNode) { // In exporting it is falsy
+                            loadingDiv.parentNode.removeChild(loadingDiv);
+                        }
+                        chart.loadingDiv = chart.loadingSpan = null as any;
+                        loadingDestroyTimers.delete(chart);
+                    }, 250)
+                );
             }
 
             // Go back to prototype, ready to build


### PR DESCRIPTION
Fixed #25105, canvas-boosted charts now remove their loading overlays independently when multiple charts render during the same fade window.

BoostCanvas previously stored one module-level destroy timeout. Starting chart B during chart A fade cleared A timeout and left its transparent loading element connected indefinitely. This change stores timers per Chart in a WeakMap, preserves same-chart cancellation, and removes completed entries.

The Playwright regression disables WebGL before Boost initializes, renders two real 100,000-point canvas fallback charts, and verifies chart A loading element is disconnected and its loading reference cleared. The untouched base leaves both behind.

Verification:
- Focused canvas-fallback Playwright regression in Chromium
- Highcharts TypeScript and ES5 build
- Changed-source and test ESLint
- Generated-sample validation
- Full pre-commit Node suite: 418 passed
- git diff --check