### PR TITLE
bugfix/25141-quoted-string-literals

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/Formula/Operators/Equal.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/Formula/Operators/Equal.test.ts
@@ -200,5 +200,15 @@ describe('Formula.basicOperation(`=`)', () => {
                 'Formula `"A" = "a"` test should return TRUE, because comparisons are case insensitive.'
             );
         });
+
+        it('"AB" = "AC" should return FALSE', () => {
+            strictEqual(
+                Formula.processFormula(
+                    Formula.parseFormula('"AB" = "AC"', false)
+                ),
+                false,
+                'Formula `"AB" = "AC"` test should compare the full strings.'
+            );
+        });
     });
 });

--- a/test/ts-node-unit-tests/tests/Data/Formula/Parse.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/Formula/Parse.test.ts
@@ -39,4 +39,14 @@ describe('Formula.parseFormula', () => {
             'Processing should result in a value of -10.'
         );
     });
+
+    it('should preserve complete quoted string literals', () => {
+        strictEqual(
+            Formula.processFormula(
+                Formula.parseFormula('"Highcharts"', false)
+            ),
+            'Highcharts',
+            'Processing should return the complete quoted string.'
+        );
+    });
 });

--- a/ts/Data/Formula/FormulaParser.ts
+++ b/ts/Data/Formula/FormulaParser.ts
@@ -620,7 +620,7 @@ function parseFormula(
         if (next[0] === '"') {
             const string = extractString(next);
 
-            formula.push(string.substring(1, -1));
+            formula.push(string);
 
             next = next.substring(string.length + 2).trim();
 


### PR DESCRIPTION
## Summary
- retain the complete value returned by the quoted-string extractor
- cover direct quoted-string evaluation
- verify string comparisons use every character, not only the first

## Breaking changes
None. Quoted formula strings now retain their documented complete value. Comparisons that previously ignored all characters after the first are corrected.

## Verification
- full pre-commit hook (420 Node tests)
- current and ES5 TypeScript builds
- focused parser/operator tests
- source lint
- generated-sample and whitespace checks

Fixes #25141