### PR TITLE
bugfix/25251-animation-limit-zero

### DIFF
--- a/samples/unit-tests/series-bullet/bullet/demo.js
+++ b/samples/unit-tests/series-bullet/bullet/demo.js
@@ -34,3 +34,32 @@ QUnit.test('Bullet', function (assert) {
     chart.series[0].removePoint(0);
     assert.deepEqual(chart.series[0].points.length, 7, 'removePoint');
 });
+
+QUnit.test('A zero animation limit disables target updates', assert => {
+    const chart = Highcharts.chart('container', {
+            chart: {
+                animation: false,
+                type: 'bullet'
+            },
+            plotOptions: {
+                bullet: {
+                    animationLimit: 0
+                }
+            },
+            series: [{
+                data: [[5, 10]]
+            }]
+        }),
+        point = chart.series[0].points[0],
+        targetGraphic = point.targetGraphic,
+        originalAnimate = targetGraphic.animate;
+    let animated = false;
+
+    targetGraphic.animate = function () {
+        animated = true;
+        return originalAnimate.apply(this, arguments);
+    };
+    point.update({ target: 12 });
+
+    assert.notOk(animated, 'The bullet target should update without animation');
+});

--- a/samples/unit-tests/series-column/data/demo.js
+++ b/samples/unit-tests/series-column/data/demo.js
@@ -49,3 +49,32 @@ QUnit.test(
         assert.ok(true, 'Setting extremes should not throw');
     }
 );
+
+QUnit.test('A zero animation limit disables point updates', assert => {
+    const chart = Highcharts.chart('container', {
+            chart: {
+                animation: false
+            },
+            plotOptions: {
+                column: {
+                    animationLimit: 0
+                }
+            },
+            series: [{
+                type: 'column',
+                data: [1]
+            }]
+        }),
+        point = chart.series[0].points[0],
+        graphic = point.graphic,
+        originalAnimate = graphic.animate;
+    let animated = false;
+
+    graphic.animate = function () {
+        animated = true;
+        return originalAnimate.apply(this, arguments);
+    };
+    point.update(2);
+
+    assert.notOk(animated, 'The column should update without animation');
+});

--- a/samples/unit-tests/series-xrange/xrange/demo.js
+++ b/samples/unit-tests/series-xrange/xrange/demo.js
@@ -299,6 +299,32 @@ QUnit.test('X-Range', function (assert) {
     );
 });
 
+QUnit.test('A zero animation limit disables point updates', assert => {
+    const chart = Highcharts.chart('container', {
+        chart: {
+            type: 'xrange'
+        },
+        plotOptions: {
+            xrange: {
+                animationLimit: 0
+            }
+        },
+        series: [{
+            data: [{
+                x: 0,
+                x2: 1,
+                y: 0
+            }]
+        }]
+    });
+
+    assert.strictEqual(
+        chart.series[0].getAnimationVerb(),
+        'attr',
+        'The X-range point should update without animation'
+    );
+});
+
 QUnit.test('Partial fill reversed', assert => {
     const chart = Highcharts.chart('container', {
         chart: {

--- a/ts/Series/Bullet/BulletSeries.ts
+++ b/ts/Series/Bullet/BulletSeries.ts
@@ -92,7 +92,7 @@ class BulletSeries extends ColumnSeries {
         const series = this,
             chart = series.chart,
             options = series.options,
-            animationLimit = options.animationLimit || 250;
+            animationLimit = options.animationLimit ?? 250;
 
         super.drawPoints.apply(this, arguments);
 

--- a/ts/Series/Column/ColumnSeries.ts
+++ b/ts/Series/Column/ColumnSeries.ts
@@ -767,7 +767,7 @@ class ColumnSeries extends Series {
             options = series.options,
             nullInteraction = options.nullInteraction,
             { styledMode, renderer } = chart,
-            animationLimit = options.animationLimit || 250;
+            animationLimit = options.animationLimit ?? 250;
         let shapeArgs;
 
         // Draw the columns

--- a/ts/Series/XRange/XRangeSeries.ts
+++ b/ts/Series/XRange/XRangeSeries.ts
@@ -644,7 +644,7 @@ class XRangeSeries extends ColumnSeries {
      */
     public getAnimationVerb(): ('animate'|'attr') {
         return (
-            this.chart.pointCount < (this.options.animationLimit || 250) ?
+            this.chart.pointCount < (this.options.animationLimit ?? 250) ?
                 'animate' :
                 'attr'
         );


### PR DESCRIPTION
## Summary

- preserve an explicit `animationLimit: 0` for Column, Bullet, and XRange series
- keep 250 as the fallback only when the option is nullish
- add separate public regressions for column graphics, bullet targets, and XRange's animation verb

## Breaking changes

None.

## Verification

- exact baseline failed all three regressions; fixed focused browser set passed
- current build, source/sample ESLint, and `git diff --check` passed
- commit hook passed all 418 Node tests; the focused browser tests were run separately because these paths have no mapped modified-area group

Fixes #25251
