### PR TITLE
bugfix/25145-comma-decimal-formulas

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/Formula/Parse.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/Formula/Parse.test.ts
@@ -39,4 +39,14 @@ describe('Formula.parseFormula', () => {
             'Processing should result in a value of -10.'
         );
     });
+
+    it('should process comma decimals with alternative separators', () => {
+        strictEqual(
+            Formula.processFormula(
+                Formula.parseFormula('SUM(1,5;2,25)', true)
+            ),
+            3.75,
+            'Comma decimals should retain their fractional values.'
+        );
+    });
 });

--- a/ts/Data/Formula/FormulaParser.ts
+++ b/ts/Data/Formula/FormulaParser.ts
@@ -601,7 +601,7 @@ function parseFormula(
         // Check for a number value
         match = next.match(decimalRegExp);
         if (match) {
-            let number = parseFloat(match[0]);
+            let number = parseFloat(match[0].replace(',', '.'));
             // If the current value is multiplication-related and the previous
             // one is a minus sign, set the current value to negative and remove
             // the minus sign.


### PR DESCRIPTION
## Summary
- normalize the recognized comma decimal separator before numeric conversion
- preserve fractional values when semicolons separate formula arguments
- cover an alternative-separator SUM with two comma decimals

## Breaking changes
None. Alternative-separator formulas now retain the fractional part that was previously truncated.

## Verification
- full pre-commit hook (419 Node tests)
- current and ES5 TypeScript builds
- focused parser tests
- source lint
- generated-sample and whitespace checks

Fixes #25145