### PR TITLE
bugfix/25223-series-accessibility-value-affixes

### DIFF
--- a/samples/unit-tests/accessibility/descriptions-added/demo.js
+++ b/samples/unit-tests/accessibility/descriptions-added/demo.js
@@ -45,6 +45,50 @@ QUnit.test('Accessible chart with multiple series', function (assert) {
     );
 });
 
+QUnit.test('Series-specific accessible value affixes', function (assert) {
+    var chart = Highcharts.chart('container', {
+            accessibility: {
+                point: {
+                    valuePrefix: 'chart-prefix-',
+                    valueSuffix: '-chart-suffix'
+                }
+            },
+            series: [{
+                accessibility: {
+                    point: {
+                        valuePrefix: 'series-prefix-',
+                        valueSuffix: '-series-suffix'
+                    }
+                },
+                data: [1]
+            }, {
+                accessibility: {
+                    point: {
+                        valuePrefix: '',
+                        valueSuffix: ''
+                    }
+                },
+                data: [2]
+            }]
+        }),
+        firstLabel = chart.series[0].points[0].graphic.element.getAttribute(
+            'aria-label'
+        ),
+        secondLabel = chart.series[1].points[0].graphic.element.getAttribute(
+            'aria-label'
+        );
+
+    assert.ok(
+        firstLabel.includes('series-prefix-1-series-suffix'),
+        'Series options should override chart options'
+    );
+    assert.notOk(
+        secondLabel.includes('chart-prefix-') ||
+            secondLabel.includes('-chart-suffix'),
+        'Empty series affixes should suppress chart fallbacks'
+    );
+});
+
 QUnit.test('Empty chart', function (assert) {
     var chart = Highcharts.chart('container', {});
     assert.ok(

--- a/ts/Accessibility/Components/SeriesComponent/SeriesDescriber.ts
+++ b/ts/Accessibility/Components/SeriesComponent/SeriesDescriber.ts
@@ -415,16 +415,15 @@ function getPointValue(
 ): string {
     const series = point.series,
         a11yPointOpts = series.chart.options.accessibility.point || {},
-        seriesA11yPointOpts = series.chart.options.accessibility &&
-            series.chart.options.accessibility.point || {},
+        seriesA11yPointOpts = series.options.accessibility?.point || {},
         tooltipOptions = series.tooltipOptions || {},
-        valuePrefix = seriesA11yPointOpts.valuePrefix ||
-            a11yPointOpts.valuePrefix ||
-            tooltipOptions.valuePrefix ||
+        valuePrefix = seriesA11yPointOpts.valuePrefix ??
+            a11yPointOpts.valuePrefix ??
+            tooltipOptions.valuePrefix ??
             '',
-        valueSuffix = seriesA11yPointOpts.valueSuffix ||
-            a11yPointOpts.valueSuffix ||
-            tooltipOptions.valueSuffix ||
+        valueSuffix = seriesA11yPointOpts.valueSuffix ??
+            a11yPointOpts.valueSuffix ??
+            tooltipOptions.valueSuffix ??
             '',
         fallbackKey: ('value'|'y') = (
             typeof point.value !==


### PR DESCRIPTION
## Summary

- Read point value affixes from the current series accessibility options.
- Preserve explicit empty series affixes with nullish fallback semantics.
- Add a browser regression covering series overrides and empty suppression.

## Breaking changes

None. Series-level accessibility configuration now applies as documented.

## Verification

- Focused descriptions QUnit and full accessibility suite: 15 tests passed.
- Full Node suite: 418 tests passed.
- Current and ES5 builds passed.
- Source/sample lint, commit hooks, and `git diff --check` passed.

Fixes #25223