### PR TITLE
bugfix/25147-insert-array-rows

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/DataTable.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/DataTable.test.ts
@@ -888,6 +888,35 @@ describe('DataTable', () => {
                 'If no value is provided, the new row is filled with `undefined`.'
             );
         });
+
+        it('should preserve existing rows when inserting array rows', () => {
+            const table = new DataTable({
+                columns: {
+                    ID: [1, 2, 3],
+                    Name: ['John', 'Jane', 'Alice']
+                }
+            });
+
+            table.setRows([
+                [98, 'Ana'],
+                [99, 'Bob']
+            ], 1, true);
+
+            strictEqual(
+                table.getRowCount(),
+                5,
+                'The table should include both inserted rows.'
+            );
+
+            deepStrictEqual(
+                table.getColumns(),
+                {
+                    ID: [1, 98, 99, 2, 3],
+                    Name: ['John', 'Ana', 'Bob', 'Jane', 'Alice']
+                },
+                'Inserted rows should not truncate existing rows.'
+            );
+        });
     });
 
     describe('Metadata in a cloned table', () => {

--- a/ts/Data/DataTable.ts
+++ b/ts/Data/DataTable.ts
@@ -1253,6 +1253,7 @@ class DataTable extends DataTableCore implements DataEventEmitter<Event> {
             columns = table.columns,
             columnIds = Object.keys(columns),
             modifier = table.modifier,
+            originalRowCount = table.rowCount,
             rowCount = rows.length;
 
         table.emit({
@@ -1285,7 +1286,15 @@ class DataTable extends DataTableCore implements DataEventEmitter<Event> {
                 }
             } else if (Array.isArray(row)) {
                 for (let j = 0, jEnd = columnIds.length; j < jEnd; ++j) {
-                    columns[columnIds[j]][i2] = row[j];
+                    const columnId = columnIds[j];
+
+                    if (insert) {
+                        columns[columnId] = splice(
+                            columns[columnId], i2, 0, true, [row[j]]
+                        ).array;
+                    } else {
+                        columns[columnId][i2] = row[j];
+                    }
                 }
             } else {
                 super.setRow(row, i2, insert, { silent: true });
@@ -1293,7 +1302,7 @@ class DataTable extends DataTableCore implements DataEventEmitter<Event> {
         }
 
         const indexRowCount = insert ?
-            rowCount + rows.length :
+            originalRowCount + rowCount :
             rowIndex + rowCount;
         if (indexRowCount > table.rowCount) {
             table.rowCount = indexRowCount;


### PR DESCRIPTION
## Summary
- splice array-form rows when `insert` is enabled instead of overwriting existing cells
- calculate the inserted table length from the original row count
- verify multiple middle insertions preserve all existing rows and expose the correct row count

## Breaking changes
None. Array-form `setRows(..., true)` now follows its documented insertion semantics instead of overwriting and truncating data.

## Verification
- full pre-commit hook (419 Node tests, 391 QUnit tests, 36 Dashboard tests plus one existing skip)
- current and ES5 TypeScript builds
- focused DataTable suite (36 tests)
- source lint
- generated-sample and whitespace checks

Fixes #25147