### PR TITLE
bugfix/25167-compare-first-html-header

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/Converters/HTMLTableConverter.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/Converters/HTMLTableConverter.test.ts
@@ -1,0 +1,29 @@
+import { describe, it } from 'node:test';
+import { ok } from 'node:assert';
+
+import CSVConnector from '../../../../../ts/Data/Connectors/CSVConnector.js';
+import HTMLTableConverter from '../../../../../ts/Data/Converters/HTMLTableConverter.js';
+
+describe('HTMLTableConverter', () => {
+    describe('export', () => {
+        it('should compare the first multilevel header', () => {
+            const connector = new CSVConnector(),
+                converter = new HTMLTableConverter();
+
+            connector.getTable().setColumns({
+                A: ['X', 1],
+                B: ['B', 2]
+            });
+
+            const html = converter.export(connector, {
+                firstRowAsNames: true,
+                useMultiLevelHeaders: true
+            });
+
+            ok(
+                html.includes('highcharts-table-topheading'),
+                'Different first-column headers should produce both levels.'
+            );
+        });
+    });
+});

--- a/ts/Data/Converters/HTMLTableConverter.ts
+++ b/ts/Data/Converters/HTMLTableConverter.ts
@@ -55,7 +55,7 @@ function isRowEqual(
     let i = row1.length;
 
     if (row2.length === i) {
-        while (--i) {
+        while (i--) {
             if (row1[i] !== row2[i]) {
                 return false;
             }


### PR DESCRIPTION
## Summary
- compare multilevel HTML header arrays through index zero
- render both header levels when only the first column differs
- cover the export path with a focused regression

## Breaking changes
None. This restores the missing top header row for distinct first-column headers.

## Verification
- full pre-commit suite (419 Node unit tests)
- current and ES5 TypeScript builds
- focused HTMLTableConverter test
- source lint, samples, and diff checks

Fixes #25167