### PR TITLE
bugfix/25225-column3d-zero-group-z-padding

### DIFF
--- a/samples/unit-tests/3d/column-group/demo.js
+++ b/samples/unit-tests/3d/column-group/demo.js
@@ -55,3 +55,33 @@ QUnit.test('3D columns with scatter series', function (assert) {
         'seriesGroup is not translated'
     );
 });
+
+QUnit.test('3D columns support zero group Z padding', function (assert) {
+    const chart = Highcharts.chart('container', {
+        chart: {
+            type: 'column',
+            options3d: {
+                enabled: true,
+                depth: 100
+            }
+        },
+        plotOptions: {
+            column: {
+                depth: 40,
+                grouping: false,
+                groupZPadding: 0
+            }
+        },
+        series: [{
+            data: [1]
+        }, {
+            data: [2]
+        }]
+    });
+
+    assert.deepEqual(
+        chart.series.map(series => series.points[0].shapeArgs.z),
+        [0, 40],
+        'Zero padding leaves no space before or between columns'
+    );
+});

--- a/ts/Series/Column3D/Column3DComposition.ts
+++ b/ts/Series/Column3D/Column3DComposition.ts
@@ -141,7 +141,7 @@ function columnSeriesTranslate3dShapes(
             (seriesOptions.stack || 0) :
             series.index; // #4743
 
-    let z = (stack as any) * (depth + (seriesOptions.groupZPadding || 1)),
+    let z = (stack as any) * (depth + (seriesOptions.groupZPadding ?? 1)),
         borderCrisp = series.borderWidth % 2 ? 0.5 : 0,
         point2dPos; // Position of point in 2D, used for 3D position calculation
 
@@ -153,7 +153,7 @@ function columnSeriesTranslate3dShapes(
         z = 0;
     }
 
-    z += (seriesOptions.groupZPadding || 1);
+    z += (seriesOptions.groupZPadding ?? 1);
     for (const point of series.points) {
         // #7103 Reset outside3dPlot flag
         point.outside3dPlot = null;


### PR DESCRIPTION
## Summary

- Preserve an explicit zero `groupZPadding` in both 3D column z calculations.
- Add a browser regression covering two ungrouped depth-40 columns.

## Breaking changes

None. The documented zero value now applies instead of the default padding.

## Verification

- Focused 3D QUnit suite: 3 tests passed.
- Full Node suite: 418 tests passed.
- Current build, source lint, commit hooks, and `git diff --check` passed.

Fixes #25225