### PR TITLE
bugfix/25175-distinct-cursor-emission-tags

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/DataCursor.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/DataCursor.test.ts
@@ -88,6 +88,35 @@ describe('DataCursor', () => {
             deepStrictEqual(test3Event?.cursors, [expectedCursor3], 'Lasting event should have cursors array with cursor.');
             strictEqual(test3Event?.table, table, 'Lasting event should have correct table.');
         });
+
+        it('should distinguish nested range column arrays', () => {
+            const cursor = new DataCursor(),
+                table = new DataTable();
+            let calls = 0;
+
+            cursor.addListener(table.id, 'hover', (): void => {
+                calls++;
+                if (calls === 1) {
+                    cursor.emitCursor(table, {
+                        type: 'range',
+                        columns: ['a', 'b'],
+                        firstRow: 0,
+                        lastRow: 1,
+                        state: 'hover'
+                    });
+                }
+            });
+
+            cursor.emitCursor(table, {
+                type: 'range',
+                columns: ['a,b'],
+                firstRow: 0,
+                lastRow: 1,
+                state: 'hover'
+            });
+
+            strictEqual(calls, 2, 'Both distinct cursors should be emitted.');
+        });
     });
 
     describe('isEqual', () => {

--- a/ts/Data/DataCursor.ts
+++ b/ts/Data/DataCursor.ts
@@ -149,7 +149,7 @@ class DataCursor {
     private buildEmittingTag(
         e: Event
     ): string {
-        return (
+        return JSON.stringify(
             e.cursor.type === 'position' ?
                 [
                     e.table.id,
@@ -166,7 +166,7 @@ class DataCursor {
                     e.cursor.state,
                     e.cursor.type
                 ]
-        ).join('\0');
+        );
     }
 
 


### PR DESCRIPTION
## Summary
- serialize cursor recursion keys structurally instead of joining coerced values
- preserve distinctions between one comma-containing column and multiple columns
- allow distinct nested cursor emissions while retaining same-cursor loop prevention

## Breaking changes
None. Only previously colliding distinct cursor events are now delivered.

## Verification
- full pre-commit suite (419 Node unit tests, 391 QUnit tests, 36 Dashboard tests with one existing skip)
- current and ES5 TypeScript builds
- focused DataCursor tests (22 passing)
- source lint, samples, and diff checks

Fixes #25175