### PR TITLE
bugfix/25195-csv-quoted-headers

### DIFF
--- a/test/ts-node-unit-tests/tests/Data/Connectors/CSVConnector.test.ts
+++ b/test/ts-node-unit-tests/tests/Data/Connectors/CSVConnector.test.ts
@@ -84,6 +84,49 @@ describe('CSVConnector', () => {
             );
         });
 
+        it('should parse quoted delimiters and escaped quotes in headers', async () => {
+            const connector = new CSVConnector({
+                csv: '"Last, First","He said ""hi"""\nDoe,1'
+            });
+
+            await connector.load();
+
+            deepStrictEqual(
+                connector.getTable().getColumnIds(),
+                ['Last, First', 'He said "hi"'],
+                'Quoted header contents should remain in their own columns.'
+            );
+        });
+
+        it('should strip surrounding single quotes from headers', async () => {
+            const connector = new CSVConnector({
+                csv: "'Name','Value'\nA,1"
+            });
+
+            await connector.load();
+
+            deepStrictEqual(
+                connector.getTable().getColumnIds(),
+                ['Name', 'Value'],
+                'Single-quoted headers should retain their existing format.'
+            );
+        });
+
+        it('should read headers from the configured start row', async () => {
+            const connector = new CSVConnector({
+                csv: 'metadata\nignored\nName,Value\nA,1',
+                startRow: 2
+            });
+
+            await connector.load();
+
+            deepStrictEqual(
+                connector.getTable().getColumnIds(),
+                ['Name', 'Value'],
+                'The selected range should supply its own header row.'
+            );
+        });
+
         it('should handle decimalpoint option', async () => {
             const csvWithDecimal = 'Date;Value\n2016-01-01;1,100\n2016-01-02;2,000\n2016-01-03;3,000';
 

--- a/ts/Data/Converters/CSVConverter.ts
+++ b/ts/Data/Converters/CSVConverter.ts
@@ -181,16 +181,10 @@ class CSVConverter extends DataConverter {
             // If the first row contain names, add them to the
             // headers array and skip the row.
             if (firstRowAsNames) {
-                const headers = lines[0].split(
+                converter.headers = converter.parseCSVHeader(
+                    lines[startRow],
                     itemDelimiter || converter.guessedItemDelimiter || ','
                 );
-
-                // Remove ""s from the headers
-                for (let i = 0; i < headers.length; i++) {
-                    headers[i] = headers[i].trim().replace(/^["']|["']$/g, '');
-                }
-
-                converter.headers = headers;
 
                 startRow++;
             }
@@ -253,6 +247,49 @@ class CSVConverter extends DataConverter {
         return DataConverterUtils.getColumnsCollection(
             columnsArray, converter.headers
         );
+    }
+
+    /**
+     * Parses one CSV header row while preserving delimiters, escaped quotes,
+     * and whitespace inside quoted fields.
+     */
+    private parseCSVHeader(
+        row: string,
+        itemDelimiter: string
+    ): string[] {
+        const headers: string[] = [];
+        let inQuotes = false,
+            quoted = false,
+            token = '';
+
+        const push = (): void => {
+            headers.push(
+                quoted ? token : token.trim().replace(/^'|'$/g, '')
+            );
+            quoted = false;
+            token = '';
+        };
+
+        for (let i = 0; i < row.length; ++i) {
+            const character = row[i];
+
+            if (character === '"') {
+                if (inQuotes && row[i + 1] === '"') {
+                    token += '"';
+                    ++i;
+                } else {
+                    inQuotes = !inQuotes;
+                    quoted = true;
+                }
+            } else if (character === itemDelimiter && !inQuotes) {
+                push();
+            } else {
+                token += character;
+            }
+        }
+        push();
+
+        return headers;
     }
 
     /**


### PR DESCRIPTION
## Summary

- Parse CSV headers without splitting delimiters inside double-quoted fields.
- Decode doubled quotes in header values.
- Read the header from the configured `startRow`.
- Preserve existing surrounding single-quote cleanup.

## Breaking changes

None. Header parsing now follows CSV quoting rules while retaining prior single-quoted-header compatibility.

## Verification

- Focused CSV connector suite: 9 tests passed.
- Full Node suite: 421 tests passed.
- Affected browser suites passed.
- Current and ES5 TypeScript builds, changed-source lint, and `git diff --check` passed.

Fixes #25195