### PR TITLE
bugfix/25197-sonification-destroy-update-timeout

### DIFF
--- a/tests/highcharts/sonification/sonification.spec.ts
+++ b/tests/highcharts/sonification/sonification.spec.ts
@@ -189,3 +189,36 @@ test('Sonification: mapping functions', async ({ page }) => {
         );
     });
 });
+
+test('Sonification: destroy cancels scheduled updates', async ({ page }) => {
+    const chart = await createChart(page, {
+        sonification: {
+            updateInterval: 100
+        },
+        series: [{ data: [1, 2, 3] }]
+    }, {
+        chartConstructor: 'chart',
+        modules: ['modules/sonification.js']
+    });
+
+    const updateCount = await chart.evaluate(async (c: any) => {
+        const sonification = c.sonification,
+            update = sonification.update.bind(sonification);
+        let count = 0;
+
+        sonification.ready = (): boolean => true;
+        sonification.lastUpdate = Date.now();
+        sonification.update = (): void => {
+            ++count;
+            update();
+        };
+
+        sonification.update();
+        c.destroy();
+        await new Promise((resolve): number => setTimeout(resolve, 100));
+
+        return count;
+    });
+
+    expect(updateCount).toBe(1);
+});

--- a/ts/Extensions/Sonification/Sonification.ts
+++ b/ts/Extensions/Sonification/Sonification.ts
@@ -566,6 +566,8 @@ class Sonification {
      */
     destroy(): void {
         this.unbindKeydown();
+        internalClearTimeout(this.scheduledUpdate);
+        delete this.scheduledUpdate;
         if (this.timeline) {
             this.timeline.destroy();
             delete this.timeline;


### PR DESCRIPTION
## Summary

- Cancel the throttled sonification update timeout during destroy.
- Release the stored timeout handle after cancellation.
- Add a browser regression proving no deferred update runs after chart destruction.

## Breaking changes

None. Destroyed sonification instances no longer execute pending update work.

## Verification

- Focused sonification browser suite: 2 tests passed.
- Full Node suite: 418 tests passed.
- Changed-source and test lint, pre-commit checks, and `git diff --check` passed.

Fixes #25197