### PR TITLE
bugfix/25213-plugin-registry-prototype-keys

### DIFF
--- a/test/ts-node-unit-tests/tests/Dashboards/PluginHandler.test.ts
+++ b/test/ts-node-unit-tests/tests/Dashboards/PluginHandler.test.ts
@@ -1,0 +1,51 @@
+/* *
+ *
+ *  (c) 2009-2026 Highsoft AS
+ *
+ *  Integration of this software requires a license.
+ *  - For commercial use, see www.highcharts.com/license
+ *  - For non-commercial, see www.highcharts.com/license-eula
+ *
+ * */
+
+'use strict';
+
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { setupDOM } from '../../test-utils.js';
+
+describe('PluginHandler', (): void => {
+    it('should support prototype-named plugin keys', async (): Promise<void> => {
+        const { doc, win } = setupDOM();
+        global.window = win;
+        global.document = doc;
+
+        const { default: PluginHandler } = await import(
+            '../../../../ts/Dashboards/PluginHandler.js'
+        );
+        let registered = 0,
+            unregistered = 0;
+        const plugin = {
+            custom: {},
+            name: 'toString',
+            onRegister: (): void => {
+                ++registered;
+            },
+            onUnregister: (): void => {
+                ++unregistered;
+            }
+        };
+
+        PluginHandler.addPlugin(plugin);
+        assert.strictEqual(PluginHandler.registry.toString, plugin);
+        assert.strictEqual(registered, 1);
+
+        PluginHandler.removePlugin('toString');
+        assert.strictEqual(unregistered, 1);
+        assert.strictEqual(
+            Object.hasOwn(PluginHandler.registry, 'toString'),
+            false
+        );
+    });
+});

--- a/ts/Dashboards/PluginHandler.ts
+++ b/ts/Dashboards/PluginHandler.ts
@@ -73,7 +73,7 @@ export type EventCallback = (e: Event) => void;
  * */
 
 /** @internal */
-export const registry: Record<string, DashboardsPlugin> = {};
+export const registry: Record<string, DashboardsPlugin> = Object.create(null);
 
 /**
  * Revision of the Dashboard plugin API.


### PR DESCRIPTION
## Summary

- Make the Dashboard plugin registry prototype-free.
- Treat `toString` and other prototype names as ordinary documented plugin keys.
- Add a focused regression for registration callback, storage, removal callback, and cleanup.

## Breaking changes

None. Previously skipped plugin names now follow the existing lifecycle contract.

## Verification

- Focused PluginHandler regression passed.
- Full Node suite: 419 tests passed.
- Full Dashboard suite: 36 tests passed, 1 skipped.
- Accessibility QUnit suite: 15 tests passed.
- Current, ES5, and Dashboard builds passed.
- Full source lint, commit hooks, and `git diff --check` passed.

Fixes #25213