### PR TITLE
bugfix/25253-sonification-zero-volume-tracking

### DIFF
--- a/samples/unit-tests/sonification/classes/demo.js
+++ b/samples/unit-tests/sonification/classes/demo.js
@@ -6,3 +6,20 @@ QUnit.test('Sonification classes are exposed', function (assert) {
     assert.ok(Highcharts.sonification.SynthPatch.prototype);
     assert.ok(Highcharts.sonification.InstrumentPresets);
 });
+
+QUnit.test('Oscillators accept zero volume pitch tracking', function (assert) {
+    const context = new AudioContext(),
+        synth = new Highcharts.sonification.SynthPatch(context, {
+            oscillators: [{
+                type: 'sine',
+                volumePitchTrackingMultiplier: 0
+            }]
+        });
+
+    assert.ok(
+        synth.oscillators[0].volTrackingNode,
+        'The oscillator should create its volume tracking stage'
+    );
+
+    context.close();
+});

--- a/ts/Extensions/Sonification/SynthPatch.ts
+++ b/ts/Extensions/Sonification/SynthPatch.ts
@@ -628,7 +628,7 @@ class Oscillator {
     ): void {
         if (this.volTrackingNode) {
             const v = getPitchTrackedMultiplierVal(
-                    this.options.volumePitchTrackingMultiplier || 1,
+                    this.options.volumePitchTrackingMultiplier ?? 1,
                     frequency
                 ),
                 rampTime = glideDuration ? glideDuration / 1000 :
@@ -749,7 +749,7 @@ class Oscillator {
     private createVolTracking(): void {
         const opts = this.options;
         if (
-            opts.volumePitchTrackingMultiplier &&
+            defined(opts.volumePitchTrackingMultiplier) &&
             opts.volumePitchTrackingMultiplier !== 1
         ) {
             this.volTrackingNode = new GainNode(this.audioContext, {


### PR DESCRIPTION
## Summary

- preserve `volumePitchTrackingMultiplier: 0` during oscillator setup and scheduling
- create the tracking gain stage for every defined non-default multiplier
- keep 1 as the fallback only when the option is nullish
- cover the public `SynthPatch` runtime oscillator

## Breaking changes

None.

## Verification

- exact baseline omitted the tracking node; fixed focused QUnit passed
- current build, source/sample ESLint, and `git diff --check` passed
- commit hook passed all 418 Node tests; the focused browser test was run separately

Fixes #25253
