### PR TITLE
bugfix/25209-grid-registry-prototype-keys

### DIFF
--- a/test/ts-node-unit-tests/tests/Grid/GridRegistries.test.ts
+++ b/test/ts-node-unit-tests/tests/Grid/GridRegistries.test.ts
@@ -1,0 +1,51 @@
+/* *
+ *
+ *  (c) 2020-2026 Highsoft AS
+ *
+ *  Integration of this software requires a license.
+ *  - For commercial use, see www.highcharts.com/license
+ *  - For non-commercial, see www.highcharts.com/license-eula
+ *
+ * */
+
+'use strict';
+
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import DataProviderRegistry from
+    '../../../../ts/Grid/Core/Data/DataProviderRegistry.js';
+import CellRendererRegistry from
+    '../../../../ts/Grid/Pro/CellRendering/CellRendererRegistry.js';
+
+describe('Grid registries', (): void => {
+    it('should support prototype-named provider and renderer types', (): void => {
+        class CustomType {}
+
+        assert.strictEqual(
+            DataProviderRegistry.registerDataProvider(
+                'toString' as never,
+                CustomType as never
+            ),
+            true
+        );
+        assert.strictEqual(
+            CellRendererRegistry.registerRenderer(
+                '__proto__' as never,
+                CustomType as never
+            ),
+            true
+        );
+        assert.strictEqual(
+            DataProviderRegistry.types.toString,
+            CustomType
+        );
+        assert.strictEqual(
+            CellRendererRegistry.types.__proto__,
+            CustomType
+        );
+
+        delete DataProviderRegistry.types.toString;
+        delete CellRendererRegistry.types.__proto__;
+    });
+});

--- a/ts/Grid/Core/Data/DataProviderRegistry.ts
+++ b/ts/Grid/Core/Data/DataProviderRegistry.ts
@@ -34,7 +34,7 @@ import type { DataProviderTypeRegistry } from './DataProviderType';
 /**
  * Record of data provider classes
  */
-export const types = {} as DataProviderTypeRegistry;
+export const types = Object.create(null) as DataProviderTypeRegistry;
 
 
 /* *

--- a/ts/Grid/Pro/CellRendering/CellRendererRegistry.ts
+++ b/ts/Grid/Pro/CellRendering/CellRendererRegistry.ts
@@ -35,7 +35,7 @@ import type { CellRendererTypeRegistry } from './CellRendererType';
 /**
  * Record of cell renderer classes
  */
-export const types = {} as CellRendererTypeRegistry;
+export const types = Object.create(null) as CellRendererTypeRegistry;
 
 
 /* *


### PR DESCRIPTION
## Summary

- Make the public Grid DataProvider and CellRenderer registries prototype-free.
- Treat `toString`, `__proto__`, and other prototype names as ordinary extension type strings.
- Add a focused registration/retrieval regression for both registries.

## Breaking changes

None. Previously unavailable type strings now follow the existing registration contract.

## Verification

- Focused Grid registry regression passed.
- Grid Lite/shared suite: 165 tests passed.
- Grid Pro suite: 153 tests passed.
- Full Node suite: 419 tests passed.
- Grid, current, and ES5 builds passed.
- Glint, source lint, commit hooks, and `git diff --check` passed.

Fixes #25209