### PR TITLE
bugfix/25163-csv-escaped-quotes

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/Connectors/CSVConnector.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/Connectors/CSVConnector.test.ts
@@ -155,6 +155,20 @@ describe('CSVConnector', () => {
                 dataType: 'string'
             });
         });
+
+        it('should decode escaped quotes in quoted fields', async () => {
+            const connector = new CSVConnector({
+                csv: 'label,value\n"He said ""hi""",1'
+            });
+
+            await connector.load();
+
+            strictEqual(
+                connector.getTable().getCell('label', 0),
+                'He said "hi"',
+                'A doubled quote should produce one literal quote.'
+            );
+        });
     });
 
     // Note: URL-based tests require browser/fetch and are handled in Playwright tests

--- a/ts/Data/Converters/CSVConverter.ts
+++ b/ts/Data/Converters/CSVConverter.ts
@@ -379,6 +379,11 @@ class CSVConverter extends DataConverter {
 
                 while (i < columnStr.length) {
                     if (c === '"') {
+                        if (columnStr[i + 1] === '"') {
+                            token += '"';
+                            read(i += 2);
+                            continue;
+                        }
                         break;
                     }
 


### PR DESCRIPTION
## Summary
- decode doubled quotes inside quoted CSV fields
- preserve one literal quote while continuing the same quoted token
- cover the standard CSV escape sequence through the connector

## Breaking changes
None. Escaped quotes are no longer silently discarded.

## Verification
- full pre-commit suite (419 Node unit tests)
- current and ES5 TypeScript builds
- focused CSV connector tests (7 passing)
- source lint, samples, and diff checks

Fixes #25163