### PR TITLE
bugfix/25143-relative-r1c1-references

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/Formula/Parse.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/Formula/Parse.test.ts
@@ -39,4 +39,40 @@ describe('Formula.parseFormula', () => {
             'Processing should result in a value of -10.'
         );
     });
+
+    it('should parse signed relative R1C1 references', () => {
+        deepStrictEqual(
+            Formula.parseFormula('R[-2]C[3]', false),
+            [{
+                column: 3,
+                columnRelative: true,
+                row: -2,
+                rowRelative: true,
+                type: 'reference'
+            }],
+            'Parsing should retain signed relative row and column offsets.'
+        );
+    });
+
+    it('should parse relative R1C1 ranges', () => {
+        deepStrictEqual(
+            Formula.parseFormula('SUM(R[-1]C[1]:R[2]C[-3])', false),
+            [{
+                args: [{
+                    beginColumn: 1,
+                    beginColumnRelative: true,
+                    beginRow: -1,
+                    beginRowRelative: true,
+                    endColumn: -3,
+                    endColumnRelative: true,
+                    endRow: 2,
+                    endRowRelative: true,
+                    type: 'range'
+                }],
+                name: 'SUM',
+                type: 'function'
+            }],
+            'Parsing should retain every signed relative range offset.'
+        );
+    });
 });

--- a/ts/Data/Formula/FormulaParser.ts
+++ b/ts/Data/Formula/FormulaParser.ts
@@ -110,7 +110,7 @@ const rangeA1RegExp = /^(\$?[A-Z]+)(\$?\d+)\:(\$?[A-Z]+)(\$?\d+)/;
  * @private
  */
 const rangeR1C1RegExp =
-    /^R(\d*|\[\d+\])C(\d*|\[\d+\])\:R(\d*|\[\d+\])C(\d*|\[\d+\])/;
+    /^R(\[-?\d+\]|\d*)C(\[-?\d+\]|\d*):R(\[-?\d+\]|\d*)C(\[-?\d+\]|\d*)/;
 
 
 /**
@@ -126,7 +126,7 @@ const referenceA1RegExp = /^(\$?[A-Z]+)(\$?\d+)(?![\:C])/;
  * - Group 2: Column
  * @private
  */
-const referenceR1C1RegExp = /^R(\d*|\[\d+\])C(\d*|\[\d+\])(?!\:)/;
+const referenceR1C1RegExp = /^R(\[-?\d+\]|\d*)C(\[-?\d+\]|\d*)(?!:)/;
 
 
 /* *
@@ -274,22 +274,22 @@ function parseArgument(
             type: 'range',
             beginColumn: (
                 beginColumnRelative ?
-                    parseInt(match[2].substring(1, -1) || '0', 10) :
+                    parseInt(match[2].slice(1, -1) || '0', 10) :
                     parseInt(match[2], 10) - 1
             ),
             beginRow: (
                 beginRowRelative ?
-                    parseInt(match[1].substring(1, -1) || '0', 10) :
+                    parseInt(match[1].slice(1, -1) || '0', 10) :
                     parseInt(match[1], 10) - 1
             ),
             endColumn: (
                 endColumnRelative ?
-                    parseInt(match[4].substring(1, -1) || '0', 10) :
+                    parseInt(match[4].slice(1, -1) || '0', 10) :
                     parseInt(match[4], 10) - 1
             ),
             endRow: (
                 endRowRelative ?
-                    parseInt(match[3].substring(1, -1) || '0', 10) :
+                    parseInt(match[3].slice(1, -1) || '0', 10) :
                     parseInt(match[3], 10) - 1
             )
         };
@@ -507,12 +507,12 @@ function parseFormula(
                 type: 'reference',
                 column: (
                     columnRelative ?
-                        parseInt(match[2].substring(1, -1) || '0', 10) :
+                        parseInt(match[2].slice(1, -1) || '0', 10) :
                         parseInt(match[2], 10) - 1
                 ),
                 row: (
                     rowRelative ?
-                        parseInt(match[1].substring(1, -1) || '0', 10) :
+                        parseInt(match[1].slice(1, -1) || '0', 10) :
                         parseInt(match[1], 10) - 1
                 )
             };


### PR DESCRIPTION
## Summary
- parse bracketed R1C1 alternatives before empty relative indices
- accept signed bracketed offsets, including documented negative back-references
- extract complete bracket contents for both references and range endpoints
- cover signed references and mixed-sign ranges

## Breaking changes
None. Previously broken relative R1C1 references and ranges now produce finite signed offsets.

## Verification
- full pre-commit hook (420 Node tests, 391 QUnit tests, 36 Dashboard tests plus one existing skip)
- current and ES5 TypeScript builds
- focused parser tests
- source lint
- generated-sample and whitespace checks

Fixes #25143