### PR TITLE
bugfix/25205-navigator-sync-timeout-cleanup

### DIFF
--- a/test/ts-node-unit-tests/tests/Dashboards/NavigatorSyncTimeout.test.ts
+++ b/test/ts-node-unit-tests/tests/Dashboards/NavigatorSyncTimeout.test.ts
@@ -1,0 +1,47 @@
+import { strictEqual } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import NavigatorCrossfilterSync from '../../../../ts/Dashboards/Components/NavigatorComponent/NavigatorSyncs/NavigatorCrossfilterSync';
+import NavigatorExtremesSync from '../../../../ts/Dashboards/Components/NavigatorComponent/NavigatorSyncs/NavigatorExtremesSync';
+import { fireEvent } from '../../../../ts/Shared/Utilities';
+
+describe('Navigator sync emitters', () => {
+    it('cancels pending emissions when removed', () => {
+        const originalClearTimeout = globalThis.clearTimeout;
+        let clearedTimeouts = 0;
+
+        globalThis.clearTimeout = ((timeoutId): void => {
+            if (timeoutId !== void 0) {
+                ++clearedTimeouts;
+            }
+            originalClearTimeout(timeoutId);
+        }) as typeof clearTimeout;
+
+        try {
+            for (const [sync, syncConfig] of [
+                [NavigatorCrossfilterSync, { crossfilter: {} }],
+                [NavigatorExtremesSync, { extremes: {} }]
+            ] as const) {
+                const axis = {};
+                const component = {
+                    chart: { xAxis: [axis] },
+                    sync: { syncConfig },
+                    type: 'Navigator'
+                };
+                const remove = sync.syncPair.emitter?.call(component as any);
+
+                fireEvent(axis, 'afterSetExtremes', { min: 1, max: 2 });
+                remove?.();
+
+                strictEqual(
+                    (axis as any).hcEvents.afterSetExtremes.length,
+                    0
+                );
+            }
+
+            strictEqual(clearedTimeouts, 2);
+        } finally {
+            globalThis.clearTimeout = originalClearTimeout;
+        }
+    });
+});

--- a/ts/Dashboards/Components/NavigatorComponent/NavigatorSyncs/NavigatorCrossfilterSync.ts
+++ b/ts/Dashboards/Components/NavigatorComponent/NavigatorSyncs/NavigatorCrossfilterSync.ts
@@ -119,14 +119,21 @@ const syncPair: SyncPair = {
 
         let delay: number;
 
-        return addEvent(
+        const unbind = addEvent(
             component.chart.xAxis[0],
             'afterSetExtremes',
             function (extremes: AxisExtremesObject): void {
                 clearTimeout(delay);
-                delay = setTimeout(afterSetExtremes, 50, this, extremes);
+                delay = setTimeout((): void => {
+                    void afterSetExtremes(extremes);
+                }, 50);
             }
         );
+
+        return (): void => {
+            clearTimeout(delay);
+            unbind();
+        };
     },
     handler: void 0
 };

--- a/ts/Dashboards/Components/NavigatorComponent/NavigatorSyncs/NavigatorExtremesSync.ts
+++ b/ts/Dashboards/Components/NavigatorComponent/NavigatorSyncs/NavigatorExtremesSync.ts
@@ -86,14 +86,21 @@ const syncPair: SyncPair = {
 
         let delay: number;
 
-        return addEvent(
+        const unbind = addEvent(
             component.chart.xAxis[0],
             'afterSetExtremes',
             function (extremes: AxisExtremesObject): void {
                 clearTimeout(delay);
-                delay = setTimeout(afterSetExtremes, 50, this, extremes);
+                delay = setTimeout((): void => {
+                    afterSetExtremes(extremes);
+                }, 50);
             }
         );
+
+        return (): void => {
+            clearTimeout(delay);
+            unbind();
+        };
     },
     handler: function (this: Component): (() => void) | void {
         if (this.type !== 'Navigator') {


### PR DESCRIPTION
## Summary

- Forward the actual `afterSetExtremes` event to delayed Navigator extremes and crossfilter emissions.
- Cancel each pending 50 ms emission when its sync emitter is removed.
- Preserve listener unbinding and debounce behavior.
- Add a regression that covers cleanup for both sync types.

## Breaking changes

None. Downstream cursor events now receive the intended event object and stopped syncs no longer emit.

## Verification

- Focused Navigator sync regression passed.
- Full Dashboard suite: 36 tests passed, 1 skipped.
- Full Node suite: 419 tests passed.
- Dashboard, current, and ES5 builds passed.
- Source lint, commit hooks, and `git diff --check` passed.

Fixes #25205