### PR TITLE
bugfix/25207-component-registry-prototype-keys

### DIFF
--- a/test/ts-node-unit-tests/tests/Dashboards/ComponentRegistry.test.ts
+++ b/test/ts-node-unit-tests/tests/Dashboards/ComponentRegistry.test.ts
@@ -1,0 +1,50 @@
+/* *
+ *
+ *  (c) 2009-2026 Highsoft AS
+ *
+ *  Integration of this software requires a license.
+ *  - For commercial use, see www.highcharts.com/license
+ *  - For non-commercial, see www.highcharts.com/license-eula
+ *
+ * */
+
+'use strict';
+
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import ComponentRegistry from
+    '../../../../ts/Dashboards/Components/ComponentRegistry.js';
+
+describe('ComponentRegistry', (): void => {
+    it('should support prototype-named component types', (): void => {
+        class ToStringComponent {}
+        class PrototypeComponent {}
+
+        assert.strictEqual(
+            ComponentRegistry.registerComponent(
+                'toString' as never,
+                ToStringComponent as never
+            ),
+            true
+        );
+        assert.strictEqual(
+            ComponentRegistry.registerComponent(
+                '__proto__' as never,
+                PrototypeComponent as never
+            ),
+            true
+        );
+        assert.strictEqual(
+            ComponentRegistry.types.toString,
+            ToStringComponent
+        );
+        assert.strictEqual(
+            ComponentRegistry.types.__proto__,
+            PrototypeComponent
+        );
+
+        delete ComponentRegistry.types.toString;
+        delete ComponentRegistry.types.__proto__;
+    });
+});

--- a/ts/Dashboards/Components/ComponentRegistry.ts
+++ b/ts/Dashboards/Components/ComponentRegistry.ts
@@ -32,7 +32,7 @@ import type { ComponentTypeRegistry } from './ComponentType';
  * @todo
  *
  */
-export const types = {} as ComponentTypeRegistry;
+export const types = Object.create(null) as ComponentTypeRegistry;
 
 /* *
  *


### PR DESCRIPTION
## Summary

- Store Dashboard component registrations in a prototype-free registry.
- Treat `toString`, `__proto__`, and other prototype names as ordinary documented string component types.
- Add a focused registration/retrieval regression with cleanup.

## Breaking changes

None. Previously unavailable string keys now follow the existing component registration contract.

## Verification

- Focused ComponentRegistry regression passed.
- Full Node suite: 419 tests passed.
- Full Dashboard suite: 36 tests passed, 1 skipped.
- Accessibility QUnit suite: 15 tests passed.
- Current, ES5, and Dashboard builds passed.
- Full source lint, commit hooks, and `git diff --check` passed.

Fixes #25207