### PR TITLE
bugfix/25109-clean-up-drag-listeners

### DIFF
--- a/samples/unit-tests/series-networkgraph/networkgraph/demo.js
+++ b/samples/unit-tests/series-networkgraph/networkgraph/demo.js
@@ -437,3 +437,50 @@ QUnit.test('#14397: Updating networkgraph series', assert => {
         'series.layout should be preserved through update()'
     );
 });
+
+QUnit.test('Destroying a network graph during node drag', assert => {
+    const chart = Highcharts.chart('container', {
+            chart: {
+                type: 'networkgraph'
+            },
+            plotOptions: {
+                networkgraph: {
+                    layoutAlgorithm: {
+                        enableSimulation: false
+                    }
+                }
+            },
+            series: [{
+                data: [['A', 'B']]
+            }]
+        }),
+        controller = new TestController(chart),
+        node = chart.series[0].nodes[0],
+        mouseupListenersBeforeDrag = document.hcEvents.mouseup.slice();
+
+    controller.moveTo(
+        chart.plotLeft + node.plotX,
+        chart.plotTop + node.plotY
+    );
+    controller.mouseDown(
+        chart.plotLeft + node.plotX,
+        chart.plotTop + node.plotY
+    );
+
+    assert.strictEqual(
+        document.hcEvents.mouseup.length,
+        mouseupListenersBeforeDrag.length + 1,
+        'Dragging should add a document mouseup listener'
+    );
+
+    const dragMouseupListener = document.hcEvents.mouseup.find(
+        listener => !mouseupListenersBeforeDrag.includes(listener)
+    );
+
+    chart.destroy();
+
+    assert.notOk(
+        document.hcEvents.mouseup.includes(dragMouseupListener),
+        'Destroying should remove the active drag listener'
+    );
+});

--- a/ts/Series/DragNodesComposition.ts
+++ b/ts/Series/DragNodesComposition.ts
@@ -117,10 +117,16 @@ function onChartLoad(
 ): void {
     const chart = this as DragNodesChart;
 
-    let mousedownUnbinder: Function,
-        mousemoveUnbinder: Function,
-        mouseupUnbinder: Function,
-        point: DragNodesPoint;
+    let mousedownUnbinder: (Function|undefined),
+        mousemoveUnbinder: (Function|undefined),
+        mouseupUnbinder: (Function|undefined),
+        point: (DragNodesPoint|undefined);
+
+    const unbindDragEvents = (): void => {
+        mousemoveUnbinder?.();
+        mouseupUnbinder?.();
+        mousemoveUnbinder = mouseupUnbinder = void 0;
+    };
 
     if (chart.container) {
         mousedownUnbinder = addEvent(
@@ -128,13 +134,7 @@ function onChartLoad(
             'mousedown',
             (event: PointerEvent): void => {
 
-                if (mousemoveUnbinder) {
-                    mousemoveUnbinder();
-                }
-
-                if (mouseupUnbinder) {
-                    mouseupUnbinder();
-                }
+                unbindDragEvents();
 
                 point = chart.hoverPoint;
 
@@ -158,9 +158,8 @@ function onChartLoad(
                         chart.container.ownerDocument,
                         'mouseup',
                         (e: PointerEvent): void => {
-                            mousemoveUnbinder();
-                            mouseupUnbinder();
-                            return point &&
+                            unbindDragEvents();
+                            point &&
                                 point.series &&
                                 point.series.onMouseUp(point, e);
                         }
@@ -171,7 +170,9 @@ function onChartLoad(
     }
 
     addEvent(chart, 'destroy', function (): void {
-        mousedownUnbinder();
+        mousedownUnbinder?.();
+        unbindDragEvents();
+        point = void 0;
     });
 }
 


### PR DESCRIPTION
Fixes #25109.

## What changed

- centralize cleanup of temporary node-drag listeners
- remove active container `mousemove` and document `mouseup` listeners when a chart is destroyed
- clear retained drag state after destruction
- add a focused regression for destroying a network graph between mousedown and mouseup

## Why

Previously, chart destruction removed only the permanent container mousedown listener. Destroying during an active node drag left the temporary listeners registered, retaining destroyed chart state and allowing callbacks after destruction.

## Verification

- focused networkgraph QUnit suite
- TypeScript and ES5 builds
- targeted ESLint
- `npm run test:precommit`
- full Node suite: 418 passed
- `git diff --check`

## Breaking changes

None.