### PR TITLE
bugfix/25127-preserve-zero-range-end

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/Modifiers/RangeModifier.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/Modifiers/RangeModifier.test.ts
@@ -75,6 +75,15 @@ describe('RangeModifier', () => {
             );
         });
 
+        it('should preserve an explicit zero end', async () => {
+            const table = new DataTable({ columns: { x: [1, 2, 3] } });
+            const modifier = new RangeModifier({ start: 0, end: 0 });
+
+            await modifier.modify(table);
+
+            strictEqual(table.getModified().getRowCount(), 0);
+        });
+
         it('should set row indexes correctly', async () => {
             const table = new DataTable({
                 columns: {

--- a/ts/Data/Modifiers/RangeModifier.ts
+++ b/ts/Data/Modifiers/RangeModifier.ts
@@ -130,8 +130,8 @@ class RangeModifier extends DataModifier {
         modifier.emit({ type: 'modify', detail: eventDetail, table });
 
         let { start, end } = modifier.options;
-        start = Math.max(0, start || 0);
-        end = Math.min(end || Infinity, table.getRowCount());
+        start = Math.max(0, start ?? 0);
+        end = Math.min(end ?? Infinity, table.getRowCount());
         const length = Math.max(end - start, 0);
 
         const modified = table.getModified();


### PR DESCRIPTION
## Summary
- distinguish an explicit zero range endpoint from an omitted endpoint
- preserve existing defaults for `undefined` start/end values
- add regression coverage for `{ start: 0, end: 0 }`

## Breaking changes
None to the API. This corrects an invalid result for the valid zero endpoint: the half-open range `[0, 0)` now contains zero rows instead of the entire table.

## Verification
- full commit hook (419 Node tests, 391 affected QUnit tests, 36 Dashboard tests with 1 existing skip)
- `npx tsc -p ts --noEmit`
- `npx tsc -p ts/masters-es5 --noEmit`
- `npx eslint ts/Data/Modifiers/RangeModifier.ts`
- `git diff --check`

Fixes #25127