### PR TITLE
bugfix/25201-boost-failed-init-render-loop

### DIFF
--- a/test/ts-node-unit-tests/tests/Extensions/Boost/WGLRenderer.test.ts
+++ b/test/ts-node-unit-tests/tests/Extensions/Boost/WGLRenderer.test.ts
@@ -1,0 +1,29 @@
+import { strictEqual } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import WGLRenderer from '../../../../../ts/Extensions/Boost/WGLRenderer';
+
+describe('WGLRenderer', () => {
+    it('does not retry rendering after initialization failed', () => {
+        const renderer = new WGLRenderer(() => {});
+        const originalSetTimeout = globalThis.setTimeout;
+        let scheduledTimeouts = 0;
+
+        globalThis.setTimeout = (() => {
+            ++scheduledTimeouts;
+            return 1;
+        }) as unknown as typeof setTimeout;
+
+        try {
+            strictEqual(
+                renderer.render({
+                    renderer: { forExport: false }
+                } as any),
+                false
+            );
+            strictEqual(scheduledTimeouts, 0);
+        } finally {
+            globalThis.setTimeout = originalSetTimeout;
+        }
+    });
+});

--- a/ts/Extensions/Boost/WGLRenderer.ts
+++ b/ts/Extensions/Boost/WGLRenderer.ts
@@ -1677,9 +1677,7 @@ class WGLRenderer {
         if (this.isInited) {
             this.renderChart(chart);
         } else {
-            setTimeout((): void => {
-                this.render(chart);
-            }, 1);
+            return false;
         }
     }
 


### PR DESCRIPTION
## Summary

- Stop Boost rendering immediately when its synchronous WebGL renderer initialization has failed.
- Avoid the unbounded 1 ms retry loop because no pending state can initialize that renderer later.
- Add a focused regression that verifies the failed renderer returns `false` without scheduling a timeout.

## Breaking changes

None. This only removes retries from an already failed renderer; successful and export rendering paths are unchanged.

## Verification

- Focused `WGLRenderer` regression passed.
- Full Node unit suite: 419 tests passed.
- Current and ES5 TypeScript builds passed.
- Source lint, sample checks, and `git diff --check` passed.

Fixes #25201