### PR TITLE
bugfix/25173-google-sheets-end-row

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/Connectors/DataConnector.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/Connectors/DataConnector.test.ts
@@ -4,7 +4,7 @@ import { ok, deepStrictEqual, strictEqual } from 'node:assert';
 import DataConnector from '../../../../../ts/Data/Connectors/DataConnector';
 import CSVConnector from '../../../../../ts/Data/Connectors/CSVConnector';
 // Import these to register them with DataConnector.types
-import '../../../../../ts/Data/Connectors/GoogleSheetsConnector';
+import { buildQueryRange } from '../../../../../ts/Data/Connectors/GoogleSheetsConnector';
 import '../../../../../ts/Data/Connectors/HTMLTableConnector';
 import '../../../../../ts/Data/Connectors/JSONConnector';
 
@@ -141,5 +141,20 @@ describe('DataConnector', () => {
                 );
             });
         }
+    });
+
+    describe('Google Sheets ranges', () => {
+        it('should translate zero-based end rows to A1 notation', () => {
+            strictEqual(
+                buildQueryRange({ startRow: 0, endRow: 5 }),
+                'A1:Z6',
+                'A bounded end row should be incremented.'
+            );
+            strictEqual(
+                buildQueryRange({ startRow: 0, endRow: 0 }),
+                'A1:Z1',
+                'Row zero should remain a bounded first row.'
+            );
+        });
     });
 });

--- a/ts/Data/Connectors/GoogleSheetsConnector.ts
+++ b/ts/Data/Connectors/GoogleSheetsConnector.ts
@@ -332,8 +332,8 @@ export function buildQueryRange(
         ':' +
         (alphabet[(endColumn ?? 25)] || 'Z') +
         (
-            endRow ?
-                Math.max(endRow, 0) :
+            endRow !== void 0 ?
+                Math.max(endRow, 0) + 1 :
                 'Z'
         )
     );


### PR DESCRIPTION
## Summary
- translate the zero-based Google Sheets `endRow` option to one-based A1 notation
- preserve `endRow: 0` as a bounded first-row range
- cover both zero and a later endpoint in the range builder

## Breaking changes
None. Bounded ranges now request the documented inclusive row instead of one row earlier or all remaining rows.

## Verification
- focused DataConnector tests (10 passing)
- current and ES5 TypeScript builds
- whitespace checks

Direct source ESLint reaches the existing untracked-polling callback at line 241 (`no-misused-promises`). That callback is removed and fully verified independently in #25166; this focused range patch does not duplicate it.

Fixes #25173