### PR TITLE
bugfix/25149-set-columns-row-offset

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/DataTable.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/DataTable.test.ts
@@ -570,6 +570,45 @@ describe('DataTable', () => {
             );
         });
 
+        it('should apply all values from a nonzero row index', () => {
+            const table = new DataTable({
+                columns: {
+                    x: [0, 1, 2]
+                }
+            });
+
+            table.setColumns({ x: [8, 9] }, 1);
+
+            deepStrictEqual(
+                table.getColumn('x'),
+                [0, 8, 9],
+                'Replacement values should start at the requested row.'
+            );
+        });
+
+        it('should extend typed columns for offset values', () => {
+            const table = new DataTable({
+                columns: {
+                    x: new Float32Array([1, 2])
+                }
+            });
+
+            table.setColumns({
+                x: new Float32Array([3, 4])
+            }, 2);
+
+            deepStrictEqual(
+                table.getColumn('x'),
+                new Float32Array([1, 2, 3, 4]),
+                'The typed column should grow through the destination range.'
+            );
+            strictEqual(
+                table.getRowCount(),
+                4,
+                'The row count should include the offset values.'
+            );
+        });
+
         it('should truncate columns when setting shorter columns', () => {
             const table = new DataTable({
                 columns: {

--- a/ts/Data/DataTable.ts
+++ b/ts/Data/DataTable.ts
@@ -1009,7 +1009,8 @@ class DataTable extends DataTableCore implements DataEventEmitter<Event> {
         const table = this,
             tableColumns = table.columns,
             tableModifier = table.modifier,
-            columnIds = Object.keys(columns);
+            columnIds = Object.keys(columns),
+            columnStart = rowIndex || 0;
 
         let rowCount = table.rowCount;
 
@@ -1032,6 +1033,7 @@ class DataTable extends DataTableCore implements DataEventEmitter<Event> {
                 let i = 0,
                     iEnd = columnIds.length,
                     column: Column,
+                    columnEnd: number,
                     tableColumn: Column,
                     columnId: string,
                     ArrayConstructor: (
@@ -1043,6 +1045,7 @@ class DataTable extends DataTableCore implements DataEventEmitter<Event> {
             ) {
                 columnId = columnIds[i];
                 column = columns[columnId];
+                columnEnd = columnStart + column.length;
                 tableColumn = tableColumns[columnId];
 
                 ArrayConstructor = Object.getPrototypeOf(
@@ -1050,14 +1053,18 @@ class DataTable extends DataTableCore implements DataEventEmitter<Event> {
                 ).constructor;
 
                 if (!tableColumn) {
-                    tableColumn = new ArrayConstructor(rowCount);
+                    tableColumn = new ArrayConstructor(
+                        Math.max(rowCount, columnEnd)
+                    );
                 } else if (ArrayConstructor === Array) {
                     if (!Array.isArray(tableColumn)) {
                         tableColumn = Array.from(tableColumn);
                     }
-                } else if (tableColumn.length < rowCount) {
+                } else if (tableColumn.length < columnEnd) {
                     tableColumn =
-                        new ArrayConstructor(rowCount) as TypedArray;
+                        new ArrayConstructor(
+                            Math.max(rowCount, columnEnd)
+                        ) as TypedArray;
                     tableColumn.set(
                         tableColumns[columnId] as ArrayLike<number>
                     );
@@ -1065,15 +1072,15 @@ class DataTable extends DataTableCore implements DataEventEmitter<Event> {
                 tableColumns[columnId] = tableColumn;
 
                 for (
-                    let i = (rowIndex || 0),
+                    let i = 0,
                         iEnd = column.length;
                     i < iEnd;
                     ++i
                 ) {
-                    tableColumn[i] = column[i];
+                    tableColumn[columnStart + i] = column[i];
                 }
 
-                rowCount = Math.max(rowCount, column.length);
+                rowCount = Math.max(rowCount, columnEnd);
             }
 
             this.applyRowCount(rowCount);


### PR DESCRIPTION
## Summary
- treat `rowIndex` as the destination start while reading replacement columns from index zero
- size new and existing typed columns for the complete destination range
- include the destination offset when updating `rowCount`
- cover conventional-array replacement and typed-array extension

## Breaking changes
None. Nonzero `rowIndex` updates now apply every provided value at the documented destination instead of skipping values.

## Verification
- full pre-commit hook (420 Node tests)
- current and ES5 TypeScript builds
- focused DataTable suite (37 tests)
- source lint
- generated-sample and whitespace checks

Fixes #25149