### PR TITLE
bugfix/25245-flowmap-zero-linked-coordinate

### DIFF
--- a/samples/unit-tests/maps/flowmap/demo.js
+++ b/samples/unit-tests/maps/flowmap/demo.js
@@ -349,3 +349,54 @@ QUnit.test('Flowmap API options.', assert => {
         'Points with correctly defined data should not be null.'
     );
 });
+
+QUnit.test('Flowmap links to points on a plot edge', assert => {
+    const chart = Highcharts.mapChart('container', {
+            mapView: {
+                zoom: 3,
+                center: [10, 50]
+            },
+            series: [{
+                type: 'mappoint',
+                data: [{
+                    id: 'A',
+                    lat: 50,
+                    lon: 0
+                }, {
+                    id: 'B',
+                    lat: 50,
+                    lon: 20
+                }]
+            }, {
+                type: 'flowmap',
+                data: [{
+                    from: 'A',
+                    to: 'B',
+                    weight: 1
+                }]
+            }]
+        }),
+        sourcePoints = chart.series[0].points,
+        flowPoint = chart.series[1].points[0];
+
+    sourcePoints[0].plotX = 0;
+    sourcePoints[1].plotY = 0;
+    chart.series[1].translate();
+
+    assert.deepEqual(
+        flowPoint.fromPos,
+        {
+            x: 0,
+            y: sourcePoints[0].plotY
+        },
+        'A point on the left plot edge should be linked'
+    );
+    assert.deepEqual(
+        flowPoint.toPos,
+        {
+            x: sourcePoints[1].plotX,
+            y: 0
+        },
+        'A point on the top plot edge should be linked'
+    );
+});

--- a/ts/Series/FlowMap/FlowMapSeries.ts
+++ b/ts/Series/FlowMap/FlowMapSeries.ts
@@ -545,8 +545,8 @@ class FlowMapSeries extends MapLineSeries {
                     // trigger series redraw for the linked point (in flow).
                     if (
                         (foundPoint instanceof Point) &&
-                        foundPoint.plotX &&
-                        foundPoint.plotY
+                        defined(foundPoint.plotX) &&
+                        defined(foundPoint.plotY)
                     ) {
                         // After linked point update flowmap point should
                         // be also updated


### PR DESCRIPTION
## Summary

- accept defined zero `plotX` and `plotY` values while resolving FlowMap endpoints
- preserve existing rejection of missing linked-point coordinates
- cover both left-edge and top-edge linked points through the public map/flowmap series API

## Breaking changes

None.

## Verification

- exact baseline failed both endpoint assertions; fixed focused QUnit passed
- ESLint and `git diff --check` passed
- commit hook passed 50 browser tests and all 418 Node tests

Fixes #25245
