### PR TITLE
bugfix/25135-support-prototype-connector-ids

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/DataPool.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/DataPool.test.ts
@@ -132,6 +132,26 @@ describe('DataPool', () => {
     });
 
     describe('promises', () => {
+        it('should load connectors with prototype-named IDs', async () => {
+            const dataPool = new DataPool({
+                connectors: ['toString', '__proto__'].map((id) => ({
+                    id,
+                    type: 'CSV' as const,
+                    csv: 'a\n1'
+                }))
+            });
+
+            const connectors = await Promise.all([
+                dataPool.getConnector('toString'),
+                dataPool.getConnector('__proto__')
+            ]);
+
+            deepStrictEqual(
+                connectors.map((connector) => connector.options.id),
+                ['toString', '__proto__']
+            );
+        });
+
         it('should resolve second connector request after first one', async () => {
             // Using a simpler modifier chain (the old RangeModifier API with conditions
             // has been deprecated/removed)

--- a/ts/Data/DataPool.ts
+++ b/ts/Data/DataPool.ts
@@ -93,8 +93,8 @@ class DataPool implements DataEventEmitter<Event> {
 
     public constructor(options?: DataPoolOptions) {
         this.options = merge(DataPool.defaultOptions, options);
-        this.connectors = {};
-        this.waiting = {};
+        this.connectors = Object.create(null);
+        this.waiting = Object.create(null);
     }
 
     /* *


### PR DESCRIPTION
## Summary
- store DataPool connector instances and waiting lists in prototype-free dictionaries
- support connector IDs such as `toString` and `__proto__`
- add focused concurrent loading coverage for both IDs

## Breaking changes
None. String IDs that previously collided with inherited object properties now behave like ordinary connector IDs.

## Verification
- full commit hook (419 Node tests, 391 affected QUnit tests, 36 Dashboard tests with 1 existing skip)
- `npx tsc -p ts --noEmit`
- `npx tsc -p ts/masters-es5 --noEmit`
- `npx eslint ts/Data/DataPool.ts`
- `git diff --check`

Fixes #25135