### PR TITLE
bugfix/25217-grid-repeat-destroy

### DIFF
--- a/test/ts-node-unit-tests/tests/Grid/GridDestroy.test.ts
+++ b/test/ts-node-unit-tests/tests/Grid/GridDestroy.test.ts
@@ -1,0 +1,43 @@
+/* *
+ *
+ *  (c) 2020-2026 Highsoft AS
+ *
+ *  Integration of this software requires a license.
+ *  - For commercial use, see www.highcharts.com/license
+ *  - For non-commercial, see www.highcharts.com/license-eula
+ *
+ * */
+
+'use strict';
+
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { setupDOM } from '../../test-utils.js';
+
+describe('Grid.destroy', (): void => {
+    it('should not unregister another Grid when called twice',
+        async (): Promise<void> => {
+            const { doc, win } = setupDOM();
+            global.window = win;
+            global.document = doc;
+
+            const GridModule = await import(
+                    '../../../../ts/Grid/Core/Grid.js'
+                ),
+                Grid = (
+                    (GridModule.default as any).default ?? GridModule.default
+                ),
+                first = Object.create(Grid.prototype),
+                second = Object.create(Grid.prototype);
+
+            Grid.grids.length = 0;
+            Grid.grids.push(first, second);
+
+            first.destroy();
+            first.destroy();
+
+            assert.deepStrictEqual(Grid.grids, [second]);
+            Grid.grids.length = 0;
+        });
+});

--- a/ts/Grid/Core/Grid.ts
+++ b/ts/Grid/Core/Grid.ts
@@ -1707,7 +1707,9 @@ export class Grid {
             delete this[key as keyof this];
         });
 
-        Grid.grids.splice(dgIndex, 1);
+        if (dgIndex !== -1) {
+            Grid.grids.splice(dgIndex, 1);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

- Remove a destroyed Grid from the global registry only when its index is present.
- Make repeated complete destruction idempotent for registry ownership.
- Add a focused regression with two live instances.

## Breaking changes

None. Repeated teardown no longer unregisters an unrelated Grid.

## Verification

- Focused Grid destroy regression passed.
- Grid Lite/shared suite: 165 tests passed.
- Grid Pro suite: 153 tests passed.
- Full Node suite: 419 tests passed.
- Grid, current, and ES5 builds passed.
- Glint, source lint, commit hooks, and `git diff --check` passed.

Fixes #25217