### PR TITLE
bugfix/25177-cache-repeated-formulas

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/Modifiers/MathModifier.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/Modifiers/MathModifier.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from 'node:test';
 import { strictEqual, deepStrictEqual, ok } from 'node:assert';
 
 import DataTable from '../../../../../ts/Data/DataTable.js';
+import FormulaParser from '../../../../../ts/Data/Formula/FormulaParser.js';
 import MathModifier from '../../../../../ts/Data/Modifiers/MathModifier.js';
 // Import Formula to register all formula functions (SUM, AVERAGE, PRODUCT, etc.)
 import '../../../../../ts/Data/Formula/Formula.js';
@@ -126,6 +127,28 @@ describe('MathModifier', () => {
                 table.getModified().getColumn('ColumnE'),
                 [176040, 281000, 3842000, 63625, 161201],
                 'The advanced aggregate functions formula is properly calculated.'
+            );
+        });
+    });
+
+    describe('formula parsing', () => {
+        it('should reuse a parsed repeated formula', async (t) => {
+            const parseFormula = t.mock.method(FormulaParser, 'parseFormula'),
+                table = new DataTable({
+                    columns: {
+                        A: [1],
+                        B: ['=A1+1', '=A1+1', '=A1+1']
+                    }
+                });
+
+            await table.setModifier(new MathModifier({
+                formulaColumns: ['B']
+            }));
+
+            strictEqual(
+                parseFormula.mock.callCount(),
+                1,
+                'An unchanged formula should be parsed once.'
             );
         });
     });

--- a/ts/Data/Modifiers/MathModifier.ts
+++ b/ts/Data/Modifiers/MathModifier.ts
@@ -219,14 +219,13 @@ class MathModifier extends DataModifier {
             ) {
                 try {
                     // Use cache while formula string is repetitive
-                    cacheFormula = (
-                        cacheString === cell ?
-                            cacheFormula :
-                            FormulaParser.parseFormula(
-                                cell.substring(1),
-                                alternativeSeparators
-                            )
-                    );
+                    if (cacheString !== cell) {
+                        cacheFormula = FormulaParser.parseFormula(
+                            cell.substring(1),
+                            alternativeSeparators
+                        );
+                        cacheString = cell;
+                    }
                     // Process parsed formula string
                     column[i] =
                         FormulaProcessor.processFormula(cacheFormula, table);


### PR DESCRIPTION
## Summary
- update MathModifier's one-entry formula cache after parsing
- parse consecutive identical formulas once instead of once per cell
- retain the same formula processing and error behavior

## Breaking changes
None. This activates the existing documented cache without changing results.

## Verification
- full pre-commit suite (419 Node unit tests)
- current and ES5 TypeScript builds
- focused MathModifier tests (4 passing)
- source lint, samples, and diff checks

Fixes #25177