### PR TITLE
bugfix/25169-preserve-google-sheets-input

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/Converters/GoogleSheetsConverter.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/Converters/GoogleSheetsConverter.test.ts
@@ -1,0 +1,31 @@
+import { describe, it } from 'node:test';
+import { deepStrictEqual } from 'node:assert';
+
+import GoogleSheetsConverter from '../../../../../ts/Data/Converters/GoogleSheetsConverter.js';
+import type { GoogleSpreadsheetJSON } from '../../../../../ts/Data/Converters/GoogleSheetsConverterOptions';
+
+describe('GoogleSheetsConverter', () => {
+    describe('parse', () => {
+        it('should not mutate callback output while extracting headers', () => {
+            const json: GoogleSpreadsheetJSON = {
+                    majorDimension: 'COLUMNS',
+                    values: [
+                        ['name', 'A'],
+                        ['value', 1]
+                    ]
+                },
+                originalValues = json.values.map((column) => column.slice()),
+                converter = new GoogleSheetsConverter({
+                    beforeParse: (values) => values
+                });
+
+            converter.parse({ json });
+
+            deepStrictEqual(
+                json.values,
+                originalValues,
+                'Header extraction should leave the callback data unchanged.'
+            );
+        });
+    });
+});

--- a/ts/Data/Converters/GoogleSheetsConverter.ts
+++ b/ts/Data/Converters/GoogleSheetsConverter.ts
@@ -146,7 +146,9 @@ class GoogleSheetsConverter extends DataConverter {
         // If beforeParse is defined, use it to modify the data
         const { beforeParse, json } = parseOptions;
         if (beforeParse && json) {
-            columnsArray = beforeParse(json.values);
+            columnsArray = beforeParse(json.values).map(
+                (column): DataTableBasicColumn => column.slice()
+            );
         }
 
         let column;


### PR DESCRIPTION
## Summary
- clone every column returned by Google Sheets `beforeParse`
- extract headers from converter-owned arrays
- preserve callback/input data when an identity or in-place callback is used

## Breaking changes
None. This removes unintended mutation after the callback returns.

## Verification
- full pre-commit suite (419 Node unit tests)
- current and ES5 TypeScript builds
- focused GoogleSheetsConverter regression
- source lint, samples, and diff checks

Fixes #25169