### PR TITLE
bugfix/25161-honor-csv-parse-options

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/Connectors/CSVConnector.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/Connectors/CSVConnector.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from 'node:test';
 import { deepStrictEqual, strictEqual, ok } from 'node:assert';
 
 import CSVConnector from '../../../../../ts/Data/Connectors/CSVConnector.js';
+import CSVConverter from '../../../../../ts/Data/Converters/CSVConverter.js';
 
 const csv = `Grade,Ounce,Gram,Inch,mm,PPO
 "#TriBall",0.7199,  20.41,    0.60,15.24,     1 #this is a comment
@@ -154,6 +155,25 @@ describe('CSVConnector', () => {
             connector.describeColumn('test', {
                 dataType: 'string'
             });
+        });
+
+        it('should honor row options supplied to parse', () => {
+            const converter = new CSVConverter();
+
+            deepStrictEqual(
+                converter.parse({
+                    csv: 'ignored;a;b\n0;1,5;2,5',
+                    itemDelimiter: ';',
+                    decimalPoint: ',',
+                    startColumn: 1,
+                    endColumn: 2
+                }),
+                {
+                    a: [1.5],
+                    b: [2.5]
+                },
+                'Parse options should control tokenization and selection.'
+            );
         });
     });
 

--- a/ts/Data/Converters/CSVConverter.ts
+++ b/ts/Data/Converters/CSVConverter.ts
@@ -183,6 +183,9 @@ class CSVConverter extends DataConverter {
             if (firstRowAsNames) {
                 const headers = lines[0].split(
                     itemDelimiter || converter.guessedItemDelimiter || ','
+                ).slice(
+                    parserOptions.startColumn,
+                    parserOptions.endColumn + 1
                 );
 
                 // Remove ""s from the headers
@@ -204,7 +207,8 @@ class CSVConverter extends DataConverter {
                     converter.parseCSVRow(
                         columnsArray,
                         lines[rowIt],
-                        rowIt - startRow - offset
+                        rowIt - startRow - offset,
+                        parserOptions
                     );
                 }
             }
@@ -262,18 +266,19 @@ class CSVConverter extends DataConverter {
     private parseCSVRow(
         columns: DataTableBasicColumn[],
         columnStr: string,
-        rowNumber: number
+        rowNumber: number,
+        options: CSVConverterOptions
     ): void {
         const converter = this,
             dataTypes = converter.dataTypes,
-            { startColumn, endColumn } = converter.options,
+            { startColumn, endColumn } = options,
             itemDelimiter = (
-                converter.options.itemDelimiter ||
+                options.itemDelimiter ||
                 converter.guessedItemDelimiter
             );
 
 
-        let { decimalPoint } = converter.options;
+        let { decimalPoint } = options;
 
         if (!decimalPoint || decimalPoint === itemDelimiter) {
             decimalPoint = converter.guessedDecimalPoint || '.';


### PR DESCRIPTION
## Summary
- pass merged per-call options into CSV row tokenization
- honor per-call delimiter, decimal point, and column bounds
- slice header names to the same selected column range as row values

## Breaking changes
None. This makes `parse(options)` consistently honor its documented call-level settings.

## Verification
- full pre-commit suite (419 Node unit tests, 391 QUnit tests, 36 Dashboard tests with one existing skip)
- current and ES5 TypeScript builds
- focused CSV connector tests (7 passing)
- source lint, samples, and diff checks

Fixes #25161