### PR TITLE
bugfix/25107-release-grid-data-source-abort-listeners

### DIFF
--- a/tests/grid/grid-pro/remote-data-provider.spec.ts
+++ b/tests/grid/grid-pro/remote-data-provider.spec.ts
@@ -98,6 +98,79 @@ async function openRemoteProviderFixture(page: Page): Promise<void> {
 }
 
 test.describe('RemoteDataProvider', () => {
+    test('releases completed data source abort listeners', async ({ page }) => {
+        await page.route('https://example.test/data*', async (route) => {
+            await route.fulfill({
+                json: {
+                    data: {
+                        id: [0],
+                        name: ['name-0']
+                    },
+                    meta: {
+                        rowIds: ['row-0'],
+                        totalRowCount: 1
+                    }
+                }
+            });
+        });
+        await openRemoteProviderFixture(page);
+
+        const listenerCounts = await page.evaluate(async () => {
+            const signalPrototype = AbortSignal.prototype;
+            // Preserve the native methods while instrumenting their receiver.
+            // eslint-disable-next-line @typescript-eslint/unbound-method
+            const nativeAdd = signalPrototype.addEventListener;
+            // eslint-disable-next-line @typescript-eslint/unbound-method
+            const nativeRemove = signalPrototype.removeEventListener;
+            let added = 0,
+                removed = 0;
+
+            signalPrototype.addEventListener = function (
+                type,
+                listener,
+                options
+            ): void {
+                if (type === 'abort') {
+                    ++added;
+                }
+                nativeAdd.call(this, type, listener, options);
+            };
+            signalPrototype.removeEventListener = function (
+                type,
+                listener,
+                options
+            ): void {
+                if (type === 'abort') {
+                    ++removed;
+                }
+                nativeRemove.call(this, type, listener, options);
+            };
+
+            const Grid = (window as any).Grid,
+                grid = await Grid.grid('container', {
+                    data: {
+                        providerType: 'remote',
+                        chunkSize: 1,
+                        dataSource: {
+                            fetchTimeout: 60000,
+                            urlTemplate: 'https://example.test/data'
+                        }
+                    }
+                }, true);
+
+            await grid.dataProvider.getValue('name', 0);
+            grid.destroy();
+
+            signalPrototype.addEventListener = nativeAdd;
+            signalPrototype.removeEventListener = nativeRemove;
+
+            return { added, removed };
+        });
+
+        expect(listenerCounts.added).toBeGreaterThan(0);
+        expect(listenerCounts.removed).toBe(listenerCounts.added);
+    });
+
     test('caches chunks and reuses them for reads', async ({ page }) => {
         const result = await runRemoteScenario(
             page,

--- a/ts/Grid/Pro/Data/DataSourceHelper.ts
+++ b/ts/Grid/Pro/Data/DataSourceHelper.ts
@@ -277,15 +277,21 @@ export async function dataSourceFetch(
         const url = buildUrl(options, state);
         const controller = fetchTimeout > 0 ? new AbortController() : null;
         const externalSignal = state.signal;
-        let timeoutId: ReturnType<typeof setTimeout> | undefined;
+        let externalAbortHandler: (() => void) | undefined,
+            timeoutId: ReturnType<typeof setTimeout> | undefined;
 
         if (controller && externalSignal) {
             if (externalSignal.aborted) {
                 controller.abort();
             } else {
-                externalSignal.addEventListener('abort', (): void => {
+                externalAbortHandler = (): void => {
                     controller.abort();
-                }, { once: true });
+                };
+                externalSignal.addEventListener(
+                    'abort',
+                    externalAbortHandler,
+                    { once: true }
+                );
             }
         }
 
@@ -305,8 +311,14 @@ export async function dataSourceFetch(
 
             return data;
         } finally {
-            if (timeoutId) {
+            if (typeof timeoutId !== 'undefined') {
                 clearTimeout(timeoutId);
+            }
+            if (externalSignal && externalAbortHandler) {
+                externalSignal.removeEventListener(
+                    'abort',
+                    externalAbortHandler
+                );
             }
         }
     } catch (err: unknown) {


### PR DESCRIPTION
Fixed #25107, completed Grid Pro data-source requests now detach the abort listener registered on the caller-owned request signal.

When fetchTimeout was enabled, dataSourceFetch created an internal controller and attached an anonymous listener to the RemoteDataProvider signal. The timeout was cleared on completion, but the listener and controller closure remained. This change retains the handler and removes it in the existing finally block on every completion path. It also treats timeout ID zero as valid.

The Playwright regression instruments real AbortSignal methods around successful serialized data-source requests. The untouched base records two registrations and zero removals; the fix records matching registration/removal counts.

Verification:
- Focused Grid Pro remote data regression
- Grid Lite/shared suite: 165 passed
- Grid Pro suite: 154 passed
- Dashboards suite: 36 passed, one existing skip
- Accessibility QUnit suite: 15 passed
- Grid and dependent product TypeScript builds
- Changed-file ESLint
- Full pre-commit Node suite: 418 passed
- git diff --check