### PR TITLE
bugfix/25246-stock-tools-zero-point-attraction

### DIFF
--- a/samples/unit-tests/stock-tools/bindings/demo.js
+++ b/samples/unit-tests/stock-tools/bindings/demo.js
@@ -728,3 +728,31 @@ QUnit.test(
             'px from the third point.'
         );
     });
+
+QUnit.test('Stock Tools attraction to a zero-valued point', assert => {
+    const chart = Highcharts.stockChart('container', {
+            series: [{
+                data: [[0, 0], [1, 1]]
+            }]
+        }),
+        point = chart.series[0].points[0];
+
+    chart.navigationBindings.options.bindings.verticalLabel.start.call(
+        chart.navigationBindings,
+        {
+            chartX: chart.plotLeft + point.plotX,
+            chartY: chart.plotTop + point.plotY
+        }
+    );
+
+    assert.deepEqual(
+        chart.annotations[0]?.options.typeOptions.point,
+        {
+            x: 0,
+            xAxis: 0,
+            y: 0,
+            yAxis: 0
+        },
+        'A point at zero should remain available to annotation tools'
+    );
+});

--- a/ts/Stock/StockTools/StockToolsUtilities.ts
+++ b/ts/Stock/StockTools/StockToolsUtilities.ts
@@ -288,7 +288,11 @@ function attractToPoint(
         }
     });
 
-    if (closestPoint && closestPoint.x && closestPoint.y) {
+    if (
+        closestPoint &&
+        defined(closestPoint.x) &&
+        defined(closestPoint.y)
+    ) {
         return {
             x: closestPoint.x,
             y: closestPoint.y,


### PR DESCRIPTION
## Summary

- accept defined zero-valued x/y coordinates in Stock Tools point attraction
- preserve the existing missing-coordinate guard
- cover vertical-label creation at `[0, 0]` through the public navigation binding

## Breaking changes

None.

## Verification

- exact baseline created no annotation; fixed focused QUnit passed
- current scripts build, source/sample ESLint, and `git diff --check` passed
- commit hook passed 59 modified-area browser tests and all 418 Node tests

Fixes #25246
