### PR TITLE
bugfix/25243-marker-cluster-zero-grid-offset

### DIFF
--- a/samples/unit-tests/series/marker-clusters/demo.js
+++ b/samples/unit-tests/series/marker-clusters/demo.js
@@ -233,6 +233,32 @@ QUnit.test('Grid algorithm tests.', function (assert) {
     assert.ok(result, 'Clusters should not overlap when allowOverlap = false.');
 });
 
+QUnit.test('Grid offset with zero data extremes', function (assert) {
+    const chart = Highcharts.chart('container', {
+            series: [{
+                type: 'scatter',
+                cluster: {
+                    enabled: true,
+                    animation: false,
+                    layoutAlgorithm: {
+                        type: 'grid'
+                    }
+                },
+                data: [[0, 0], [1, 1]]
+            }]
+        }),
+        series = chart.series[0];
+
+    assert.deepEqual(
+        series.getGridOffset(),
+        {
+            plotLeft: series.xAxis.toPixels(series.dataMinX),
+            plotTop: series.yAxis.toPixels(series.dataMaxY)
+        },
+        'Zero should be treated as a valid data boundary'
+    );
+});
+
 QUnit.test('Kmeans algorithm tests.', function (assert) {
     var chart = Highcharts.chart('container', options),
         series = chart.series[0],

--- a/ts/Extensions/MarkerClusters/MarkerClusterScatter.ts
+++ b/ts/Extensions/MarkerClusters/MarkerClusterScatter.ts
@@ -1329,14 +1329,22 @@ function seriesGetGridOffset(
     let plotLeft = 0,
         plotTop = 0;
 
-    if (xAxis && series.dataMinX && series.dataMaxX) {
+    if (
+        xAxis &&
+        isNumber(series.dataMinX) &&
+        isNumber(series.dataMaxX)
+    ) {
         plotLeft = xAxis.reversed ?
             xAxis.toPixels(series.dataMaxX) : xAxis.toPixels(series.dataMinX);
     } else {
         plotLeft = chart.plotLeft;
     }
 
-    if (yAxis && series.dataMinY && series.dataMaxY) {
+    if (
+        yAxis &&
+        isNumber(series.dataMinY) &&
+        isNumber(series.dataMaxY)
+    ) {
         plotTop = yAxis.reversed ?
             yAxis.toPixels(series.dataMinY) : yAxis.toPixels(series.dataMaxY);
     } else {


### PR DESCRIPTION
## Summary

- Treat zero cached data extrema as valid numeric grid boundaries.
- Retain plot-edge fallback only when an axis or numeric extremes are unavailable.
- Add a public grid-cluster regression with zero minima.

## Breaking changes

None. Grid alignment now uses valid zero data bounds consistently.

## Verification

- Marker-clusters QUnit suite passed.
- Full Node suite: 418 tests passed.
- Current build, source/sample lint, full commit hook, and `git diff --check` passed.

Fixes #25243