### PR TITLE
bugfix/25117-clear-announcer-timers

### DIFF
--- a/samples/unit-tests/accessibility/newdataannouncer/demo.js
+++ b/samples/unit-tests/accessibility/newdataannouncer/demo.js
@@ -72,3 +72,71 @@ QUnit.test('Chart with newDataAnnouncer', function (assert) {
         done();
     }, 3200); // make sure clearAnnouncementTimerRegion is done
 });
+
+QUnit.test('Chart destruction clears announcer timers', function (assert) {
+    var chart = Highcharts.chart('container', {
+            chart: {
+                animation: false
+            },
+            accessibility: {
+                announceNewData: {
+                    enabled: true
+                }
+            },
+            series: [{
+                data: [1, 2, 3]
+            }]
+        }),
+        win = Highcharts.win,
+        originalSetTimeout = win.setTimeout,
+        originalClearTimeout = win.clearTimeout,
+        pendingTimeouts = new Set(),
+        nextTimeoutId = 1,
+        newDataAnnouncer = chart.accessibility.components.series
+            .newDataAnnouncer,
+        clearRegionTimer,
+        queuedAnnouncementTimer;
+
+    win.setTimeout = function () {
+        var timeoutId = nextTimeoutId++;
+        pendingTimeouts.add(timeoutId);
+        return timeoutId;
+    };
+    win.clearTimeout = function (timeoutId) {
+        pendingTimeouts.delete(timeoutId);
+    };
+
+    try {
+        newDataAnnouncer.announcer.announce('Announcement');
+        clearRegionTimer = newDataAnnouncer.announcer
+            .clearAnnouncementRegionTimer;
+        chart.series[0].addPoint(4);
+        queuedAnnouncementTimer = newDataAnnouncer.queuedAnnouncementTimer;
+
+        assert.ok(
+            pendingTimeouts.has(clearRegionTimer),
+            'Announce-region cleanup should be scheduled'
+        );
+        assert.ok(
+            pendingTimeouts.has(queuedAnnouncementTimer),
+            'New-data announcement should be scheduled'
+        );
+
+        chart.destroy();
+
+        assert.notOk(
+            pendingTimeouts.has(clearRegionTimer),
+            'Announce-region cleanup should be cancelled'
+        );
+        assert.notOk(
+            pendingTimeouts.has(queuedAnnouncementTimer),
+            'New-data announcement should be cancelled'
+        );
+    } finally {
+        win.setTimeout = originalSetTimeout;
+        win.clearTimeout = originalClearTimeout;
+        if (chart.renderer) {
+            chart.destroy();
+        }
+    }
+});

--- a/ts/Accessibility/Components/SeriesComponent/NewDataAnnouncer.ts
+++ b/ts/Accessibility/Components/SeriesComponent/NewDataAnnouncer.ts
@@ -176,6 +176,9 @@ class NewDataAnnouncer {
      * @private
      */
     public destroy(): void {
+        internalClearTimeout(this.queuedAnnouncementTimer);
+        delete this.queuedAnnouncement;
+        delete this.queuedAnnouncementTimer;
         this.eventProvider.removeAddedEvents();
         this.announcer.destroy();
     }

--- a/ts/Accessibility/Utils/Announcer.ts
+++ b/ts/Accessibility/Utils/Announcer.ts
@@ -89,6 +89,8 @@ class Announcer {
      * */
 
     public destroy(): void {
+        internalClearTimeout(this.clearAnnouncementRegionTimer);
+        delete this.clearAnnouncementRegionTimer;
         this.domElementProvider.destroyCreatedElements();
     }
 


### PR DESCRIPTION
Fixes #25117.

## What changed

- cancel and release queued new-data announcement work when `NewDataAnnouncer` is destroyed
- cancel and release delayed live-region cleanup when `Announcer` is destroyed
- release the queued announcement payload during teardown
- add a deterministic QUnit regression covering both timer paths

## Why

The accessibility destructors removed their event and DOM resources but left pending announcement timers active. Those callbacks could execute after chart teardown and retained announcement, announcer, and chart state until they fired.

## Verification

- exact regression fails on current `master` with both timers retained and passes with the fix
- complete accessibility Chromium QUnit suite: 15 passed
- TypeScript and ES5 builds
- changed source/test ESLint
- generated-sample validation
- full pre-commit hook and Node suite: 418 passed
- `git diff --check`

## Breaking changes

None.