### PR TITLE
bugfix/25181-data-connector-table-keys

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/Connectors/DataConnector.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/Connectors/DataConnector.test.ts
@@ -142,4 +142,35 @@ describe('DataConnector', () => {
             });
         }
     });
+
+    describe('data tables', () => {
+        it('should support empty and prototype-named table keys', () => {
+            const connector = new CSVConnector({
+                dataTables: [
+                    { key: '' },
+                    { key: '__proto__' },
+                    { key: 'toString' }
+                ]
+            });
+
+            strictEqual(
+                connector.getTable(),
+                connector.getTable(''),
+                'The empty key should identify the first table.'
+            );
+            deepStrictEqual(
+                Object.keys(connector.dataTables),
+                ['', '__proto__', 'toString'],
+                'Every configured key should identify its own table.'
+            );
+            ok(
+                connector.getTable('__proto__') !== connector.getTable(''),
+                'The __proto__ key should identify its own table.'
+            );
+            ok(
+                connector.getTable('toString') !== connector.getTable(''),
+                'The toString key should identify its own table.'
+            );
+        });
+    });
 });

--- a/ts/Data/Connectors/DataConnector.ts
+++ b/ts/Data/Connectors/DataConnector.ts
@@ -115,7 +115,7 @@ abstract class DataConnector implements DataEventEmitter<Event> {
     /**
      * Tables managed by this DataConnector instance.
      */
-    public readonly dataTables: Record<string, DataTable> = {};
+    public readonly dataTables: Record<string, DataTable> = Object.create(null);
 
     /**
      * The options of the connector.
@@ -178,7 +178,7 @@ abstract class DataConnector implements DataEventEmitter<Event> {
                 this.dataTables[key ?? dataTableIndex] =
                     new DataTable(dataTable);
 
-                if (!key) {
+                if (typeof key === 'undefined') {
                     dataTableIndex++;
                 }
             }
@@ -208,7 +208,7 @@ abstract class DataConnector implements DataEventEmitter<Event> {
      * The data table instance.
      */
     public getTable(key?: string): DataTable {
-        if (key) {
+        if (typeof key !== 'undefined') {
             return this.dataTables[key];
         }
         return Object.values(this.dataTables)[0];


### PR DESCRIPTION
## Summary

- Store connector tables in a prototype-free registry.
- Treat only `undefined` as a missing table key, so empty-string keys remain valid.
- Add regression coverage for empty, `__proto__`, and `toString` keys.

## Breaking changes

None. Previously unusable string keys now follow the existing `key?: string` contract.

## Verification

- Focused DataConnector tests: 10 passed.
- Full Node suite: 419 passed.
- Current and ES5 TypeScript builds passed.
- Changed-source lint, generated-sample validation, pre-commit hooks, and `git diff --check` passed.

Fixes #25181