### PR TITLE
bugfix/25235-packedbubble-circular-angle

### DIFF
--- a/samples/unit-tests/series-packedbubble/positions/demo.js
+++ b/samples/unit-tests/series-packedbubble/positions/demo.js
@@ -175,6 +175,48 @@ QUnit.test('PackedBubble layout simulation', function (assert) {
     );
 });
 
+QUnit.test('Circular initial positions', function (assert) {
+    const chart = Highcharts.chart('container', {
+            chart: {
+                type: 'packedbubble'
+            },
+            plotOptions: {
+                packedbubble: {
+                    layoutAlgorithm: {
+                        enableSimulation: false,
+                        initialPositionRadius: 20
+                    }
+                }
+            },
+            series: [{
+                data: [1, 2, 3, 4]
+            }]
+        }),
+        layout = chart.series[0].layout,
+        nodes = layout.nodes,
+        angle = 2 * Math.PI / (nodes.length + 1),
+        centerX = layout.box.width / 2,
+        centerY = layout.box.height / 2;
+
+    nodes.forEach(node => {
+        node.plotX = node.plotY = void 0;
+    });
+    layout.setCircularPositions();
+
+    assert.close(
+        nodes[1].plotX,
+        centerX + 20 * Math.cos(angle),
+        1e-8,
+        'The second node should use one angular step on the x axis'
+    );
+    assert.close(
+        nodes[1].plotY,
+        centerY + 20 * Math.sin(angle),
+        1e-8,
+        'The second node should use one angular step on the y axis'
+    );
+});
+
 QUnit.test('PackedBubble hover and dehover (#12537)', function (assert) {
     const chart = Highcharts.chart('container', {
         chart: {

--- a/ts/Series/PackedBubble/PackedBubbleLayout.ts
+++ b/ts/Series/PackedBubble/PackedBubbleLayout.ts
@@ -186,10 +186,10 @@ class PackedBubbleLayout extends ReingoldFruchtermanLayout {
             }
 
             node.plotX = node.prevX = (node.plotX ?? (centerX as any) +
-                (radius as any) * Math.cos(node.index || index * angle));
+                (radius as any) * Math.cos(index * angle));
 
             node.plotY = node.prevY = (node.plotY ?? (centerY as any) +
-                (radius as any) * Math.sin(node.index || index * angle));
+                (radius as any) * Math.sin(index * angle));
 
             node.dispX = 0;
             node.dispY = 0;


### PR DESCRIPTION
## Summary

- Use the layout index times the computed angular step for every packed bubble node.
- Match the inherited networkgraph circular initializer and evenly space initial positions.
- Add a deterministic no-simulation coordinate regression.

## Breaking changes

None. This corrects pre-simulation starting geometry; configured/preserved existing positions remain unchanged.

## Verification

- All packed-bubble QUnit tests: 5 passed.
- Full Node suite: 418 tests passed.
- Current build, source/sample lint, full commit hook, and `git diff --check` passed.

Fixes #25235