### PR TITLE
bugfix/25249-sonification-zero-pulse-width

### DIFF
--- a/samples/unit-tests/sonification/classes/demo.js
+++ b/samples/unit-tests/sonification/classes/demo.js
@@ -6,3 +6,22 @@ QUnit.test('Sonification classes are exposed', function (assert) {
     assert.ok(Highcharts.sonification.SynthPatch.prototype);
     assert.ok(Highcharts.sonification.InstrumentPresets);
 });
+
+QUnit.test('Pulse oscillators accept a zero pulse width', function (assert) {
+    const context = new AudioContext(),
+        synth = new Highcharts.sonification.SynthPatch(context, {
+            oscillators: [{
+                type: 'pulse',
+                pulseWidth: 0
+            }]
+        }),
+        pulseNode = synth.oscillators[0].pulseNode;
+
+    assert.strictEqual(
+        pulseNode.pulseWidth,
+        0,
+        'The oscillator should preserve the configured zero width'
+    );
+
+    context.close();
+});

--- a/ts/Extensions/Sonification/SynthPatch.ts
+++ b/ts/Extensions/Sonification/SynthPatch.ts
@@ -379,7 +379,7 @@ class PulseOscNode {
     private pulseWidth: number;
 
     constructor(context: AudioContext, options: PulseOscOptions) {
-        this.pulseWidth = Math.min(Math.max(0, options.pulseWidth || 0.5));
+        this.pulseWidth = Math.min(Math.max(0, options.pulseWidth ?? 0.5));
 
         const makeOsc = (): OscillatorNode => new OscillatorNode(context, {
             type: 'sawtooth',


### PR DESCRIPTION
## Summary

- preserve an explicitly configured zero pulse width in sonification oscillators
- keep `0.5` as the fallback only when the option is nullish
- cover the public `SynthPatch` constructor and runtime oscillator value

## Breaking changes

None.

## Verification

- exact untouched baseline returned `0.5`; fixed focused QUnit returned `0`
- current scripts build, source/sample ESLint, and `git diff --check` passed
- commit hook passed all 418 Node tests; the focused browser regression was run separately because this path has no mapped modified-area browser group

Fixes #25249
