### PR TITLE
bugfix/25171-prototype-safe-data-cursors

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/DataCursor.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/DataCursor.test.ts
@@ -88,6 +88,41 @@ describe('DataCursor', () => {
             deepStrictEqual(test3Event?.cursors, [expectedCursor3], 'Lasting event should have cursors array with cursor.');
             strictEqual(test3Event?.table, table, 'Lasting event should have correct table.');
         });
+
+        it('should support prototype-named table IDs and states', () => {
+            const cursor = new DataCursor(),
+                table = new DataTable({ id: 'toString' }),
+                state = '__proto__';
+            let calls = 0;
+            const listener = (): void => {
+                calls++;
+            };
+
+            cursor.addListener(table.id, state, listener);
+            cursor.emitCursor(table, {
+                type: 'position',
+                state
+            }, void 0, true);
+
+            strictEqual(calls, 1, 'The listener should receive the cursor.');
+            strictEqual(
+                cursor.stateMap[table.id][state].length,
+                1,
+                'The lasting cursor should be stored under its exact keys.'
+            );
+
+            cursor.remitCursor(table.id, {
+                type: 'position',
+                state
+            });
+            cursor.removeListener(table.id, state, listener);
+            cursor.emitCursor(table, {
+                type: 'position',
+                state
+            });
+
+            strictEqual(calls, 1, 'The listener should be removable.');
+        });
     });
 
     describe('isEqual', () => {

--- a/ts/Data/DataCursor.ts
+++ b/ts/Data/DataCursor.ts
@@ -57,10 +57,10 @@ class DataCursor {
 
 
     public constructor(
-        stateMap: StateMap = {}
+        stateMap: StateMap = Object.create(null)
     ) {
         this.emittingRegister = [];
-        this.listenerMap = {};
+        this.listenerMap = Object.create(null);
         this.stateMap = stateMap;
     }
 
@@ -129,12 +129,12 @@ class DataCursor {
         listener: Listener
     ): this {
         const listenerMap = this.listenerMap[tableId] = (
-            this.listenerMap[tableId] ||
-            {}
+            hasOwn(this.listenerMap, tableId) ?
+                this.listenerMap[tableId] :
+                Object.create(null)
         );
         const listeners = listenerMap[state] = (
-            listenerMap[state] ||
-            []
+            hasOwn(listenerMap, state) ? listenerMap[state] : []
         );
 
         listeners.push(listener);
@@ -209,16 +209,21 @@ class DataCursor {
         const tableId = table.id,
             state = cursor.state,
             listeners = (
-                this.listenerMap[tableId] &&
-                this.listenerMap[tableId][state]
+                hasOwn(this.listenerMap, tableId) &&
+                hasOwn(this.listenerMap[tableId], state) ?
+                    this.listenerMap[tableId][state] :
+                    void 0
             );
 
         if (listeners) {
             const stateMap = this.stateMap[tableId] = (
-                this.stateMap[tableId] ?? {}
+                hasOwn(this.stateMap, tableId) ?
+                    this.stateMap[tableId] :
+                    Object.create(null)
             );
 
-            const cursors = stateMap[cursor.state] || [];
+            const cursors = hasOwn(stateMap, cursor.state) ?
+                stateMap[cursor.state] : [];
 
             if (lasting) {
 
@@ -287,8 +292,10 @@ class DataCursor {
         cursor: Type
     ): this {
         const cursors = (
-            this.stateMap[tableId] &&
-            this.stateMap[tableId][cursor.state]
+            hasOwn(this.stateMap, tableId) &&
+            hasOwn(this.stateMap[tableId], cursor.state) ?
+                this.stateMap[tableId][cursor.state] :
+                void 0
         );
 
         if (cursors) {
@@ -326,8 +333,10 @@ class DataCursor {
         listener: Listener
     ): this {
         const listeners = (
-            this.listenerMap[tableId] &&
-            this.listenerMap[tableId][state]
+            hasOwn(this.listenerMap, tableId) &&
+            hasOwn(this.listenerMap[tableId], state) ?
+                this.listenerMap[tableId][state] :
+                void 0
         );
 
         if (listeners) {
@@ -398,6 +407,18 @@ export type TableMap = Record<TableId, DataTable>;
  *  Functions
  *
  * */
+
+
+/**
+ * Checks whether a registry owns a key.
+ * @private
+ */
+function hasOwn(
+    registry: object,
+    key: PropertyKey
+): boolean {
+    return Object.prototype.hasOwnProperty.call(registry, key);
+}
 
 
 /**


### PR DESCRIPTION
## Summary
- store DataCursor listener registries without prototypes
- distinguish own table/state keys from inherited object members
- support prototype-named IDs through add, emit, lasting-state, remit, and removal paths

## Breaking changes
None. Previously unusable string keys now behave like ordinary IDs and states.

## Verification
- full pre-commit suite (419 Node unit tests)
- current and ES5 TypeScript builds
- focused DataCursor tests (22 passing)
- source lint, samples, and diff checks

Fixes #25171