### PR TITLE
bugfix/25187-json-missing-nested-values

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/Connectors/JSONConnector.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/Connectors/JSONConnector.test.ts
@@ -121,6 +121,33 @@ describe('JSONConnector', () => {
                 'Should have correct Column Ids'
             );
         });
+
+        it('should preserve rows with missing nested values', async () => {
+            const connector = new JSONConnector({
+                columnIds: {
+                    id: ['id'],
+                    score: ['metrics', 'score']
+                },
+                data: [{
+                    id: 1,
+                    metrics: { score: 5 }
+                }, {
+                    id: 2
+                }] as any,
+                firstRowAsNames: false
+            });
+
+            await connector.load();
+
+            deepStrictEqual(
+                connector.getTable().getColumns(['id', 'score']),
+                {
+                    id: [1, 2],
+                    score: [5, void 0]
+                },
+                'A missing nested path should produce an empty cell.'
+            );
+        });
     });
 
     describe('with beforeParse', () => {

--- a/ts/Data/Converters/JSONConverter.ts
+++ b/ts/Data/Converters/JSONConverter.ts
@@ -329,8 +329,12 @@ class JSONConverter extends DataConverter {
                     name
                 ): void => {
                     newRow.push(arrayWithPath.reduce(
-                        (acc: any, key: string | number): any =>
-                            acc[key], rowObj
+                        (acc: any, key: string | number): any => (
+                            acc === null || typeof acc === 'undefined' ?
+                                void 0 :
+                                acc[key]
+                        ),
+                        rowObj
                     ));
                     if (converter.headers.indexOf(name) < 0) {
                         converter.headers.push(name);


### PR DESCRIPTION
## Summary

- Stop nested JSON path traversal when an intermediate value is nullish.
- Preserve the row and emit an empty cell for the missing nested value.
- Add regression coverage for mixed complete and incomplete object rows.

## Breaking changes

None. Missing nested values no longer abort the complete connector load.

## Verification

- Focused JSON connector suite: 9 tests passed.
- Full Node suite: 419 tests passed.
- Current and ES5 TypeScript builds, changed-source lint, and `git diff --check` passed.

Fixes #25187