### PR TITLE
bugfix/25193-csv-multiline-fields

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/Connectors/CSVConnector.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/Connectors/CSVConnector.test.ts
@@ -155,6 +155,25 @@ describe('CSVConnector', () => {
                 dataType: 'string'
             });
         });
+
+        it('should preserve line breaks inside quoted fields', async () => {
+            const connector = new CSVConnector({
+                csv: 'Name,Note\nA,"first\nsecond"\nB,end'
+            });
+
+            await connector.load();
+
+            strictEqual(
+                connector.getTable().getRowCount(),
+                2,
+                'A multiline field should remain one logical row.'
+            );
+            strictEqual(
+                connector.getTable().getCell('Note', 0),
+                'first\nsecond',
+                'The line break should remain in the field value.'
+            );
+        });
     });
 
     // Note: URL-based tests require browser/fetch and are handled in Playwright tests

--- a/ts/Data/Converters/CSVConverter.ts
+++ b/ts/Data/Converters/CSVConverter.ts
@@ -161,9 +161,10 @@ class CSVConverter extends DataConverter {
         }
 
         if (csv) {
-            lines = csv
-                .replace(/\r\n|\r/g, '\n') // Windows | Mac
-                .split(lineDelimiter || '\n');
+            lines = converter.parseCSVLines(
+                csv.replace(/\r\n|\r/g, '\n'), // Windows | Mac
+                lineDelimiter || '\n'
+            );
 
             if (!startRow || startRow < 0) {
                 startRow = 0;
@@ -253,6 +254,42 @@ class CSVConverter extends DataConverter {
         return DataConverterUtils.getColumnsCollection(
             columnsArray, converter.headers
         );
+    }
+
+    /**
+     * Splits CSV into logical rows without breaking quoted multiline fields.
+     */
+    private parseCSVLines(
+        csv: string,
+        lineDelimiter: string
+    ): string[] {
+        const lines: string[] = [];
+        let inQuotes = false,
+            line = '';
+
+        for (let i = 0; i < csv.length; ++i) {
+            const character = csv[i];
+
+            if (character === '"') {
+                if (inQuotes && csv[i + 1] === '"') {
+                    line += '""';
+                    ++i;
+                    continue;
+                }
+                inQuotes = !inQuotes;
+            }
+
+            if (!inQuotes && csv.startsWith(lineDelimiter, i)) {
+                lines.push(line);
+                line = '';
+                i += lineDelimiter.length - 1;
+            } else {
+                line += character;
+            }
+        }
+        lines.push(line);
+
+        return lines;
     }
 
     /**


### PR DESCRIPTION
## Summary

- Split CSV input into logical rows only when the configured line delimiter occurs outside quotes.
- Preserve embedded line breaks and doubled quotes while scanning records.
- Add regression coverage for a multiline quoted field followed by another row.

## Breaking changes

None. Quoted line delimiters now follow standard CSV field behavior.

## Verification

- Focused CSV connector suite: 7 tests passed.
- Full Node suite: 419 tests passed.
- Current and ES5 TypeScript builds, changed-source lint, and `git diff --check` passed.

Fixes #25193