### PR TITLE
bugfix/25211-serializable-prototype-classes

### DIFF
--- a/test/ts-node-unit-tests/tests/Dashboards/SerializableRegistry.test.ts
+++ b/test/ts-node-unit-tests/tests/Dashboards/SerializableRegistry.test.ts
@@ -1,0 +1,46 @@
+/* *
+ *
+ *  (c) 2009-2026 Highsoft AS
+ *
+ *  Integration of this software requires a license.
+ *  - For commercial use, see www.highcharts.com/license
+ *  - For non-commercial, see www.highcharts.com/license-eula
+ *
+ * */
+
+'use strict';
+
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import Serializable from '../../../../ts/Dashboards/Serializable.js';
+
+describe('Serializable registry', (): void => {
+    it('should support prototype-named serializers', (): void => {
+        const classPrototype = {
+            fromJSON: (): Record<string, boolean> => ({ classResult: true }),
+            toJSON: (): Record<string, string> => ({ $class: 'toString' })
+        };
+        const helper = {
+            $class: '__proto__',
+            fromJSON: (): Record<string, boolean> => ({ helper: true }),
+            jsonSupportFor: (): boolean => false,
+            toJSON: (): Record<string, string> => ({ $class: '__proto__' })
+        };
+
+        Serializable.registerClassPrototype(
+            'toString',
+            classPrototype as never
+        );
+        Serializable.registerHelper(helper as never);
+
+        assert.deepStrictEqual(
+            Serializable.fromJSON({ $class: 'toString' }),
+            { classResult: true }
+        );
+        assert.deepStrictEqual(
+            Serializable.fromJSON({ $class: '__proto__' }),
+            { helper: true }
+        );
+    });
+});

--- a/ts/Dashboards/Serializable.ts
+++ b/ts/Dashboards/Serializable.ts
@@ -144,12 +144,14 @@ export interface JSON<T extends string> extends JSONObject {
 /**
  * Registry of serializable classes.
  */
-const classRegistry: Record<string, Serializable<AnyRecord, JSON<string>>> = {};
+const classRegistry: Record<string, Serializable<AnyRecord, JSON<string>>> =
+    Object.create(null);
 
 /**
  * Registry of function sets.
  */
-const helperRegistry: Record<string, Helper<AnyRecord, JSON<string>>> = {};
+const helperRegistry: Record<string, Helper<AnyRecord, JSON<string>>> =
+    Object.create(null);
 
 /* *
  *


### PR DESCRIPTION
## Summary

- Make Dashboard serialization class and helper registries prototype-free.
- Treat `toString`, `__proto__`, and other prototype names as ordinary `$class` keys.
- Add a regression for prototype-named class/helper registration and `fromJSON` lookup.

## Breaking changes

None. Previously unusable serializer names now follow the existing registration/deserialization contract.

## Verification

- Focused Serializable registry regression passed.
- Full Node suite: 419 tests passed.
- Full Dashboard suite: 36 tests passed, 1 skipped.
- Accessibility QUnit suite: 15 tests passed.
- Current, ES5, and Dashboard builds passed.
- Full source lint, commit hooks, and `git diff --check` passed.

Fixes #25211