### PR TITLE
bugfix/25159-reset-csv-parse-state

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/Connectors/CSVConnector.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/Connectors/CSVConnector.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from 'node:test';
 import { deepStrictEqual, strictEqual, ok } from 'node:assert';
 
 import CSVConnector from '../../../../../ts/Data/Connectors/CSVConnector.js';
+import CSVConverter from '../../../../../ts/Data/Converters/CSVConverter.js';
 
 const csv = `Grade,Ounce,Gram,Inch,mm,PPO
 "#TriBall",0.7199,  20.41,    0.60,15.24,     1 #this is a comment
@@ -154,6 +155,24 @@ describe('CSVConnector', () => {
             connector.describeColumn('test', {
                 dataType: 'string'
             });
+        });
+
+        it('should reset parser state between CSV inputs', () => {
+            const converter = new CSVConverter();
+
+            converter.parse({ csv: 'oldA,oldB\n1,2' });
+
+            deepStrictEqual(
+                converter.parse({
+                    csv: '3,4',
+                    firstRowAsNames: false
+                }),
+                {
+                    0: [3],
+                    1: [4]
+                },
+                'The second parse should not reuse the first CSV headers.'
+            );
         });
     });
 

--- a/ts/Data/Converters/CSVConverter.ts
+++ b/ts/Data/Converters/CSVConverter.ts
@@ -128,8 +128,14 @@ class CSVConverter extends DataConverter {
         options: Partial<CSVConverterOptions>,
         eventDetail?: DataEventDetail
     ): DataTableColumnCollection {
-        const converter = this,
-            dataTypes = converter.dataTypes,
+        const converter = this;
+
+        converter.headers = [];
+        converter.dataTypes = [];
+        converter.guessedItemDelimiter = void 0;
+        converter.guessedDecimalPoint = void 0;
+
+        const dataTypes = converter.dataTypes,
             parserOptions = merge(this.options, options),
             {
                 beforeParse,


### PR DESCRIPTION
## Summary
- reset CSV headers and type history at the start of each parse
- clear inferred delimiter and decimal-point state between unrelated inputs
- keep repeated use of one converter independent across calls

## Breaking changes
None. Later parses no longer inherit stale names or inference state from earlier CSV data.

## Verification
- full pre-commit suite (419 Node unit tests)
- current and ES5 TypeScript builds
- focused CSV connector tests (7 passing)
- source lint, samples, and diff checks

Fixes #25159