### PR TITLE
bugfix/25119-fix-chain-modifier-management

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/Modifiers/ChainModifier.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/Modifiers/ChainModifier.test.ts
@@ -3,11 +3,28 @@ import { strictEqual, deepStrictEqual } from 'node:assert';
 
 import DataTable from '../../../../../ts/Data/DataTable.js';
 import ChainModifier from '../../../../../ts/Data/Modifiers/ChainModifier.js';
+import DataModifier from '../../../../../ts/Data/Modifiers/DataModifier.js';
 // Import these to register them with DataModifier.types
 import '../../../../../ts/Data/Modifiers/FilterModifier.js';
 import '../../../../../ts/Data/Modifiers/RangeModifier.js';
 
 describe('ChainModifier', () => {
+
+    class RecordingModifier extends DataModifier {
+        public readonly options = { type: 'Chain' as const };
+
+        public constructor(
+            private readonly name: string,
+            private readonly calls: string[]
+        ) {
+            super();
+        }
+
+        public modifyTable(table: DataTable): DataTable {
+            this.calls.push(this.name);
+            return table;
+        }
+    }
 
     // Note: benchmark test requires browser environment (uses window.performance)
     // Skipped in Node.js environment
@@ -70,6 +87,62 @@ describe('ChainModifier', () => {
                 [1, 2, 3],
                 'Modified table should have expected original row indexes.'
             );
+        });
+
+        it('should preserve a reversed chain across repeated modifications', () => {
+            const calls: string[] = [];
+            const first = new RecordingModifier('first', calls);
+            const second = new RecordingModifier('second', calls);
+            const modifier = new ChainModifier(
+                { reverse: true },
+                first,
+                second
+            );
+            const table = new DataTable();
+
+            modifier.modifyTable(table);
+            modifier.modifyTable(table);
+
+            deepStrictEqual(calls, [
+                'second', 'first', 'second', 'first'
+            ]);
+            deepStrictEqual(modifier.chain, [first, second]);
+        });
+    });
+
+    describe('chain management', () => {
+        it('should emit the after-add event', () => {
+            const events: string[] = [];
+            const modifier = new ChainModifier();
+            const added = new RecordingModifier('added', []);
+
+            modifier.on('addModifier', (): void => {
+                events.push('addModifier');
+            });
+            modifier.on('afterAddModifier', (): void => {
+                events.push('afterAddModifier');
+            });
+            modifier.add(added);
+
+            deepStrictEqual(events, ['addModifier', 'afterAddModifier']);
+        });
+
+        it('should remove every matching modifier and ignore an absent one', () => {
+            const first = new RecordingModifier('first', []);
+            const second = new RecordingModifier('second', []);
+            const absent = new RecordingModifier('absent', []);
+            const modifier = new ChainModifier(
+                void 0,
+                first,
+                second,
+                first
+            );
+
+            modifier.remove(first);
+            deepStrictEqual(modifier.chain, [second]);
+
+            modifier.remove(absent);
+            deepStrictEqual(modifier.chain, [second]);
         });
     });
 

--- a/ts/Data/Modifiers/ChainModifier.ts
+++ b/ts/Data/Modifiers/ChainModifier.ts
@@ -158,7 +158,7 @@ class ChainModifier extends DataModifier {
         this.chain.push(modifier);
 
         this.emit({
-            type: 'addModifier',
+            type: 'afterAddModifier',
             detail: eventDetail,
             modifier
         });
@@ -264,7 +264,7 @@ class ChainModifier extends DataModifier {
 
         const modifiers = (
             chain.options.reverse ?
-                chain.chain.reverse() :
+                chain.chain.slice().reverse() :
                 chain.chain.slice()
         );
 
@@ -314,7 +314,11 @@ class ChainModifier extends DataModifier {
             modifier
         });
 
-        modifiers.splice(modifiers.indexOf(modifier), 1);
+        for (let i = modifiers.length - 1; i >= 0; --i) {
+            if (modifiers[i] === modifier) {
+                modifiers.splice(i, 1);
+            }
+        }
 
         this.emit({
             type: 'afterRemoveModifier',


### PR DESCRIPTION
## Summary
- preserve the configured modifier order when repeatedly executing a reversed chain
- emit the documented `afterAddModifier` event after adding a modifier
- remove every occurrence of a modifier while leaving the chain unchanged when it is absent
- add regression coverage for all three behaviors

## Breaking changes
None to the public API. This corrects inconsistent behavior: reversed chains now remain stable across calls, `remove` follows its documented all-occurrences semantics, and `add` emits the documented after-event.

## Verification
- `npm run test:precommit` (421 Node tests, 391 affected QUnit tests, 36 Dashboard tests with 1 existing skip)
- `npx tsc -p ts --noEmit`
- `npx tsc -p ts/masters-es5 --noEmit`
- `npx eslint ts/Data/Modifiers/ChainModifier.ts`
- `git diff --check`

Fixes #25119