### PR TITLE
bugfix/25203-treegraph-endpoint-width-layout

### DIFF
--- a/samples/unit-tests/series-treegraph/treegraph/demo.js
+++ b/samples/unit-tests/series-treegraph/treegraph/demo.js
@@ -212,3 +212,49 @@ QUnit.test(
         );
     }
 );
+
+QUnit.test('Treegraph with unequal endpoint widths', function (assert) {
+    const chart = Highcharts.chart('container', {
+            chart: {
+                animation: false
+            },
+            series: [{
+                type: 'treegraph',
+                data: [{
+                    id: 'root',
+                    marker: {
+                        symbol: 'rect',
+                        width: 100
+                    }
+                }, {
+                    id: 'leaf',
+                    parent: 'root',
+                    marker: {
+                        symbol: 'rect',
+                        width: 20
+                    }
+                }],
+                dataLabels: {
+                    enabled: false
+                },
+                link: {
+                    lineWidth: 0
+                },
+                marker: {
+                    lineWidth: 0
+                }
+            }]
+        }),
+        points = chart.series[0].points;
+
+    assert.strictEqual(
+        points[0].shapeArgs.x,
+        0,
+        'The wider root starts at the left plot edge.'
+    );
+    assert.strictEqual(
+        points[1].shapeArgs.x + points[1].shapeArgs.width,
+        chart.plotSizeX,
+        'The narrower leaf ends at the right plot edge.'
+    );
+});

--- a/ts/Series/Treegraph/TreegraphSeries.ts
+++ b/ts/Series/Treegraph/TreegraphSeries.ts
@@ -227,21 +227,32 @@ class TreegraphSeries extends TreemapSeries {
             node.nodeSizeX = nodeSizeX;
             node.nodeSizeY = nodeSizeY;
 
-            if (node.xPosition <= minX) {
+            const nodeSizeWithLineX = nodeSizeX + lineWidth,
+                nodeSizeWithLineY = nodeSizeY + lineWidth;
+
+            if (node.xPosition < minX) {
                 minX = node.xPosition;
-                minXSize = Math.max(nodeSizeX + lineWidth, minXSize);
+                minXSize = nodeSizeWithLineX;
+            } else if (node.xPosition === minX) {
+                minXSize = Math.max(nodeSizeWithLineX, minXSize);
             }
-            if (node.xPosition >= maxX) {
+            if (node.xPosition > maxX) {
                 maxX = node.xPosition;
-                maxXSize = Math.max(nodeSizeX + lineWidth, maxXSize);
+                maxXSize = nodeSizeWithLineX;
+            } else if (node.xPosition === maxX) {
+                maxXSize = Math.max(nodeSizeWithLineX, maxXSize);
             }
-            if (node.yPosition <= minY) {
+            if (node.yPosition < minY) {
                 minY = node.yPosition;
-                minYSize = Math.max(nodeSizeY + lineWidth, minYSize);
+                minYSize = nodeSizeWithLineY;
+            } else if (node.yPosition === minY) {
+                minYSize = Math.max(nodeSizeWithLineY, minYSize);
             }
-            if (node.yPosition >= maxY) {
+            if (node.yPosition > maxY) {
                 maxY = node.yPosition;
-                maxYSize = Math.max(nodeSizeY + lineWidth, maxYSize);
+                maxYSize = nodeSizeWithLineY;
+            } else if (node.yPosition === maxY) {
+                maxYSize = Math.max(nodeSizeWithLineY, maxYSize);
             }
         });
 
@@ -253,7 +264,7 @@ class TreegraphSeries extends TreemapSeries {
             by = maxY === minY ? plotSizeY / 2 : -ay * minY + minYSize / 2,
             ax = maxX === minX ?
                 1 :
-                (plotSizeX - (maxXSize + maxXSize) / 2) / (maxX - minX),
+                (plotSizeX - (minXSize + maxXSize) / 2) / (maxX - minX),
             bx = maxX === minX ? plotSizeX / 2 : -ax * minX + minXSize / 2;
 
         return { ax, bx, ay, by };


### PR DESCRIPTION
## Summary

- Reset tracked marker size whenever treegraph traversal finds a new coordinate extreme.
- Keep the largest marker only among nodes tied at the same boundary.
- Use both minimum and maximum endpoint widths in horizontal scaling.
- Add a regression that verifies unequal-width endpoints meet both plot edges.

## Breaking changes

None. This corrects geometry for unequal boundary markers; equal-size layouts are unchanged.

## Verification

- Focused treegraph QUnit regression passed.
- Full pre-commit hook: 418 Node tests passed.
- Current and ES5 TypeScript builds passed.
- Source/test lint, sample validation, and `git diff --check` passed.

Fixes #25203