### PR TITLE
bugfix/25165-track-google-sheets-polling

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/Connectors/DataConnector.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/Connectors/DataConnector.test.ts
@@ -3,8 +3,8 @@ import { ok, deepStrictEqual, strictEqual } from 'node:assert';
 
 import DataConnector from '../../../../../ts/Data/Connectors/DataConnector';
 import CSVConnector from '../../../../../ts/Data/Connectors/CSVConnector';
+import GoogleSheetsConnector from '../../../../../ts/Data/Connectors/GoogleSheetsConnector';
 // Import these to register them with DataConnector.types
-import '../../../../../ts/Data/Connectors/GoogleSheetsConnector';
 import '../../../../../ts/Data/Connectors/HTMLTableConnector';
 import '../../../../../ts/Data/Connectors/JSONConnector';
 
@@ -141,5 +141,35 @@ describe('DataConnector', () => {
                 );
             });
         }
+    });
+
+    describe('polling', () => {
+        it('should track Google Sheets refreshes', async (t) => {
+            t.mock.method(globalThis, 'fetch', async () => ({
+                json: async () => ({
+                    values: [['Name', 'A']]
+                })
+            } as Response));
+
+            const connector = new GoogleSheetsConnector({
+                    googleAPIKey: 'key',
+                    googleSpreadsheetKey: 'sheet',
+                    enablePolling: true,
+                    dataRefreshRate: 1
+                });
+            let refreshTime;
+
+            connector.startPolling = (time): void => {
+                refreshTime = time;
+            };
+
+            await connector.load();
+
+            strictEqual(
+                refreshTime,
+                1000,
+                'Google Sheets should use the cancellable polling path.'
+            );
+        });
     });
 });

--- a/ts/Data/Connectors/GoogleSheetsConnector.ts
+++ b/ts/Data/Connectors/GoogleSheetsConnector.ts
@@ -237,8 +237,7 @@ class GoogleSheetsConnector extends DataConnector {
 
                 // Polling
                 if (enablePolling) {
-                    setTimeout(
-                        (): Promise<this> => connector.load(),
+                    connector.startPolling(
                         Math.max(dataRefreshRate || 0, 1) * 1000
                     );
                 }


### PR DESCRIPTION
## Summary
- schedule Google Sheets refreshes through the shared DataConnector polling path
- expose active polling through `connector.polling`
- let `stopPolling()` cancel the next Google Sheets refresh and abort active work

## Breaking changes
None. This restores the documented polling lifecycle and cancellation behavior.

## Verification
- full pre-commit suite (419 Node unit tests, 391 QUnit tests, 36 Dashboard tests with one existing skip)
- current and ES5 TypeScript builds
- focused DataConnector tests (10 passing)
- source lint, samples, and diff checks

Fixes #25165