### PR TITLE
bugfix/25233-venn-input-set-order

### DIFF
--- a/samples/unit-tests/series-venn/integration/demo.js
+++ b/samples/unit-tests/series-venn/integration/demo.js
@@ -47,6 +47,12 @@ QUnit.test('zIndex. #10490', assert => {
     }, {});
 
     assert.deepEqual(
+        unsortedData[1].sets,
+        ['B', 'C', 'A'],
+        'should not mutate the input set order'
+    );
+
+    assert.deepEqual(
         mapOfIdToZIndex,
         {
             A: 1,

--- a/ts/Series/Venn/VennSeries.ts
+++ b/ts/Series/Venn/VennSeries.ts
@@ -580,7 +580,9 @@ class VennSeries extends ScatterSeries {
 
         // Iterate all points and calculate and draw their graphics.
         for (const point of this.points) {
-            const sets: Array<string> = isArray(point.sets) ? point.sets : [],
+            const sets: Array<string> = isArray(point.sets) ?
+                    point.sets.slice().sort() :
+                    [],
                 id = sets.join(),
                 shape = mapOfIdToShape[id],
                 dataLabelValues = mapOfIdToLabelValues[id] || {},
@@ -589,6 +591,8 @@ class VennSeries extends ScatterSeries {
             let shapeArgs: (SVGAttributes|undefined),
                 dataLabelWidth = dataLabelValues.width,
                 dataLabelPosition = dataLabelValues.position;
+
+            point.sets = sets;
 
             if (shape) {
                 if ((shape as any).r) {

--- a/ts/Series/Venn/VennUtils.ts
+++ b/ts/Series/Venn/VennUtils.ts
@@ -871,10 +871,10 @@ function processVennData(
                 return validSets.indexOf(set) === -1;
             })
         ) {
-            mapOfIdToRelation[
-                relation.sets.sort().join(splitter)
-            ] = {
-                sets: relation.sets,
+            const sets = relation.sets.slice().sort();
+
+            mapOfIdToRelation[sets.join(splitter)] = {
+                sets,
                 value: relation.value || 0
             };
         }


### PR DESCRIPTION
## Summary

- Canonicalize cloned Venn relation set arrays instead of sorting caller input in place.
- Canonicalize the internal point copy used for layout lookup and identifiers.
- Extend the existing unsorted-data integration regression to protect caller ordering.

## Breaking changes

None. Rendered layout and canonical internal point identifiers are preserved; caller-owned input is no longer mutated.

## Verification

- Focused integration regression and all Venn QUnit tests passed.
- Full Node suite: 418 tests passed.
- Current build, source/sample lint, full commit hook, and `git diff --check` passed.

Fixes #25233