### PR TITLE
bugfix/25183-html-table-falsy-values

### DIFF
--- a/tests/dashboards/html-table-connector.spec.ts
+++ b/tests/dashboards/html-table-connector.spec.ts
@@ -451,4 +451,43 @@ test.describe('HTMLTableConnector', () => {
         expect(result.loadError).toBe(false);
         expect(result.exportedMatchesOriginal).toBe(true);
     });
+
+    test('Export preserves falsy values', async ({ page }) => {
+        await page.setContent(`
+            <!DOCTYPE html>
+            <html>
+                <head>
+                    <script src="https://code.highcharts.com/highcharts.src.js"></script>
+                    <script src="https://code.highcharts.com/modules/data-tools.src.js"></script>
+                </head>
+                <body></body>
+            </html>
+        `, { waitUntil: 'networkidle' });
+
+        const result = await page.evaluate(() => {
+            const Highcharts = (window as any).Highcharts,
+                HTMLTableConnector =
+                    Highcharts.DataConnector.types.HTMLTable,
+                connector = new HTMLTableConnector({
+                    dataTables: [{
+                        columns: {
+                            value: [0, false, true]
+                        }
+                    }]
+                }),
+                table = document.createElement('div');
+
+            table.innerHTML = connector.converter.export(connector);
+
+            return {
+                subheader: table.querySelector('thead tr:last-child th')
+                    ?.textContent,
+                values: Array.from(table.querySelectorAll('tbody th'))
+                    .map((cell): string | null => cell.textContent)
+            };
+        });
+
+        expect(result.subheader).toBe('0');
+        expect(result.values).toStrictEqual(['false', 'true']);
+    });
 });

--- a/ts/Data/Converters/HTMLTableConverter.ts
+++ b/ts/Data/Converters/HTMLTableConverter.ts
@@ -192,7 +192,7 @@ class HTMLTableConverter extends DataConverter {
                         column = Array.from(column);
                     }
 
-                    const subhead = (column.shift() || '').toString();
+                    const subhead = (column.shift() ?? '').toString();
                     columns[columnId] = column;
 
                     subcategories.push(subhead);
@@ -231,7 +231,7 @@ class HTMLTableConverter extends DataConverter {
                         typeof cellValue === 'undefined'
                     )
                 ) {
-                    cellValue = (cellValue || '').toString();
+                    cellValue = (cellValue ?? '').toString();
                 }
 
                 rowArray[rowIndex][columnIndex] = this.getCellHTMLFromValue(


### PR DESCRIPTION
## Summary

- Preserve numeric zero when exporting multilevel table subheaders.
- Preserve boolean false when exporting body cells.
- Add browser-level regression coverage for both values.

## Breaking changes

None. Valid falsy table values are no longer serialized as empty cells.

## Verification

- Focused HTML table export tests: 4 passed.
- Dashboard suite: 38 passed.
- Full Node suite: 418 passed.
- Highcharts/QUnit suite: 391 passed.
- Current and ES5 TypeScript builds, changed-source lint, and `git diff --check` passed.

Fixes #25183