### PR TITLE
bugfix/25153-prototype-column-ids

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/DataTable.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/DataTable.test.ts
@@ -138,6 +138,43 @@ describe('DataTable', () => {
                     'Result has correct amount of column cells.'
                 ));
         });
+
+        it('should support prototype-named column IDs', () => {
+            const table = new DataTable();
+
+            strictEqual(
+                table.hasColumns(['toString']),
+                false,
+                'Inherited object properties should not count as columns.'
+            );
+
+            table.setColumn('toString', [1]);
+            table.setColumn('__proto__', [2]);
+
+            deepStrictEqual(
+                table.getColumnIds(),
+                ['toString', '__proto__'],
+                'Both prototype-named columns should be enumerable.'
+            );
+            deepStrictEqual(table.getColumn('toString'), [1]);
+            deepStrictEqual(table.getColumn('__proto__'), [2]);
+
+            const columns = table.getColumns();
+            const row = table.getRowObject(0)!;
+
+            strictEqual(Object.hasOwn(columns, '__proto__'), true);
+            strictEqual(Object.hasOwn(row, '__proto__'), true);
+            strictEqual(row['toString'], 1);
+            strictEqual(row['__proto__'], 2);
+
+            table.setRow({ ordinary: 3 }, 1);
+
+            strictEqual(
+                table.getCell('toString', 1),
+                void 0,
+                'Inherited row properties should not become cell values.'
+            );
+        });
     });
 
     describe('Events', () => {

--- a/ts/Data/DataTable.ts
+++ b/ts/Data/DataTable.ts
@@ -37,7 +37,7 @@ import type {
 } from './DataTableOptions';
 import type { TypedArray, TypedArrayConstructor } from '../Shared/Types';
 
-import DataTableCore from './DataTableCore.js';
+import DataTableCore, { setRecordValue } from './DataTableCore.js';
 
 import ColumnUtils from './ColumnUtils.js';
 const { splice, setLength } = ColumnUtils;
@@ -211,8 +211,12 @@ class DataTable extends DataTableCore implements DataEventEmitter<Event> {
                 columnId = columnIds[i];
                 column = columns[columnId];
                 if (column) {
-                    deletedColumns[columnId] = column;
-                    modifiedColumns[columnId] = new Array(rowCount);
+                    setRecordValue(deletedColumns, columnId, column);
+                    setRecordValue(
+                        modifiedColumns,
+                        columnId,
+                        new Array(rowCount)
+                    );
                 }
                 delete columns[columnId];
             }
@@ -501,11 +505,11 @@ class DataTable extends DataTableCore implements DataEventEmitter<Event> {
 
             if (column) {
                 if (asReference) {
-                    columns[columnId] = column;
+                    setRecordValue(columns, columnId, column);
                 } else if (asBasicColumns && !Array.isArray(column)) {
-                    columns[columnId] = Array.from(column);
+                    setRecordValue(columns, columnId, Array.from(column));
                 } else {
-                    columns[columnId] = column.slice();
+                    setRecordValue(columns, columnId, column.slice());
                 }
             }
         }
@@ -711,7 +715,11 @@ class DataTable extends DataTableCore implements DataEventEmitter<Event> {
 
             for (const columnId of columnIds) {
                 column = columns[columnId];
-                row[columnId] = (column ? column[i] : void 0);
+                setRecordValue(
+                    row,
+                    columnId,
+                    column ? column[i] : void 0
+                );
             }
         }
 

--- a/ts/Data/DataTableCore.ts
+++ b/ts/Data/DataTableCore.ts
@@ -41,6 +41,35 @@ import { uniqueKey } from '../Core/Utilities.js';
 
 /* *
  *
+ *  Functions
+ *
+ * */
+
+
+/**
+ * Sets an own enumerable record property without invoking `__proto__`.
+ * @private
+ */
+export function setRecordValue<T>(
+    record: Record<string, T>,
+    key: string,
+    value: T
+): void {
+    if (key === '__proto__') {
+        Object.defineProperty(record, key, {
+            configurable: true,
+            enumerable: true,
+            value,
+            writable: true
+        });
+    } else {
+        record[key] = value;
+    }
+}
+
+
+/* *
+ *
  *  Class
  *
  * */
@@ -83,7 +112,10 @@ class DataTableCore {
         options: DataTableOptionsObject = {}
     ) {
         this.autoId = !options.id;
-        this.columns = {};
+        this.columns = Object.create(null) as Record<
+            string,
+            DataTableColumn
+        >;
         this.id = (options.id || uniqueKey());
         this.rowCount = 0;
         this.versionTag = uniqueKey();
@@ -247,7 +279,7 @@ class DataTableCore {
     ): DataTableColumnCollection {
         return (columnIds || Object.keys(this.columns)).reduce(
             (columns, columnId): DataTableColumnCollection => {
-                columns[columnId] = this.columns[columnId];
+                setRecordValue(columns, columnId, this.columns[columnId]);
                 return columns;
             },
             {} as DataTableColumnCollection
@@ -278,7 +310,11 @@ class DataTableCore {
         columnNames ??= Object.keys(this.columns);
 
         for (const columnName of columnNames) {
-            row[columnName] = columns[columnName]?.[rowIndex];
+            setRecordValue(
+                row,
+                columnName,
+                columns[columnName]?.[rowIndex]
+            );
         }
         return row;
     }
@@ -399,20 +435,25 @@ class DataTableCore {
 
         objectEach(columns, (column, columnId): void => {
             if (column) {
+                const hasValue = Object.prototype.hasOwnProperty.call(
+                    row,
+                    columnId
+                );
+
                 if (insert) {
                     column = splice(
                         column,
                         rowIndex,
                         0,
                         true,
-                        [row[columnId]]
+                        [hasValue ? row[columnId] : void 0]
                     ).array;
                 } else {
                     column[rowIndex] =
                         // Preserve explicit null and undefined but fall back
                         // to existing value if the new row does not have the
                         // key
-                        columnId in row ?
+                        hasValue ?
                             row[columnId] :
                             column[rowIndex];
                 }


### PR DESCRIPTION
## Summary
- store internal DataTable columns in a prototype-free registry
- define `__proto__` as an own data property when returning ordinary column and row objects
- ignore inherited row-object properties when updating special-named columns
- cover missing and stored `toString`/`__proto__` IDs across enumeration, column lookup, row export, and row updates

## Breaking changes
None. Prototype-named strings now behave as ordinary column IDs; inherited object members are no longer mistaken for columns or row values.

## Verification
- full pre-commit hook (419 Node tests, 391 QUnit tests, 36 Dashboard tests plus one existing skip)
- current and ES5 TypeScript builds
- focused DataTable suite (36 tests)
- source lint
- generated-sample and whitespace checks

Fixes #25153