### PR TITLE
bugfix/25113-cancel-connector-table-event

### DIFF
--- a/tests/dashboards/components.spec.ts
+++ b/tests/dashboards/components.spec.ts
@@ -675,6 +675,61 @@ test.describe('Highcharts Component', () => {
         ]);
     });
 
+    test('ConnectorHandler does not emit after component destruction', async ({ page }) => {
+        await page.setContent(dashboardsWithHighchartsHTML, { waitUntil: 'networkidle' });
+
+        const result = await page.evaluate(async () => {
+            const Highcharts = (window as any).Highcharts;
+            const Dashboards = (window as any).Dashboards;
+
+            Dashboards.HighchartsPlugin.custom.connectHighcharts(Highcharts);
+            Dashboards.PluginHandler.addPlugin(Dashboards.HighchartsPlugin);
+
+            const board = await Dashboards.board('container', {
+                dataPool: {
+                    connectors: [{
+                        id: 'connector',
+                        type: 'JSON',
+                        data: [['x', 'y'], [1, 2]]
+                    }]
+                },
+                gui: {
+                    layouts: [{
+                        rows: [{
+                            cells: [{ id: 'cell' }]
+                        }]
+                    }]
+                },
+                components: [{
+                    renderTo: 'cell',
+                    type: 'Highcharts',
+                    connector: { id: 'connector' }
+                }]
+            }, true);
+            const component = board.mountedComponents[0].component;
+            const table = component.connectorHandlers[0].connector.getTable();
+            const originalEmit = component.emit;
+            let destroyed = false;
+            let emissionsAfterDestroy = 0;
+
+            component.emit = function (...args: any[]): void {
+                if (destroyed) {
+                    ++emissionsAfterDestroy;
+                }
+                originalEmit.apply(this, args);
+            };
+
+            table.setCell('y', 0, 3);
+            component.destroy();
+            destroyed = true;
+            await new Promise((resolve): number => setTimeout(resolve, 20));
+
+            return emissionsAfterDestroy;
+        });
+
+        expect(result).toBe(0);
+    });
+
     test('HighchartsComponent resizing', async ({ page }) => {
         await page.setContent(dashboardsWithHighchartsHTML, { waitUntil: 'networkidle' });
 

--- a/ts/Dashboards/Components/ConnectorHandler.ts
+++ b/ts/Dashboards/Components/ConnectorHandler.ts
@@ -379,6 +379,8 @@ class ConnectorHandler {
      */
     public destroy(): void {
         this.destroyed = true;
+        clearTimeout(this.tableEventTimeout);
+        this.tableEventTimeout = void 0;
         this.removeConnectorAssignment();
         this.removeTableEvents();
     }


### PR DESCRIPTION
Fixes #25113.

## What changed

- cancel a pending connector table-event timeout when its handler is destroyed
- release the stored timeout handle during teardown
- add a browser regression covering a table change immediately followed by component destruction

## Why

`ConnectorHandler` removed its table listeners during destruction but left an already queued table-change callback active. That callback could call `component.emit(...)` on the next timer tick after the component and its event state had been torn down.

## Verification

- exact regression failed on current `master` with one post-destroy emission and passes with the fix
- full Dashboards browser suite: 37 passed, one pre-existing skip
- Dashboards TypeScript build
- Dashboards source and test ESLint
- accessibility QUnit suites: 15 passed
- generated-sample validation
- full pre-commit hook and Node suite: 418 passed
- `git diff --check`

## Breaking changes

None.