### PR TITLE
bugfix/25199-dashboard-sidebar-show-timeout

### DIFF
--- a/tests/dashboards/layout.spec.ts
+++ b/tests/dashboards/layout.spec.ts
@@ -613,4 +613,35 @@ test.describe('Layout Tests', () => {
             'layoutChanged should be fired with type cellDestroyed when cell is destroyed (#24258)'
         ).toContainEqual({ type: 'cellDestroyed', target: 'cell-1' });
     });
+
+    test('Hiding sidebar cancels its pending show transition', async ({ page }) => {
+        await page.setContent(
+            dashboardsWithHighchartsAndEditModeHTML,
+            { waitUntil: 'networkidle' }
+        );
+
+        const result = await page.evaluate(async () => {
+            const Dashboards = (window as any).Dashboards;
+            const board = Dashboards.board('container', {
+                editMode: { enabled: true }
+            });
+
+            board.editMode.toggleEditMode(true);
+            const sidebar = board.editMode.sidebar;
+
+            sidebar.show();
+            sidebar.hide();
+            await new Promise((resolve): void => setTimeout(resolve));
+
+            return {
+                className: sidebar.container.className,
+                isVisible: sidebar.isVisible
+            };
+        });
+
+        expect(result.isVisible).toBe(false);
+        expect(result.className).not.toContain(
+            'highcharts-dashboards-edit-sidebar-show'
+        );
+    });
 });

--- a/ts/Dashboards/EditMode/SidebarPopup.ts
+++ b/ts/Dashboards/EditMode/SidebarPopup.ts
@@ -188,6 +188,11 @@ class SidebarPopup extends BaseForm {
     public isVisible = false;
 
     /**
+     * Pending timeout that applies the sidebar's visible-position class.
+     */
+    private showClassTimeout?: number;
+
+    /**
      * List of components that can be added to the board.
      */
     private componentsList: Array<AddComponentDetails> = [];
@@ -240,6 +245,9 @@ class SidebarPopup extends BaseForm {
         const classNames = EditGlobals.classNames,
             classList = this.container.classList;
 
+        clearTimeout(this.showClassTimeout);
+        delete this.showClassTimeout;
+
         classList.remove(classNames.editSidebarShow);
         classList.remove(classNames.editSidebarRightShow);
     }
@@ -264,7 +272,9 @@ class SidebarPopup extends BaseForm {
             );
         }
 
-        setTimeout((): void => {
+        clearTimeout(this.showClassTimeout);
+        this.showClassTimeout = setTimeout((): void => {
+            delete this.showClassTimeout;
             classList.add(EditGlobals.classNames[
                 isRightSidebar ? 'editSidebarRightShow' : 'editSidebarShow'
             ]


### PR DESCRIPTION
## Summary

- Track the deferred sidebar show-class callback.
- Cancel and release it when hiding or scheduling another side transition.
- Add a public show-then-hide regression.

## Breaking changes

None. Hidden sidebars no longer regain a visible-position class from stale deferred work.

## Verification

- Focused Dashboard layout suite: 10 tests passed.
- Full Dashboard hook: 37 passed, 1 existing skip.
- Affected QUnit checks: 15 passed.
- Full Node suite: 418 tests passed.
- Current and ES5 builds, source/test lint, generated-sample validation, and `git diff --check` passed.

Fixes #25199