### PR TITLE
bugfix/25179-deduplicate-formula-columns

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/Modifiers/MathModifier.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/Modifiers/MathModifier.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from 'node:test';
 import { strictEqual, deepStrictEqual, ok } from 'node:assert';
 
 import DataTable from '../../../../../ts/Data/DataTable.js';
+import FormulaParser from '../../../../../ts/Data/Formula/FormulaParser.js';
 import MathModifier from '../../../../../ts/Data/Modifiers/MathModifier.js';
 // Import Formula to register all formula functions (SUM, AVERAGE, PRODUCT, etc.)
 import '../../../../../ts/Data/Formula/Formula.js';
@@ -126,6 +127,28 @@ describe('MathModifier', () => {
                 table.getModified().getColumn('ColumnE'),
                 [176040, 281000, 3842000, 63625, 161201],
                 'The advanced aggregate functions formula is properly calculated.'
+            );
+        });
+    });
+
+    describe('formula columns', () => {
+        it('should process each column once', async (t) => {
+            const parseFormula = t.mock.method(FormulaParser, 'parseFormula'),
+                table = new DataTable({
+                    columns: {
+                        A: [1],
+                        B: ['=A1+1']
+                    }
+                });
+
+            await table.setModifier(new MathModifier({
+                formulaColumns: ['B', 'B']
+            }));
+
+            strictEqual(
+                parseFormula.mock.callCount(),
+                1,
+                'A duplicate formula column should not be processed twice.'
             );
         });
     });

--- a/ts/Data/Modifiers/MathModifier.ts
+++ b/ts/Data/Modifiers/MathModifier.ts
@@ -127,22 +127,12 @@ class MathModifier extends DataModifier {
             ),
             modified = table.getModified();
 
-        for (
-            let i = 0,
-                iEnd = formulaColumns.length,
-                columnId: string;
-            i < iEnd;
-            ++i
-        ) {
-            columnId = formulaColumns[i];
-
-            if (formulaColumns.indexOf(columnId) >= 0) {
-                modified.setColumn(
-                    columnId,
-                    modifier.processColumn(table, columnId)
-                );
-            }
-        }
+        new Set(formulaColumns).forEach((columnId): void => {
+            modified.setColumn(
+                columnId,
+                modifier.processColumn(table, columnId)
+            );
+        });
 
         const columnFormulas = (modifier.options.columnFormulas || []);
 


### PR DESCRIPTION
## Summary

- Deduplicate `formulaColumns` before processing them.
- Avoid recalculating and replacing the same modified column when its ID is configured more than once.
- Add a regression test that verifies one formula parse for a duplicated column ID.

## Breaking changes

None. Duplicate entries now produce the same result with one calculation instead of repeating identical work.

## Verification

- Targeted MathModifier tests: 4 passed.
- TypeScript source lint passed.
- Current and ES5 builds passed.
- Pre-commit suite: 36 Dashboard tests passed, 1 existing skip; 391 Highcharts/QUnit tests passed; 419 Node tests passed.
- `git diff --check` passed.

Fixes #25179