### PR TITLE
bugfix/25231-series-registry-prototype-keys

### DIFF
--- a/samples/unit-tests/series/seriestypes/demo.js
+++ b/samples/unit-tests/series/seriestypes/demo.js
@@ -42,3 +42,16 @@ Object.keys(Highcharts.Series.types).forEach(function (type) {
         );
     }
 });
+
+QUnit.test('Unknown prototype-named series types', function (assert) {
+    ['toString', '__proto__'].forEach(type => {
+        assert.throws(
+            () => Highcharts.chart('container', {
+                chart: { type },
+                series: [{ data: [1] }]
+            }),
+            /Highcharts error #17/,
+            `${type} reports the standard unknown-series error`
+        );
+    });
+});

--- a/ts/Core/Globals.ts
+++ b/ts/Core/Globals.ts
@@ -264,7 +264,9 @@ namespace Globals {
      * @deprecated
      * @todo Use only `Core/Series/SeriesRegistry.seriesTypes`
      */
-    export const seriesTypes = {} as GlobalsBase['seriesTypes'];
+    export const seriesTypes = Object.create(
+        null
+    ) as GlobalsBase['seriesTypes'];
 
     /** @internal */
     export const symbolSizes: GlobalsBase['symbolSizes'] = {};


### PR DESCRIPTION
## Summary

- Store registered series classes in a prototype-free global registry.
- Route unknown prototype-named series types through standard Highcharts error #17 handling.
- Add browser regressions for `toString` and `__proto__`.

## Breaking changes

None. Unknown types now report the established Highcharts error instead of throwing a raw TypeError.

## Verification

- Focused series-types QUnit regression passed.
- Full modified QUnit suite: 391 tests passed.
- Full Node suite: 418 tests passed.
- Current build, source/sample lint, commit hooks, and `git diff --check` passed.

Fixes #25231