### PR TITLE
bugfix/25221-accessibility-zero-decimals

### DIFF
--- a/samples/unit-tests/accessibility/descriptions-added/demo.js
+++ b/samples/unit-tests/accessibility/descriptions-added/demo.js
@@ -45,6 +45,30 @@ QUnit.test('Accessible chart with multiple series', function (assert) {
     );
 });
 
+QUnit.test('Zero decimals in point descriptions', function (assert) {
+    var chart = Highcharts.chart('container', {
+            accessibility: {
+                point: {
+                    valueDecimals: 0
+                }
+            },
+            tooltip: {
+                valueDecimals: 2
+            },
+            series: [{
+                data: [1.23]
+            }]
+        }),
+        label = chart.series[0].points[0].graphic.element.getAttribute(
+            'aria-label'
+        );
+
+    assert.notOk(
+        label.includes('1.23'),
+        'An explicit zero should override the tooltip decimals'
+    );
+});
+
 QUnit.test('Empty chart', function (assert) {
     var chart = Highcharts.chart('container', {});
     assert.ok(

--- a/ts/Accessibility/Components/SeriesComponent/SeriesDescriber.ts
+++ b/ts/Accessibility/Components/SeriesComponent/SeriesDescriber.ts
@@ -275,9 +275,9 @@ function pointNumberToString(
     if (isNumber(value)) {
         return numberFormat(
             value,
-            seriesA11yPointOptions.valueDecimals ||
-                a11yPointOptions.valueDecimals ||
-                tooltipOptions.valueDecimals ||
+            seriesA11yPointOptions.valueDecimals ??
+                a11yPointOptions.valueDecimals ??
+                tooltipOptions.valueDecimals ??
                 -1,
             lang.decimalPoint,
             (lang.accessibility as any).thousandsSep || lang.thousandsSep


### PR DESCRIPTION
## Summary

- Use nullish fallback semantics for accessibility point decimal precision.
- Preserve an explicit zero at series or chart accessibility scope before tooltip fallback.
- Add a browser regression that verifies zero overrides tooltip precision in the ARIA label.

## Breaking changes

None. The explicit accessibility override now controls formatting as documented.

## Verification

- Accessibility QUnit suite: 15 tests passed.
- Full Node suite: 418 tests passed.
- Current and ES5 builds passed.
- Source/sample lint, commit hooks, and `git diff --check` passed.

Fixes #25221