### PR TITLE
bugfix/25257-a11y-point-marker-zero-opacity

### DIFF
--- a/samples/unit-tests/accessibility/forced-markers/demo.js
+++ b/samples/unit-tests/accessibility/forced-markers/demo.js
@@ -395,3 +395,32 @@ QUnit.test(
             'exist again'
         );
     });
+
+QUnit.test('Point markers preserve explicit zero opacity', function (assert) {
+    const chart = Highcharts.chart('container', {
+            series: [{
+                data: [{
+                    y: 1,
+                    marker: {
+                        enabled: true,
+                        states: {
+                            normal: {
+                                opacity: 0
+                            }
+                        }
+                    }
+                }]
+            }]
+        }),
+        point = chart.series[0].points[0];
+
+    assert.strictEqual(
+        point.options.marker.states.normal.opacity,
+        0,
+        'The accessibility marker handling should retain zero opacity'
+    );
+    assert.notOk(
+        hasVisibleMarker(point),
+        'The point marker should stay hidden'
+    );
+});

--- a/ts/Accessibility/Components/SeriesComponent/ForcedMarkers.ts
+++ b/ts/Accessibility/Components/SeriesComponent/ForcedMarkers.ts
@@ -302,7 +302,7 @@ namespace ForcedMarkersComposition {
         merge(true, pointOptions.marker, {
             states: {
                 normal: {
-                    opacity: getPointMarkerOpacity(pointOptions) || 1
+                    opacity: getPointMarkerOpacity(pointOptions) ?? 1
                 }
             }
         });


### PR DESCRIPTION
## Summary

- preserve explicit per-point normal marker opacity zero during accessibility forced-marker cleanup
- use opacity one only when the configured value is nullish
- cover both retained point options and the rendered hidden marker through the public chart API

## Breaking changes

None.

## Verification

- exact baseline mutated opacity to one and displayed the marker; fixed focused QUnit passed
- current build, source/sample ESLint, and `git diff --check` passed
- commit hook passed 15 accessibility browser suites and all 418 Node tests

Fixes #25257
