### PR TITLE
bugfix/25111-destroy-navigator-chart

### DIFF
--- a/tests/dashboards/components.spec.ts
+++ b/tests/dashboards/components.spec.ts
@@ -1419,3 +1419,72 @@ test.describe('Highcharts Component', () => {
         expect(result.tableModifiedRowCount, 'DataTable should have 1 row after extremes changed.').toBe(1);
     });
 });
+
+test.describe('Navigator Component', () => {
+    test('destroys its chart with the component', async ({ page }) => {
+        await page.setContent(dashboardsWithHighchartsHTML, {
+            waitUntil: 'networkidle'
+        });
+
+        const result = await page.evaluate(async () => {
+            const Highcharts = (window as any).Highcharts;
+            const Dashboards = (window as any).Dashboards;
+
+            Dashboards.HighchartsPlugin.custom.connectHighcharts(Highcharts);
+            Dashboards.PluginHandler.addPlugin(Dashboards.HighchartsPlugin);
+
+            const dashboard = await Dashboards.board('container', {
+                gui: {
+                    layouts: [{
+                        rows: [{
+                            cells: [{ id: 'navigator-cell' }]
+                        }]
+                    }]
+                },
+                components: [{
+                    renderTo: 'navigator-cell',
+                    type: 'Navigator'
+                }]
+            }, true);
+
+            const component = dashboard.mountedComponents[0].component;
+            const chart = component.chart;
+            const redraw = chart.redraw;
+            const resize = component.resize;
+            let delayedRedraws = 0;
+            let delayedResizes = 0;
+            let destroyed = false;
+
+            chart.redraw = function (): void {
+                delayedRedraws++;
+                redraw.call(this);
+            };
+            component.resize = function (...args: any[]): void {
+                if (destroyed) {
+                    delayedResizes++;
+                }
+                resize.apply(this, args);
+            };
+
+            component.resize();
+            component.resizeTo(component.parentElement);
+            component.destroy();
+            destroyed = true;
+            Highcharts.fireEvent(dashboard, 'cellResize');
+
+            await new Promise(resolve => setTimeout(resolve, 50));
+
+            return {
+                chartDestroyed: typeof chart.index === 'undefined',
+                chartStillRegistered: Highcharts.charts.includes(chart),
+                delayedRedraws,
+                delayedResizes
+            };
+        });
+
+        expect(result.chartDestroyed).toBe(true);
+        expect(result.chartStillRegistered).toBe(false);
+        expect(result.delayedRedraws).toBe(0);
+        expect(result.delayedResizes).toBe(0);
+    });
+});

--- a/ts/Dashboards/Components/Component.ts
+++ b/ts/Dashboards/Components/Component.ts
@@ -295,11 +295,8 @@ abstract class Component {
      */
     public sync: Sync;
 
-    /**
-     * Timeouts for calls to `Component.resizeTo()`.
-     * @internal
-     */
-    protected resizeTimeouts: number[] = [];
+    /** @internal */
+    private resizeAnimationFrame?: number;
 
     /**
      * Timeouts for resizing the content. I.e. `chart.setSize()`.
@@ -485,13 +482,7 @@ abstract class Component {
      * @internal
      */
     private attachCellListeners(): void {
-        // Remove old listeners
-        while (this.cellListeners.length) {
-            const destroy = this.cellListeners.pop();
-            if (destroy) {
-                destroy();
-            }
-        }
+        this.detachCellListeners();
 
         if (
             this.cell &&
@@ -523,6 +514,13 @@ abstract class Component {
                 )
             );
 
+        }
+    }
+
+    /** @internal */
+    private detachCellListeners(): void {
+        while (this.cellListeners.length) {
+            this.cellListeners.pop()?.();
         }
     }
 
@@ -668,13 +666,11 @@ abstract class Component {
      * HTML element that is resized.
      */
     public resizeTo(element: HTMLElement): void {
-        while (this.resizeTimeouts.length) {
-            const timeout = this.resizeTimeouts.pop();
-            if (timeout) {
-                cancelAnimationFrame(timeout);
-            }
+        if (this.resizeAnimationFrame !== void 0) {
+            cancelAnimationFrame(this.resizeAnimationFrame);
         }
-        const timeoutID = requestAnimationFrame((): void => {
+        this.resizeAnimationFrame = requestAnimationFrame((): void => {
+            this.resizeAnimationFrame = void 0;
             const { width, height } = element.getBoundingClientRect();
             const padding = getPaddings(element);
             const margins = getMargins(element);
@@ -683,8 +679,6 @@ abstract class Component {
                 height - padding.y - margins.y
             );
         });
-
-        this.resizeTimeouts.push(timeoutID);
     }
 
     /**
@@ -921,6 +915,15 @@ abstract class Component {
 
         if (this.sync.isSyncing) {
             this.sync.stop();
+        }
+
+        this.resizeObserver?.disconnect();
+        this.resizeObserver = void 0;
+        this.detachCellListeners();
+
+        if (this.resizeAnimationFrame !== void 0) {
+            cancelAnimationFrame(this.resizeAnimationFrame);
+            this.resizeAnimationFrame = void 0;
         }
 
         while (this.element.firstChild) {

--- a/ts/Dashboards/Components/NavigatorComponent/NavigatorComponent.ts
+++ b/ts/Dashboards/Components/NavigatorComponent/NavigatorComponent.ts
@@ -165,6 +165,9 @@ class NavigatorComponent extends Component {
      */
     private categories?: string[];
 
+    /** @private */
+    private redrawTimeout?: number;
+
 
     /* *
      *
@@ -316,18 +319,12 @@ class NavigatorComponent extends Component {
 
     /** @private */
     private redrawNavigator(): void {
-        const timeouts = this.resizeTimeouts;
-
-        for (let i = 0, iEnd = timeouts.length; i < iEnd; ++i) {
-            clearTimeout(timeouts[i]);
-        }
-
-        timeouts.length = 0;
-
-        timeouts.push(setTimeout((): void => {
+        clearTimeout(this.redrawTimeout);
+        this.redrawTimeout = setTimeout((): void => {
+            this.redrawTimeout = void 0;
             this.adjustNavigator();
             this.chart.redraw();
-        }, 33));
+        }, 33);
     }
 
 
@@ -536,6 +533,17 @@ class NavigatorComponent extends Component {
 
     public getOptionsOnDrop(): Partial<Options> {
         return {};
+    }
+
+    /**
+     * Destroys the navigator component and its chart.
+     */
+    public override destroy(): void {
+        clearTimeout(this.redrawTimeout);
+        this.redrawTimeout = void 0;
+        this.chart.destroy();
+        this.chart = void 0 as any;
+        super.destroy();
     }
 }
 


### PR DESCRIPTION
Fixes #25111.

## What changed

- destroy and release the chart owned by `NavigatorComponent`
- cancel its pending delayed redraw
- replace the base component resize-frame array with one explicit RAF handle
- cancel that RAF and disconnect resize/cell listeners during component destruction
- add a browser regression covering chart registration, delayed redraw/resize work, and post-destroy cell-resize events

## Why

Navigator components previously inherited the base destructor without destroying their chart. The chart remained in `Highcharts.charts`, while pending redraw and resize callbacks could run against detached component DOM. Base component ResizeObserver and cell listeners also remained attached after destruction.

## Verification

- focused Navigator Playwright regression
- full Dashboards browser suite: 37 passed, one pre-existing skip
- full Grid Lite/shared/Pro browser suites: 318 passed
- accessibility QUnit suites: 15 passed
- TypeScript/ES5 and Dashboards builds
- Dashboards source and test ESLint
- generated-sample validation
- full pre-commit hook and Node suite: 418 passed
- `git diff --check`

## Breaking changes

None.