### PR TITLE
bugfix/25139-greater-than-or-equal

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/Formula/Operators/Higher.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/Formula/Operators/Higher.test.ts
@@ -210,3 +210,21 @@ describe('Formula.basicOperation(`>`)', () => {
         });
     });
 });
+
+describe('Formula.basicOperation(`>=`)', () => {
+    it('2 >= 1 should return TRUE', () => {
+        strictEqual(
+            Formula.processFormula(Formula.parseFormula('2 >= 1', false)),
+            true,
+            'Formula `2 >= 1` test should return TRUE.'
+        );
+    });
+
+    it('1 >= 2 should return FALSE', () => {
+        strictEqual(
+            Formula.processFormula(Formula.parseFormula('1 >= 2', false)),
+            false,
+            'Formula `1 >= 2` test should return FALSE.'
+        );
+    });
+});

--- a/ts/Data/Formula/FormulaParser.ts
+++ b/ts/Data/Formula/FormulaParser.ts
@@ -89,7 +89,7 @@ const functionRegExp = /^([A-Z][A-Z\d\.]*)\(/;
 /**
  * @private
  */
-const operatorRegExp = /^(?:[+\-*\/^<=>]|<=|=>)/;
+const operatorRegExp = /^(?:<=|>=|[+\-*\/^<=>])/;
 
 
 /**


### PR DESCRIPTION
## Summary
- recognize `>=` as one formula operator instead of `>` followed by `=`
- keep two-character comparison operators ahead of single-character tokens
- cover true and false greater-than-or-equal results

## Breaking changes
None. Previously valid `>=` formulas returned `NaN`; they now return the documented boolean result.

## Verification
- full pre-commit hook (420 Node tests, 391 QUnit tests, 36 Dashboard tests plus one existing skip)
- current and ES5 builds
- source lint
- generated-sample and whitespace checks

Fixes #25139