### PR TITLE
bugfix/25188-math-column-formula-row-range

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/Modifiers/MathModifier.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/Modifiers/MathModifier.test.ts
@@ -94,6 +94,35 @@ describe('MathModifier', () => {
                 'Opposite celsius is a negative value.'
             );
         });
+
+        it('should apply column formulas within their configured rows', async () => {
+            const table = new DataTable({
+                columns: {
+                    Kelvin: [273.15, 283.15, 293.15, 303.15, 313.15],
+                    Celsius: [0, 10, 0, 0, 40]
+                }
+            });
+
+            await table.setModifier(new MathModifier({
+                columnFormulas: [{
+                    column: 'Celsius',
+                    formula: 'A1 - 273.15',
+                    rowStart: 2,
+                    rowEnd: 4
+                }]
+            }));
+
+            deepStrictEqual(
+                table.getModified().getColumn('Celsius'),
+                [0, 10, 20, 30, 40],
+                'Only rows in the configured range should be replaced.'
+            );
+            strictEqual(
+                table.getModified().getRowCount(),
+                table.getRowCount(),
+                'A partial column formula should not truncate the table.'
+            );
+        });
     });
 
     describe('advanced formulas', () => {

--- a/ts/Data/Modifiers/MathModifier.ts
+++ b/ts/Data/Modifiers/MathModifier.ts
@@ -155,19 +155,25 @@ class MathModifier extends DataModifier {
             ++i
         ) {
             columnFormula = columnFormulas[i];
+            const rowStart = Math.max(columnFormula.rowStart ?? 0, 0),
+                column = Array.from(
+                    modified.getColumn(columnFormula.column, true) ||
+                    new Array(table.getRowCount())
+                );
             formula = FormulaParser.parseFormula(
                 columnFormula.formula,
                 alternativeSeparators
             );
-            modified.setColumn(
-                columnFormula.column,
-                modifier.processColumnFormula(
-                    formula,
-                    table,
-                    columnFormula.rowStart,
-                    columnFormula.rowEnd
-                )
+            const values = modifier.processColumnFormula(
+                formula,
+                table,
+                rowStart,
+                columnFormula.rowEnd
             );
+            for (let j = 0, jEnd = values.length; j < jEnd; ++j) {
+                column[rowStart + j] = values[j];
+            }
+            modified.setColumn(columnFormula.column, column);
         }
 
         modifier.emit({ type: 'afterModify', detail: eventDetail, table });
@@ -273,6 +279,13 @@ class MathModifier extends DataModifier {
         const column = [],
             modified = table.getModified();
 
+        if (rowStart) {
+            formula = FormulaProcessor.translateReferences(
+                formula,
+                0,
+                rowStart
+            );
+        }
 
         for (let i = 0, iEnd = (rowEnd - rowStart); i < iEnd; ++i) {
             try {


### PR DESCRIPTION
## Summary

- Apply partial column-formula results at their configured row offset.
- Preserve destination values outside the selected range and retain the table length.
- Translate relative formula references to `rowStart`.
- Add a regression covering a bounded middle range.

## Breaking changes

None. `rowStart` and `rowEnd` now constrain and align replacements according to their documented row indices.

## Verification

- Focused MathModifier suite: 4 tests passed.
- Full Node suite: 419 tests passed.
- Affected browser, Grid, and Dashboard checks passed.
- Current and ES5 TypeScript builds, changed-source lint, and `git diff --check` passed.

Fixes #25188