### PR TITLE
bugfix/25121-preserve-invert-modifier-source

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/Modifiers/InvertModifier.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/Modifiers/InvertModifier.test.ts
@@ -46,7 +46,15 @@ describe('InvertModifier', () => {
                 }
             }));
 
-            const modified = await modifier.modify(table.getModified().clone());
+            const inverted = table.getModified().clone();
+            const invertedColumns = inverted.getColumns();
+            const modified = await modifier.modify(inverted);
+
+            deepStrictEqual(
+                inverted.getColumns(),
+                invertedColumns,
+                'The already inverted source table should remain unchanged.'
+            );
 
             deepStrictEqual(
                 modified.getModified().getColumns(),

--- a/ts/Data/Modifiers/InvertModifier.ts
+++ b/ts/Data/Modifiers/InvertModifier.ts
@@ -123,8 +123,10 @@ class InvertModifier extends DataModifier {
 
         if (table.hasColumns(['columnIds'])) { // Inverted table
             const columnIdsColumn = (
-                    (table.deleteColumns(['columnIds']) || {})
-                        .columnIds || []
+                    table.getColumn('columnIds') || []
+                ),
+                sourceColumnIds = table.getColumnIds().filter(
+                    (columnId): boolean => columnId !== 'columnIds'
                 ),
                 columns: DataTableColumnCollection = {},
                 columnIds: Array<string> = [];
@@ -140,7 +142,7 @@ class InvertModifier extends DataModifier {
                 i < iEnd;
                 ++i
             ) {
-                row = table.getRow(i);
+                row = table.getRow(i, sourceColumnIds);
                 if (row) {
                     columns[columnIds[i]] = row;
                 }


### PR DESCRIPTION
## Summary
- read the inverted marker column without deleting it from the source table
- rebuild restored rows from data columns only
- add regression coverage proving the source remains unchanged while round-trip output is preserved

## Breaking changes
None. This restores the documented `modify()` isolation contract by preventing an unintended source-table mutation.

## Verification
- `npm run test:precommit` (418 Node tests, 391 affected QUnit tests, 36 Dashboard tests with 1 existing skip)
- `npx tsc -p ts --noEmit`
- `npx tsc -p ts/masters-es5 --noEmit`
- `npx eslint ts/Data/Modifiers/InvertModifier.ts`
- `git diff --check`

Fixes #25121