### PR TITLE
bugfix/25229-annotation-registry-prototype-keys

### DIFF
--- a/samples/unit-tests/annotations/annotations-dynamic/demo.js
+++ b/samples/unit-tests/annotations/annotations-dynamic/demo.js
@@ -288,6 +288,24 @@ QUnit.test('Annotation\'s dynamic methods', function (assert) {
     );
 });
 
+QUnit.test('Unknown prototype-named annotation types', function (assert) {
+    const chart = Highcharts.chart('container', {
+        series: [{
+            data: [1]
+        }]
+    });
+
+    const annotations = ['toString', '__proto__'].map(type => (
+        chart.addAnnotation({ type }, false)
+    ));
+
+    assert.deepEqual(
+        annotations.map(annotation => annotation.constructor),
+        [Highcharts.Annotation, Highcharts.Annotation],
+        'Unknown types fall back to the base annotation class'
+    );
+});
+
 QUnit.test(
     'Hiding and showing annotations with linked points',
     function (assert) {

--- a/ts/Extensions/Annotations/Annotation.ts
+++ b/ts/Extensions/Annotations/Annotation.ts
@@ -223,7 +223,9 @@ class Annotation extends EventEmitter implements ControlTarget {
         };
 
     /** @internal */
-    public static readonly types = {} as AnnotationTypeRegistry;
+    public static readonly types = Object.create(
+        null
+    ) as AnnotationTypeRegistry;
 
     /* *
      *


### PR DESCRIPTION
## Summary

- Store registered annotation classes in a prototype-free registry.
- Let unknown prototype-named types use the existing base-Annotation fallback.
- Add public API regressions for `toString` and `__proto__`.

## Breaking changes

None. Unknown annotation types now follow the documented fallback path instead of throwing.

## Verification

- Focused annotations QUnit suite: 2 tests passed.
- Full Node suite: 418 tests passed.
- Current build, source/sample lint, full commit hook, and `git diff --check` passed.

Fixes #25229