### PR TITLE
bugfix/25137-sort-median-values

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/Formula/Functions/MEDIAN.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/Formula/Functions/MEDIAN.test.ts
@@ -26,4 +26,25 @@ describe('Formula.processorFunctions.MEDIAN', () => {
             'MEDIAN test should return expected value.'
         );
     });
+
+    it('should calculate medians independently of input order', () => {
+        const unsortedTable = new DataTable({
+            columns: { values: [100, 1, 2, -5] }
+        });
+
+        strictEqual(
+            Formula.processFormula(
+                Formula.parseFormula('MEDIAN(A1:A3)', false),
+                unsortedTable
+            ),
+            2
+        );
+        strictEqual(
+            Formula.processFormula(
+                Formula.parseFormula('MEDIAN(A1:A4)', false),
+                unsortedTable
+            ),
+            1.5
+        );
+    });
 });

--- a/test/ts-node-unit-tests/tests/Data/Modifiers/MathModifier.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/Modifiers/MathModifier.test.ts
@@ -124,7 +124,7 @@ describe('MathModifier', () => {
 
             deepStrictEqual(
                 table.getModified().getColumn('ColumnE'),
-                [176040, 281000, 3842000, 63625, 161201],
+                [176640, 281500, 3842000, 63625, 161201],
                 'The advanced aggregate functions formula is properly calculated.'
             );
         });

--- a/ts/Data/Formula/Functions/MEDIAN.ts
+++ b/ts/Data/Formula/Functions/MEDIAN.ts
@@ -106,6 +106,8 @@ function MEDIAN(
         return NaN;
     }
 
+    median.sort((a, b): number => a - b);
+
     const half = Math.floor(count / 2); // Floor because index starts at 0
 
     return (


### PR DESCRIPTION
## Summary
- sort numeric MEDIAN inputs before selecting middle values
- cover unsorted odd and even input ranges
- update the MathModifier integration expectation to the mathematically correct result

## Breaking changes
None. MEDIAN now returns the correct value independent of input order.

## Verification
- full pre-commit hook
- 419 Node tests
- TypeScript and ES5 builds
- source lint

Fixes #25137