### PR TITLE
bugfix/25157-preserve-json-column-input

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/Connectors/JSONConnector.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/Connectors/JSONConnector.test.ts
@@ -73,6 +73,35 @@ describe('JSONConnector', () => {
                 'Should have correct column Names'
             );
         });
+
+        it('should not mutate input while extracting column names', async () => {
+            const data = [
+                    ['name', 'A', 'B'],
+                    ['value', 1, 2]
+                ],
+                originalData = data.map((column) => column.slice()),
+                connector = new JSONConnector({
+                    orientation: 'columns',
+                    firstRowAsNames: true,
+                    data
+                });
+
+            await connector.load();
+
+            deepStrictEqual(
+                data,
+                originalData,
+                'Input columns should remain unchanged.'
+            );
+            deepStrictEqual(
+                connector.getTable().getColumns(),
+                {
+                    name: ['A', 'B'],
+                    value: [1, 2]
+                },
+                'Headers and values should still be parsed.'
+            );
+        });
     });
 
     describe('from objects', () => {

--- a/ts/Data/Converters/JSONConverter.ts
+++ b/ts/Data/Converters/JSONConverter.ts
@@ -209,13 +209,14 @@ class JSONConverter extends DataConverter {
             if (!(Array.isArray(item))) {
                 return;
             }
+            const column = item.slice();
             if (Array.isArray(converter.headers)) {
                 if (firstRowAsNames) {
-                    converter.headers.push(`${item.shift()}`);
+                    converter.headers.push(`${column.shift()}`);
                 } else if (columnIds && Array.isArray(columnIds)) {
                     converter.headers.push(columnIds[i]);
                 }
-                columnsArray.push(item);
+                columnsArray.push(column);
             } else {
                 error(
                     'JSONConverter: Invalid `columnIds` option.',


### PR DESCRIPTION
## Summary
- clone each JSON input column before extracting its header
- preserve the caller-owned nested arrays across conversion and reuse
- retain the same parsed headers and values

## Breaking changes
None. This removes an unintended mutation of caller input.

## Verification
- full pre-commit suite (419 Node unit tests, 391 QUnit tests, 36 Dashboard tests with one existing skip)
- current and ES5 TypeScript builds
- focused JSON connector tests (9 passing)
- source lint, samples, and diff checks

Fixes #25157