### PR TITLE
bugfix/25184-typed-column-splice-bounds

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/ColumnUtils.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/ColumnUtils.test.ts
@@ -1,0 +1,41 @@
+import { describe, it } from 'node:test';
+import { deepStrictEqual } from 'node:assert';
+
+import ColumnUtils from '../../../../ts/Data/ColumnUtils.js';
+
+describe('ColumnUtils', () => {
+    describe('splice', () => {
+        const cases: Array<[number, number, number[]]> = [
+            [-2, 1, [8]],
+            [-10, 1, [8]],
+            [10, 1, [8]],
+            [1, 10, [8]],
+            [1, -1, [8]],
+            [1.9, 1.9, [8]],
+            [NaN, NaN, [8]],
+            [Infinity, 1, [8]],
+            [-Infinity, 1, [8]]
+        ];
+
+        for (const [start, deleteCount, items] of cases) {
+            it(`should match Array.splice at start ${start}`, () => {
+                const expected = [1, 2, 3],
+                    expectedRemoved = expected.splice(
+                        start,
+                        deleteCount,
+                        ...items
+                    ),
+                    result = ColumnUtils.splice(
+                        new Uint8Array([1, 2, 3]),
+                        start,
+                        deleteCount,
+                        false,
+                        items
+                    );
+
+                deepStrictEqual(Array.from(result.array), expected);
+                deepStrictEqual(Array.from(result.removed), expectedRemoved);
+            });
+        }
+    });
+});

--- a/ts/Data/ColumnUtils.ts
+++ b/ts/Data/ColumnUtils.ts
@@ -140,16 +140,34 @@ export function splice(
     const Constructor = Object.getPrototypeOf(column)
         .constructor as TypedArrayConstructor;
 
+    const normalizedStart = isNaN(start) ? 0 : Math.trunc(start),
+        normalizedDeleteCount = isNaN(deleteCount) ? 0 : Math.trunc(
+            deleteCount
+        ),
+        startIndex = Math.min(
+            normalizedStart < 0 ?
+                Math.max(column.length + normalizedStart, 0) :
+                normalizedStart,
+            column.length
+        ),
+        removedCount = Math.min(
+            Math.max(normalizedDeleteCount, 0),
+            column.length - startIndex
+        );
+
     const removed = column[
         removedAsSubarray ? 'subarray' : 'slice'
-    ](start, start + deleteCount);
+    ](startIndex, startIndex + removedCount);
 
-    const newLength = column.length - deleteCount + items.length;
+    const newLength = column.length - removedCount + items.length;
     const result = new Constructor(newLength);
 
-    result.set(column.subarray(0, start), 0);
-    result.set(items as (number[]|TypedArray), start);
-    result.set(column.subarray(start + deleteCount), start + items.length);
+    result.set(column.subarray(0, startIndex), 0);
+    result.set(items as (number[]|TypedArray), startIndex);
+    result.set(
+        column.subarray(startIndex + removedCount),
+        startIndex + items.length
+    );
 
     return {
         removed: removed,


### PR DESCRIPTION
## Summary

- Normalize typed-column splice starts using `Array.splice` numeric semantics.
- Clamp delete counts to the available range before allocating and copying.
- Add parity coverage for negative, out-of-range, fractional, `NaN`, and infinite arguments.

## Breaking changes

None. Typed-array-backed columns now match the existing ordinary-array branch for valid splice arguments.

## Verification

- Focused ColumnUtils tests: 9 passed.
- Full Node suite: 427 passed.
- Highcharts/QUnit suite: 391 passed.
- Dashboard suite: 36 passed, 1 existing skip.
- Current and ES5 TypeScript builds, changed-source lint, and `git diff --check` passed.

Fixes #25184