### PR TITLE
bugfix/25123-complete-filter-modifier-lifecycle

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/Modifiers/FilterModifier.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/Modifiers/FilterModifier.test.ts
@@ -15,6 +15,10 @@ describe('FilterModifier', () => {
                 }
             });
             const modifier = new FilterModifier();
+            const events: string[] = [];
+
+            modifier.on('modify', (): void => events.push('modify'));
+            modifier.on('afterModify', (): void => events.push('afterModify'));
 
             await modifier.modify(table);
 
@@ -22,6 +26,11 @@ describe('FilterModifier', () => {
                 table.getModified().getColumns(),
                 { x: [1, 2, 3], name: ['A', 'B', 'C'] },
                 'With no condition, all rows are kept.'
+            );
+            deepStrictEqual(
+                events,
+                ['modify', 'afterModify'],
+                'The no-op path should complete the modifier event lifecycle.'
             );
         });
 

--- a/ts/Data/Modifiers/FilterModifier.ts
+++ b/ts/Data/Modifiers/FilterModifier.ts
@@ -211,6 +211,7 @@ class FilterModifier extends DataModifier {
         const { condition } = modifier.options;
         if (!condition) {
             // If no condition is set, return the unmodified table.
+            modifier.emit({ type: 'afterModify', detail: eventDetail, table });
             return table;
         }
 


### PR DESCRIPTION
## Summary
- emit `afterModify` when FilterModifier has no configured condition
- preserve the existing no-op table result
- add regression coverage for the complete event pair

## Breaking changes
None. This adds the missing documented completion event to a successful no-op path and prevents event-driven callers from remaining incomplete.

## Verification
- full commit hook (418 Node tests, 391 affected QUnit tests, 36 Dashboard tests with 1 existing skip)
- `npx tsc -p ts --noEmit`
- `npx tsc -p ts/masters-es5 --noEmit`
- `npx eslint ts/Data/Modifiers/FilterModifier.ts`
- `git diff --check`

Fixes #25123