### PR TITLE
bugfix/25131-retain-updated-connector-options

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/DataPool.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/DataPool.test.ts
@@ -169,6 +169,25 @@ describe('DataPool', () => {
     });
 
     describe('replacement', () => {
+        it('should retain options after updating a loaded connector', async () => {
+            const dataPool = new DataPool({
+                connectors: [{
+                    id: 'My Data',
+                    type: 'CSV',
+                    csv: 'a\n1'
+                }]
+            });
+
+            await dataPool.getConnector('My Data');
+            await dataPool.setConnectorOptions({
+                id: 'My Data',
+                type: 'CSV',
+                csv: 'a\n2'
+            }, true);
+
+            deepStrictEqual(dataPool.getConnectorIds(), ['My Data']);
+        });
+
         it('should track new vs loaded connectors', async () => {
             const dataPool = new DataPool({
                 connectors: [{

--- a/ts/Data/DataPool.ts
+++ b/ts/Data/DataPool.ts
@@ -365,9 +365,7 @@ class DataPool implements DataEventEmitter<Event> {
             }
         }
 
-        if (!existingConnector) {
-            connectorsOptions.push(options);
-        }
+        connectorsOptions.push(existingConnector?.options ?? options);
 
         this.emit({
             type: 'afterSetConnectorOptions',


### PR DESCRIPTION
## Summary
- restore an updated loaded connector's merged options to the pool registry
- retain the connector ID after `setConnectorOptions(..., true)`
- add focused regression coverage for the loaded-update path

## Breaking changes
None. This restores the connector configuration that was unintentionally removed after a successful in-place update.

## Verification
- full commit hook (419 Node tests, 391 affected QUnit tests, 36 Dashboard tests with 1 existing skip)
- `npx tsc -p ts --noEmit`
- `npx tsc -p ts/masters-es5 --noEmit`
- `npx eslint ts/Data/DataPool.ts`
- `git diff --check`

Fixes #25131