### PR TITLE
bugfix/25133-handle-missing-row-search-columns

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/DataTable.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/DataTable.test.ts
@@ -512,6 +512,14 @@ describe('DataTable', () => {
         });
     });
 
+    describe('hasRowWith', () => {
+        it('should return false for a missing numeric column', () => {
+            const table = new DataTable({ columns: { x: [1] } });
+
+            strictEqual(table.hasRowWith('missing', 1), false);
+        });
+    });
+
     describe('setRows', () => {
         it('should maintain row data when cloning and resetting', () => {
             const table = new DataTable({

--- a/ts/Data/DataTable.ts
+++ b/ts/Data/DataTable.ts
@@ -840,7 +840,11 @@ class DataTable extends DataTableCore implements DataEventEmitter<Event> {
         }
 
         // Typed array
-        if (defined(cellValue) && Number.isFinite(cellValue)) {
+        if (
+            column &&
+            defined(cellValue) &&
+            Number.isFinite(cellValue)
+        ) {
             return (column.indexOf(+cellValue) !== -1);
         }
 


### PR DESCRIPTION
## Summary
- guard the typed-array lookup path when the requested DataTable column is absent
- return `false` consistently for missing columns and finite numeric search values
- add focused regression coverage

## Breaking changes
None. This replaces an unintended TypeError with the documented boolean result for a missing column.

## Verification
- full commit hook (419 Node tests, 391 affected QUnit tests, 36 Dashboard tests with 1 existing skip)
- `npx tsc -p ts --noEmit`
- `npx tsc -p ts/masters-es5 --noEmit`
- `npx eslint ts/Data/DataTable.ts`
- `git diff --check`

Fixes #25133