### PR TITLE
bugfix/25151-column-length-order

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/DataTable.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/DataTable.test.ts
@@ -570,6 +570,31 @@ describe('DataTable', () => {
             );
         });
 
+        it('should use the longest replacement column for row count', () => {
+            const table = new DataTable();
+
+            table.setColumns({
+                long: [1, 2, 3],
+                short: [4]
+            });
+
+            strictEqual(
+                table.getRowCount(),
+                3,
+                'The longest column should determine the row count.'
+            );
+            deepStrictEqual(
+                table.getColumn('long'),
+                [1, 2, 3],
+                'Column order should not truncate longer replacement data.'
+            );
+            strictEqual(
+                table.getColumn('short')?.length,
+                3,
+                'The shorter column should be padded to the table length.'
+            );
+        });
+
         it('should truncate columns when setting shorter columns', () => {
             const table = new DataTable({
                 columns: {

--- a/ts/Data/DataTableCore.ts
+++ b/ts/Data/DataTableCore.ts
@@ -340,12 +340,15 @@ class DataTableCore {
         rowIndex?: number,
         eventDetail?: DataEventDetail
     ): void {
-        let rowCount = this.rowCount;
+        let hasColumns = false,
+            rowCount = 0;
+
         objectEach(columns, (column, columnId): void => {
+            hasColumns = true;
             this.columns[columnId] = column.slice();
-            rowCount = column.length;
+            rowCount = Math.max(rowCount, column.length);
         });
-        this.applyRowCount(rowCount);
+        this.applyRowCount(hasColumns ? rowCount : this.rowCount);
 
         if (!eventDetail?.silent) {
             fireEvent(this, 'afterSetColumns');


### PR DESCRIPTION
## Summary
- derive a full column replacement's row count from its longest input column
- preserve the existing table length for an empty replacement object
- verify longer data is retained when followed by a shorter column

## Breaking changes
None. Full multi-column replacements now produce the same result regardless of property order, consistently with construction behavior.

## Verification
- full pre-commit hook (419 Node tests, 391 QUnit tests, 36 Dashboard tests plus one existing skip)
- current and ES5 TypeScript builds
- focused DataTable suite (36 tests)
- source lint
- generated-sample and whitespace checks

Fixes #25151