### PR TITLE
bugfix/25115-stop-live-data-polling

### DIFF
--- a/samples/unit-tests/data/general/demo.js
+++ b/samples/unit-tests/data/general/demo.js
@@ -447,3 +447,69 @@ QUnit.test('Updating with firstRowAsNames and dataGrouping', function (assert) {
         'having data grouping options.'
     );
 });
+
+QUnit.test('Destroy clears live data polling timeout', function (assert) {
+    const win = Highcharts.win,
+        OriginalXMLHttpRequest = win.XMLHttpRequest,
+        originalSetTimeout = win.setTimeout,
+        originalClearTimeout = win.clearTimeout,
+        pendingPollingTimeouts = new Set();
+
+    let nextTimeoutId = 1,
+        pollingTimeoutId;
+
+    function FakeXMLHttpRequest() {
+        this.readyState = 0;
+        this.status = 0;
+        this.responseText = '';
+    }
+
+    FakeXMLHttpRequest.prototype.open = function () {};
+    FakeXMLHttpRequest.prototype.setRequestHeader = function () {};
+    FakeXMLHttpRequest.prototype.send = function () {
+        this.readyState = 4;
+        this.status = 200;
+        this.responseText = 'x,y\n1,2';
+        this.onreadystatechange();
+    };
+
+    win.XMLHttpRequest = FakeXMLHttpRequest;
+    win.setTimeout = function (callback, delay) {
+        if (delay === 1000) {
+            pollingTimeoutId = nextTimeoutId++;
+            pendingPollingTimeouts.add(pollingTimeoutId);
+            return pollingTimeoutId;
+        }
+        return originalSetTimeout.apply(this, arguments);
+    };
+    win.clearTimeout = function (timeoutId) {
+        pendingPollingTimeouts.delete(timeoutId);
+        return originalClearTimeout(timeoutId);
+    };
+
+    try {
+        const chart = Highcharts.chart('container', {
+            data: {
+                csvURL: '/fake.csv',
+                enablePolling: true,
+                dataRefreshRate: 1
+            }
+        });
+
+        assert.ok(
+            pendingPollingTimeouts.has(pollingTimeoutId),
+            'Polling timeout should be scheduled'
+        );
+
+        chart.destroy();
+
+        assert.notOk(
+            pendingPollingTimeouts.has(pollingTimeoutId),
+            'Polling timeout should be cleared'
+        );
+    } finally {
+        win.XMLHttpRequest = OriginalXMLHttpRequest;
+        win.setTimeout = originalSetTimeout;
+        win.clearTimeout = originalClearTimeout;
+    }
+});

--- a/ts/Extensions/Data.ts
+++ b/ts/Extensions/Data.ts
@@ -2618,6 +2618,20 @@ addEvent(
     }
 );
 
+// Stop live-data polling when the owning chart is destroyed.
+addEvent(
+    Chart,
+    'destroy',
+    function (): void {
+        const data = this.data;
+
+        if (data?.liveDataTimeout !== void 0) {
+            internalClearTimeout(data.liveDataTimeout);
+            data.liveDataTimeout = void 0;
+        }
+    }
+);
+
 // Extend Chart.init so that the Chart constructor accepts a new configuration
 // option group, data.
 addEvent(


### PR DESCRIPTION
Fixes #25115.

## What changed

- clear the Data module live-polling timeout from the chart destroy lifecycle
- release the stored timeout handle after cancellation
- add a deterministic QUnit regression with an instrumented request and timer boundary

## Why

The Data module cleared its polling timer when data options were reinitialized, but not when the owning chart was destroyed. A URL-backed chart destroyed between polls therefore retained the scheduled callback and could start another network request after teardown. The same timeout field is used by CSV, row, column, and Google Sheets polling.

## Verification

- exact regression fails on current `master` because the polling timeout remains active and passes with the fix
- focused Data-module Chromium QUnit suite
- TypeScript and ES5 builds
- changed source/test ESLint
- generated-sample validation
- full pre-commit hook and Node suite: 418 passed
- `git diff --check`

## Breaking changes

None.