### PR TITLE
bugfix/25155-json-object-row-alignment

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/Connectors/JSONConnector.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/Connectors/JSONConnector.test.ts
@@ -121,6 +121,34 @@ describe('JSONConnector', () => {
                 'Should have correct Column Ids'
             );
         });
+
+        it('should align values by the first object row keys', async () => {
+            const connector = new JSONConnector({
+                firstRowAsNames: false,
+                data: [{
+                    a: 1,
+                    b: 2
+                }, {
+                    b: 3,
+                    a: 4
+                }, {
+                    a: 5
+                }]
+            });
+
+            await connector.load();
+
+            deepStrictEqual(
+                connector.getTable().getColumn('a'),
+                [1, 4, 5],
+                'Reordered keys should stay in the first row column order.'
+            );
+            deepStrictEqual(
+                connector.getTable().getColumn('b'),
+                [2, 3, void 0],
+                'Missing keys should leave an empty cell in their column.'
+            );
+        });
     });
 
     describe('with beforeParse', () => {

--- a/ts/Data/Converters/JSONConverter.ts
+++ b/ts/Data/Converters/JSONConverter.ts
@@ -137,6 +137,7 @@ class JSONConverter extends DataConverter {
         }
 
         converter.headers = [];
+        converter.headerColumnIds = [];
         const columnsArray: DataTableBasicColumn[] = [];
 
         converter.emit({
@@ -338,8 +339,13 @@ class JSONConverter extends DataConverter {
                 });
             return newRow;
         }
-        converter.headerColumnIds = Object.keys(rowObj);
-        return Object.values(rowObj);
+        if (!(converter.headerColumnIds as string[]).length) {
+            converter.headerColumnIds = Object.keys(rowObj);
+        }
+
+        return (converter.headerColumnIds as string[]).map(
+            (columnId): string | number => rowObj[columnId]
+        );
     }
 
 }


### PR DESCRIPTION
## Summary
- keep JSON object rows aligned to the first row's column-key order
- leave cells empty when later rows omit a known key
- reset learned column IDs for each parse

## Breaking changes
None. This corrects silent column misalignment when object property order varies between rows.

## Verification
- full pre-commit suite (419 Node unit tests)
- current and ES5 TypeScript builds
- focused JSON connector tests (9 passing)
- source lint, samples, and diff checks

Fixes #25155