### PR TITLE
bugfix/25239-marker-cluster-y-extremes

### DIFF
--- a/samples/unit-tests/series/marker-clusters/demo.js
+++ b/samples/unit-tests/series/marker-clusters/demo.js
@@ -233,6 +233,40 @@ QUnit.test('Grid algorithm tests.', function (assert) {
     assert.ok(result, 'Clusters should not overlap when allowOverlap = false.');
 });
 
+QUnit.test('Real Y extremes use the plot area', function (assert) {
+    const chart = Highcharts.chart('container', {
+            chart: {
+                margin: [100, 20, 30, 150]
+            },
+            series: [{
+                type: 'scatter',
+                cluster: {
+                    enabled: true
+                },
+                data: [[0, 0], [1, 1]]
+            }]
+        }),
+        series = chart.series[0],
+        extremes = series.getRealExtremes(),
+        yValues = [
+            series.yAxis.toValue(chart.plotTop),
+            series.yAxis.toValue(chart.plotTop + chart.plotHeight)
+        ];
+
+    assert.close(
+        extremes.minY,
+        Math.min(...yValues),
+        1e-8,
+        'The minimum should come from a vertical plot boundary'
+    );
+    assert.close(
+        extremes.maxY,
+        Math.max(...yValues),
+        1e-8,
+        'The maximum should come from a vertical plot boundary'
+    );
+});
+
 QUnit.test('Kmeans algorithm tests.', function (assert) {
     var chart = Highcharts.chart('container', options),
         series = chart.series[0],

--- a/ts/Extensions/MarkerClusters/MarkerClusterScatter.ts
+++ b/ts/Extensions/MarkerClusters/MarkerClusterScatter.ts
@@ -1430,7 +1430,7 @@ function seriesGetRealExtremes(
         }),
         p2 = pixelsToValues(this, {
             x: x + chart.plotWidth,
-            y: x + chart.plotHeight
+            y: y + chart.plotHeight
         }),
         realMinX = p1.x,
         realMaxX = p2.x,


### PR DESCRIPTION
## Summary

- Compute the second marker-cluster Y boundary from `plotTop + plotHeight`.
- Add a regression with deliberately unequal top and left chart margins.

## Breaking changes

None. Visible-point cropping and clustering now use the actual vertical plot bounds.

## Verification

- Marker-clusters QUnit suite passed.
- Full Node suite: 418 tests passed.
- Current build, source/sample lint, full commit hook, and `git diff --check` passed.

Fixes #25239