### PR TITLE
bugfix/25215-sync-prototype-keys

### DIFF
--- a/test/ts-node-unit-tests/tests/Dashboards/SyncPrototypeKeys.test.ts
+++ b/test/ts-node-unit-tests/tests/Dashboards/SyncPrototypeKeys.test.ts
@@ -1,0 +1,68 @@
+/* *
+ *
+ *  (c) 2009-2026 Highsoft AS
+ *
+ *  Integration of this software requires a license.
+ *  - For commercial use, see www.highcharts.com/license
+ *  - For non-commercial, see www.highcharts.com/license-eula
+ *
+ * */
+
+'use strict';
+
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import Sync from '../../../../ts/Dashboards/Components/Sync/Sync.js';
+import SyncEmitter from
+    '../../../../ts/Dashboards/Components/Sync/Emitter.js';
+import SyncHandler from
+    '../../../../ts/Dashboards/Components/Sync/Handler.js';
+
+describe('Dashboard synchronization', (): void => {
+    it('should support prototype-named sync IDs', (): void => {
+        const syncOptions = Object.create(null),
+            callbacks: string[] = [];
+
+        for (const id of ['toString', '__proto__']) {
+            syncOptions[id] = {
+                enabled: true,
+                emitter: (): (() => void) => {
+                    callbacks.push(`create-${id}`);
+                    return (): void => callbacks.push(`remove-${id}`);
+                },
+                handler: (): (() => void) => {
+                    callbacks.push(`register-${id}`);
+                    return (): void => callbacks.push(`unregister-${id}`);
+                }
+            };
+        }
+
+        const component = {
+                on: (): (() => void) => (): void => {},
+                options: { sync: syncOptions }
+            },
+            sync = new Sync(component as never, {
+                defaultSyncOptions: {},
+                defaultSyncPairs: {}
+            });
+
+        sync.start();
+        assert.deepStrictEqual(callbacks, [
+            'register-toString',
+            'create-toString',
+            'register-__proto__',
+            'create-__proto__'
+        ]);
+        assert.strictEqual(SyncHandler.get('toString')?.id, 'toString');
+        assert.strictEqual(SyncEmitter.get('__proto__')?.id, '__proto__');
+
+        sync.stop();
+        assert.deepStrictEqual(callbacks.slice(4), [
+            'unregister-toString',
+            'unregister-__proto__',
+            'remove-toString',
+            'remove-__proto__'
+        ]);
+    });
+});

--- a/ts/Dashboards/Components/Sync/Emitter.ts
+++ b/ts/Dashboards/Components/Sync/Emitter.ts
@@ -28,7 +28,7 @@ class SyncEmitter {
      * Registry for reusable emitter.
      * The emitter is stored by ID.
      */
-    public static registry: Record<string, SyncEmitter> = {};
+    public static registry: Record<string, SyncEmitter> = Object.create(null);
 
     /**
      * Adds an emitter to the emitter registry.

--- a/ts/Dashboards/Components/Sync/Handler.ts
+++ b/ts/Dashboards/Components/Sync/Handler.ts
@@ -41,7 +41,7 @@ class SyncHandler {
      * Registry for reusable handlers.
      * The handler is stored by ID.
      */
-    public static registry: Record<string, SyncHandler> = {};
+    public static registry: Record<string, SyncHandler> = Object.create(null);
 
     /**
      * Adds a handler to the handler registry.

--- a/ts/Dashboards/Components/Sync/Sync.ts
+++ b/ts/Dashboards/Components/Sync/Sync.ts
@@ -63,8 +63,8 @@ class Sync {
             predefinedSyncConfig,
             component.options.sync
         );
-        this.registeredSyncHandlers = {};
-        this.registeredSyncEmitters = {};
+        this.registeredSyncHandlers = Object.create(null);
+        this.registeredSyncEmitters = Object.create(null);
         this.isSyncing = false;
         this.listeners = [];
     }
@@ -84,7 +84,8 @@ class Sync {
      * different Components, where default syncs are added. Allows overwriting
      * the configuration before creating the dashboard.
      */
-    public static defaultHandlers: Record<string, OptionsEntry> = {};
+    public static defaultHandlers: Record<string, OptionsEntry> =
+        Object.create(null);
 
     /**
      * Registry for the sync handlers used within the component.
@@ -142,8 +143,14 @@ class Sync {
         return Object.keys(componentSyncOptions).reduce(
             (acc: OptionsRecord, syncName): OptionsRecord => {
                 if (syncName) {
-                    const defaultPair = defaultPairs[syncName];
-                    const defaultOptions = defaultOptionsList[syncName];
+                    const defaultPair = Object.hasOwnProperty.call(
+                            defaultPairs,
+                            syncName
+                        ) ? defaultPairs[syncName] : void 0,
+                        defaultOptions = Object.hasOwnProperty.call(
+                            defaultOptionsList,
+                            syncName
+                        ) ? defaultOptionsList[syncName] : void 0;
                     const entry = componentSyncOptions[syncName];
 
                     const preparedOptions: OptionsEntry = merge(
@@ -174,7 +181,7 @@ class Sync {
 
                 return acc;
             },
-            {}
+            Object.create(null)
         );
     }
 


### PR DESCRIPTION
## Summary

- Make global Dashboard sync handler/emitter registries and per-instance registrations prototype-free.
- Build prepared sync options in a prototype-free record.
- Read default pairs/options only from their own properties.
- Add a lifecycle regression for `toString` and `__proto__` sync IDs.

## Breaking changes

None. Previously unusable custom string IDs now follow the existing start/stop contract.

## Verification

- Focused custom-sync regression passed.
- Full Node suite: 419 tests passed.
- Full Dashboard suite: 36 tests passed, 1 skipped.
- Accessibility QUnit suite: 15 tests passed.
- Current, ES5, and Dashboard builds passed.
- Full source lint, commit hooks, and `git diff --check` passed.

Fixes #25215