### PR TITLE
bugfix/25125-stabilize-modifier-benchmarks

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/Modifiers/RangeModifier.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/Modifiers/RangeModifier.test.ts
@@ -1,10 +1,23 @@
 import { describe, it } from 'node:test';
-import { deepStrictEqual, strictEqual } from 'node:assert';
+import { deepStrictEqual, strictEqual, throws } from 'node:assert';
 
 import DataTable from '../../../../../ts/Data/DataTable.js';
+import DataModifier from '../../../../../ts/Data/Modifiers/DataModifier.js';
 import RangeModifier from '../../../../../ts/Data/Modifiers/RangeModifier.js';
 
 describe('RangeModifier', () => {
+
+    class RecordingModifier extends DataModifier {
+        public readonly options = { type: 'Range' as const };
+        public calls = 0;
+
+        public modifyTable(table: DataTable): DataTable {
+            ++this.calls;
+            this.emit({ type: 'modify', table });
+            this.emit({ type: 'afterModify', table });
+            return table;
+        }
+    }
 
     describe('modify', () => {
         it('should keep all rows when no range is specified', async () => {
@@ -104,6 +117,50 @@ describe('RangeModifier', () => {
                 originalRowIndexes,
                 [4],
                 'Original row indexes should be set correctly.'
+            );
+        });
+    });
+
+    describe('benchmark', () => {
+        it('should isolate the source table and repeated runs', () => {
+            const table = new DataTable({ columns: { x: [1, 2, 3] } });
+            const sourceColumns = table.getColumns();
+            const rangeModifier = new RangeModifier({ start: 1 });
+
+            strictEqual(rangeModifier.benchmark(table).length, 1);
+            deepStrictEqual(table.getColumns(), sourceColumns);
+
+            const modifier = new RecordingModifier();
+            let benchmarkEvents = 0;
+            let iterationEvents = 0;
+
+            modifier.on('afterBenchmark', (): void => ++benchmarkEvents);
+            modifier.on(
+                'afterBenchmarkIteration',
+                (): void => ++iterationEvents
+            );
+
+            strictEqual(modifier.benchmark(table, { iterations: 2 }).length, 2);
+            strictEqual(modifier.benchmark(table, { iterations: 1 }).length, 1);
+            strictEqual(modifier.calls, 3);
+            strictEqual(iterationEvents, 3);
+            strictEqual(benchmarkEvents, 2);
+        });
+
+        it('should handle bounded iteration counts without recursion', () => {
+            const table = new DataTable();
+            const modifier = new RecordingModifier();
+
+            strictEqual(modifier.benchmark(table, { iterations: 0 }).length, 0);
+            strictEqual(
+                modifier.benchmark(table, { iterations: 10_000 }).length,
+                10_000
+            );
+            throws(
+                (): void => {
+                    modifier.benchmark(table, { iterations: 1.5 });
+                },
+                /non-negative integer/
             );
         });
     });

--- a/ts/Data/Modifiers/DataModifier.ts
+++ b/ts/Data/Modifiers/DataModifier.ts
@@ -32,7 +32,7 @@ import type DataModifierOptions from './DataModifierOptions';
 import type DataTable from '../DataTable';
 import type { DataModifierTypes } from './DataModifierType';
 
-import { addEvent, fireEvent, merge } from '../../Shared/Utilities.js';
+import { addEvent, fireEvent } from '../../Shared/Utilities.js';
 
 /* *
  *
@@ -120,54 +120,47 @@ abstract class DataModifier implements DataEventEmitter<DataModifierEvent> {
         dataTable: DataTable,
         options?: BenchmarkOptions
     ): Array<number> {
-        const results: Array<number> = [];
-        const modifier = this;
-        const execute = (): void => {
-            modifier.modifyTable(dataTable);
-            modifier.emit<DataModifierEvent>({
-                type: 'afterBenchmarkIteration'
-            });
-        };
+        const modifier = this,
+            iterations = options?.iterations ?? 1,
+            results: Array<number> = [];
 
-        const defaultOptions = {
-            iterations: 1
-        };
+        if (!Number.isInteger(iterations) || iterations < 0) {
+            throw new Error(
+                'Benchmark iterations must be a non-negative integer.'
+            );
+        }
 
-        const { iterations } = merge(
-            defaultOptions,
-            options
-        );
+        if (iterations && !dataTable.modified) {
+            dataTable.modified = dataTable.clone();
+        }
 
-        modifier.on('afterBenchmarkIteration', (): void => {
-            if (results.length === iterations) {
-                modifier.emit<DataModifierEvent>({
-                    type: 'afterBenchmark',
-                    results
-                });
-                return;
-            }
-
-            // Run again
-            execute();
-        });
-
-        const times = {
-            startTime: 0,
-            endTime: 0
-        };
+        let startTime = 0;
 
         // Add timers
-        modifier.on('modify', (): void => {
-            times.startTime = window.performance.now();
+        const removeModifyTimer = modifier.on('modify', (): void => {
+            startTime = globalThis.performance.now();
         });
 
-        modifier.on('afterModify', (): void => {
-            times.endTime = window.performance.now();
-            results.push(times.endTime - times.startTime);
+        const removeAfterModifyTimer = modifier.on('afterModify', (): void => {
+            results.push(globalThis.performance.now() - startTime);
         });
 
-        // Initial run
-        execute();
+        try {
+            for (let i = 0; i < iterations; ++i) {
+                modifier.modifyTable(dataTable);
+                modifier.emit<DataModifierEvent>({
+                    type: 'afterBenchmarkIteration'
+                });
+            }
+        } finally {
+            removeModifyTimer();
+            removeAfterModifyTimer();
+        }
+
+        modifier.emit<DataModifierEvent>({
+            type: 'afterBenchmark',
+            results
+        });
 
         return results;
     }


### PR DESCRIPTION
## Summary
- create the normal modified-table clone before benchmarking a modifier
- replace recursive event-driven iteration with a bounded loop
- remove temporary timing listeners after every run, including failures
- support zero iterations, validate non-negative integer counts, and use `globalThis.performance`
- add regressions for source isolation, repeated runs, zero iterations, invalid counts, and 10,000 iterations

## Breaking changes
Invalid negative or fractional `iterations` now throw a descriptive error instead of entering non-terminating recursive execution. Valid non-negative integer inputs retain the synchronous result and benchmark event sequence; zero now correctly performs zero iterations.

## Verification
- full commit hook (420 Node tests, 391 affected QUnit tests, 36 Dashboard tests with 1 existing skip)
- `npx tsc -p ts --noEmit`
- `npx tsc -p ts/masters-es5 --noEmit`
- `npx eslint ts/Data/Modifiers/DataModifier.ts`
- `git diff --check`

Fixes #25125