### PR TITLE
bugfix/25241-marker-cluster-zero-y-cropping

### DIFF
--- a/samples/unit-tests/series/marker-clusters/demo.js
+++ b/samples/unit-tests/series/marker-clusters/demo.js
@@ -233,6 +233,41 @@ QUnit.test('Grid algorithm tests.', function (assert) {
     assert.ok(result, 'Clusters should not overlap when allowOverlap = false.');
 });
 
+QUnit.test('Cropping points with a zero Y value', function (assert) {
+    let visibleYData;
+
+    const chart = Highcharts.chart('container', {
+        yAxis: {
+            min: 100,
+            max: 200
+        },
+        series: [{
+            type: 'scatter',
+            cluster: {
+                enabled: true,
+                layoutAlgorithm: {
+                    type: function (xData, yData) {
+                        visibleYData = yData;
+                        return false;
+                    }
+                }
+            },
+            data: [[0, 0], [1, 150]]
+        }]
+    });
+
+    assert.deepEqual(
+        visibleYData,
+        [150],
+        'A zero outside the visible Y-axis range should be cropped'
+    );
+    assert.strictEqual(
+        chart.series[0].dataMinY,
+        0,
+        'Zero should remain the calculated minimum Y value'
+    );
+});
+
 QUnit.test('Kmeans algorithm tests.', function (assert) {
     var chart = Highcharts.chart('container', options),
         series = chart.series[0],

--- a/ts/Extensions/MarkerClusters/MarkerClusterScatter.ts
+++ b/ts/Extensions/MarkerClusters/MarkerClusterScatter.ts
@@ -953,10 +953,10 @@ function seriesGeneratePoints(
                     seriesMaxX = Math.max(xData[i], seriesMaxX);
                     seriesMinX = Math.min(xData[i], seriesMinX);
                     seriesMaxY = Math.max(
-                        (yData[i] as any) || seriesMaxY, seriesMaxY
+                        yData[i] as number, seriesMaxY
                     );
                     seriesMinY = Math.min(
-                        (yData[i] as any) || seriesMinY, seriesMinY
+                        yData[i] as number, seriesMinY
                     );
                 }
             }
@@ -966,9 +966,10 @@ function seriesGeneratePoints(
             if (
                 xData[i] >= (realExtremes.minX - cropDataOffsetX) &&
                 xData[i] <= (realExtremes.maxX + cropDataOffsetX) &&
-                (yData[i] as number || realExtremes.minY) >=
+                isNumber(yData[i]) &&
+                yData[i] >=
                     (realExtremes.minY - cropDataOffsetY) &&
-                (yData[i] as number || realExtremes.maxY) <=
+                yData[i] <=
                     (realExtremes.maxY + cropDataOffsetY)
             ) {
                 visibleXData.push(xData[i]);


### PR DESCRIPTION
## Summary

- Require numeric Y values during pre-cluster visibility cropping.
- Compare/store the actual numeric value so zero is neither replaced by axis bounds nor excluded from data extrema.
- Add a public chart regression with zero outside a 100..200 visible range.

## Breaking changes

None. Numeric zero now follows normal cropping/extreme rules; null/non-numeric values stay outside numeric clustering.

## Verification

- Marker-clusters QUnit suite passed.
- Full Node suite: 418 tests passed.
- Current build, source/sample lint, full commit hook, and `git diff --check` passed.

Fixes #25241