### PR TITLE
bugfix/25189-date-to-number-timestamp

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/Converters/DataConverter.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/Converters/DataConverter.test.ts
@@ -125,6 +125,16 @@ describe('DataConverter', () => {
                 'Should handle decimal point set by a user.'
             );
         });
+
+        it('should convert dates to timestamps', () => {
+            const date = new Date('2020-01-09T12:34:56Z');
+
+            strictEqual(
+                DataConverterUtils.asNumber(date),
+                date.getTime(),
+                'A date should retain its complete numeric value.'
+            );
+        });
     });
 
     describe('asDate', () => {

--- a/ts/Data/Converters/DataConverterUtils.ts
+++ b/ts/Data/Converters/DataConverterUtils.ts
@@ -99,7 +99,7 @@ export function asNumber(
     }
 
     if (value instanceof Date) {
-        return value.getDate();
+        return value.getTime();
     }
     if (value) {
         return value.getRowCount();


### PR DESCRIPTION
## Summary

- Convert Date values with `getTime()` instead of `getDate()`.
- Preserve the complete epoch timestamp rather than only the local day of month.
- Add a regression using a date with nonzero date and time components.

## Breaking changes

Date conversion now returns the full timestamp instead of the incorrect day-of-month value. This is a correctness change for callers that happened to rely on the previous 1–31 result.

## Verification

- Focused DataConverter suite: 15 tests passed.
- Full Node suite: 419 tests passed.
- Current and ES5 TypeScript builds, changed-source lint, and `git diff --check` passed.

Fixes #25189