### PR TITLE
bugfix/25129-reject-unknown-connectors

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/DataPool.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/DataPool.test.ts
@@ -1,5 +1,11 @@
 import { describe, it } from 'node:test';
-import { deepStrictEqual, strictEqual, notStrictEqual, ok } from 'node:assert';
+import {
+    deepStrictEqual,
+    strictEqual,
+    notStrictEqual,
+    ok,
+    rejects
+} from 'node:assert';
 
 import DataPool from '../../../../ts/Data/DataPool.js';
 // Import connectors to register them with DataConnector
@@ -132,6 +138,17 @@ describe('DataPool', () => {
     });
 
     describe('promises', () => {
+        it('should reject every request for an unknown connector', async () => {
+            const dataPool = new DataPool();
+            const first = dataPool.getConnector('missing');
+            const second = dataPool.getConnector('missing');
+
+            await Promise.all([
+                rejects(first, /Connector 'missing' not found/),
+                rejects(second, /Connector 'missing' not found/)
+            ]);
+        });
+
         it('should resolve second connector request after first one', async () => {
             // Using a simpler modifier chain (the old RangeModifier API with conditions
             // has been deprecated/removed)

--- a/ts/Data/DataPool.ts
+++ b/ts/Data/DataPool.ts
@@ -138,13 +138,15 @@ class DataPool implements DataEventEmitter<Event> {
 
         // Start loading
         if (!waitingList) {
-            waitingList = this.waiting[connectorId] = [];
-
             const connectorOptions = this.getConnectorOptions(connectorId);
 
             if (!connectorOptions) {
-                throw new Error(`Connector '${connectorId}' not found.`);
+                return Promise.reject(
+                    new Error(`Connector '${connectorId}' not found.`)
+                );
             }
+
+            waitingList = this.waiting[connectorId] = [];
 
             // eslint-disable-next-line @typescript-eslint/no-floating-promises
             this


### PR DESCRIPTION
## Summary
- reject unknown connector IDs through the documented Promise result
- avoid creating a stale waiting-list entry before connector options are validated
- verify repeated missing-ID requests both reject instead of leaving the second pending

## Breaking changes
None to the API. A missing connector now rejects asynchronously through the returned Promise instead of throwing synchronously on the first call and leaving later calls permanently pending.

## Verification
- full commit hook (419 Node tests, 391 affected QUnit tests, 36 Dashboard tests with 1 existing skip)
- `npx tsc -p ts --noEmit`
- `npx tsc -p ts/masters-es5 --noEmit`
- `npx eslint ts/Data/DataPool.ts`
- `git diff --check`

Fixes #25129