### PR TITLE
bugfix/25255-sonification-zero-filter-tracking

### DIFF
--- a/samples/unit-tests/sonification/classes/demo.js
+++ b/samples/unit-tests/sonification/classes/demo.js
@@ -6,3 +6,32 @@ QUnit.test('Sonification classes are exposed', function (assert) {
     assert.ok(Highcharts.sonification.SynthPatch.prototype);
     assert.ok(Highcharts.sonification.InstrumentPresets);
 });
+
+QUnit.test('Filters accept zero frequency pitch tracking', function (assert) {
+    const context = new AudioContext(),
+        synth = new Highcharts.sonification.SynthPatch(context, {
+            oscillators: [{
+                type: 'sine',
+                lowpass: {
+                    frequency: 1000,
+                    frequencyPitchTrackingMultiplier: 0
+                }
+            }]
+        }),
+        frequencyParam = synth.oscillators[0].lowpassNode.frequency,
+        originalSetTargetAtTime = frequencyParam.setTargetAtTime;
+    let scheduledFrequency;
+
+    frequencyParam.setTargetAtTime = function (value) {
+        scheduledFrequency = value;
+        return originalSetTargetAtTime.apply(this, arguments);
+    };
+    synth.playFreqAtTime(0, 1000);
+
+    assert.ok(
+        scheduledFrequency < 1000,
+        'The filter should apply the configured zero tracking multiplier'
+    );
+
+    context.close();
+});

--- a/ts/Extensions/Sonification/SynthPatch.ts
+++ b/ts/Extensions/Sonification/SynthPatch.ts
@@ -656,7 +656,7 @@ class Oscillator {
                 filterOptions: FilterOptions
             ): void => {
                 const multiplier = getPitchTrackedMultiplierVal(
-                        filterOptions.frequencyPitchTrackingMultiplier || 1,
+                        filterOptions.frequencyPitchTrackingMultiplier ?? 1,
                         frequency
                     ),
                     f = clamp(


### PR DESCRIPTION
## Summary

- preserve a zero filter `frequencyPitchTrackingMultiplier`
- use 1 as the scheduling fallback only when the option is nullish
- cover the actual low-pass AudioParam through the public `SynthPatch` API

## Breaking changes

None.

## Verification

- exact baseline kept the cutoff at 1000 Hz and failed; fixed focused QUnit passed with the reduced cutoff
- current build, source/sample ESLint, and `git diff --check` passed
- commit hook passed all 418 Node tests; the focused browser test was run separately

Fixes #25255
