### PR TITLE
bugfix/25237-marker-cluster-zero-coordinates

### DIFF
--- a/samples/unit-tests/series/marker-clusters/demo.js
+++ b/samples/unit-tests/series/marker-clusters/demo.js
@@ -328,6 +328,42 @@ QUnit.test('Kmeans algorithm tests.', function (assert) {
     );
 });
 
+QUnit.test('Custom algorithm with zero coordinates', function (assert) {
+    const chart = Highcharts.chart('container', {
+            series: [{
+                type: 'scatter',
+                cluster: {
+                    enabled: true,
+                    animation: false,
+                    layoutAlgorithm: {
+                        type: function () {
+                            return {
+                                zero: [{
+                                    x: 0,
+                                    y: 0,
+                                    index: 0
+                                }, {
+                                    x: 0,
+                                    y: 1,
+                                    index: 1
+                                }]
+                            };
+                        }
+                    }
+                },
+                data: [[0, 0], [0, 1]]
+            }]
+        }),
+        cluster = chart.series[0].markerClusterInfo?.clusters[0];
+
+    assert.ok(cluster, 'Zero coordinates should produce a valid cluster');
+    assert.deepEqual(
+        [cluster?.x, cluster?.y],
+        [0, 0.5],
+        'The cluster should preserve its zero x coordinate'
+    );
+});
+
 QUnit.test('OptimizedKmeans algorithm tests.', function (assert) {
     var chart = Highcharts.chart('container', options),
         series = chart.series[0],

--- a/ts/Extensions/MarkerClusters/MarkerClusterScatter.ts
+++ b/ts/Extensions/MarkerClusters/MarkerClusterScatter.ts
@@ -1560,7 +1560,11 @@ function seriesIsValidGroupedDataObject(
         }
 
         for (let i = 0; i < elem.length; i++) {
-            if (!isObject(elem[i]) || (!elem[i].x || !elem[i].y)) {
+            if (
+                !isObject(elem[i]) ||
+                !isNumber(elem[i].x) ||
+                !isNumber(elem[i].y)
+            ) {
                 result = false;
                 return;
             }


### PR DESCRIPTION
## Summary

- Validate custom cluster point coordinates with the existing numeric predicate instead of truthiness.
- Preserve valid zero-axis coordinates while retaining invalid-value rejection.
- Add a public chart regression centered at x=0.

## Breaking changes

None. Documented numeric zero coordinates now work as expected.

## Verification

- Marker-clusters QUnit suite passed.
- Full Node suite: 418 tests passed.
- Current build, source/sample lint, full commit hook, and `git diff --check` passed.

Fixes #25237