### PR TITLE
bugfix/25259-a11y-zero-axis-ranges

### DIFF
--- a/samples/unit-tests/accessibility/i18n/demo.js
+++ b/samples/unit-tests/accessibility/i18n/demo.js
@@ -270,8 +270,8 @@ QUnit.test('Chart lang can be configured', function (assert) {
         .screenReaderSections.before.element.innerHTML;
 
     assert.ok(
-        screenReaderHTML.includes('类别') &&
-        !screenReaderHTML.includes('categories'),
+        screenReaderHTML.includes('displaying 类别.') &&
+        !screenReaderHTML.includes('displaying categories.'),
         'Screen reader uses translated "类别" instead of default "categories"'
     );
 

--- a/samples/unit-tests/accessibility/utilities/demo.js
+++ b/samples/unit-tests/accessibility/utilities/demo.js
@@ -49,3 +49,47 @@ QUnit.test('Heading auto detection works as expected', function (assert) {
         'Parent previous sibling h1 should give h2.'
     );
 });
+
+QUnit.test('Axis range descriptions preserve zero data bounds', assert => {
+    const getRangeDescription =
+        Highcharts.A11yChartUtilities.getAxisRangeDescription;
+    let chart = Highcharts.chart('container', {
+        xAxis: {
+            categories: ['A', 'B', 'C']
+        },
+        series: [{
+            data: [1, 2, 3]
+        }]
+    });
+
+    assert.strictEqual(
+        getRangeDescription(chart.xAxis[0]),
+        'Data range: 3 categories.',
+        'Category ranges should include a zero-based first category'
+    );
+
+    chart = Highcharts.chart('container', {
+        series: [{
+            data: [[0, 1], [10, 2]]
+        }]
+    });
+    assert.strictEqual(
+        getRangeDescription(chart.xAxis[0]),
+        'Data ranges from 0 to 10.',
+        'Numeric ranges should start at the zero data minimum'
+    );
+
+    chart = Highcharts.chart('container', {
+        xAxis: {
+            type: 'datetime'
+        },
+        series: [{
+            data: [[0, 1], [24 * 60 * 60 * 1000, 2]]
+        }]
+    });
+    assert.strictEqual(
+        getRangeDescription(chart.xAxis[0]),
+        'Data range: 24 hours.',
+        'Time ranges should start at the zero timestamp'
+    );
+});

--- a/ts/Accessibility/Utils/ChartUtilities.ts
+++ b/ts/Accessibility/Utils/ChartUtilities.ts
@@ -155,7 +155,7 @@ function getAxisRangeDescription(axis: Axis): string {
 function getCategoryAxisRangeDesc(axis: Axis): string {
     const chart = axis.chart;
 
-    if (axis.dataMax && axis.dataMin) {
+    if (defined(axis.dataMax) && defined(axis.dataMin)) {
         return chart.langFormat(
             'accessibility.axis.rangeCategories',
             {
@@ -177,8 +177,8 @@ function getCategoryAxisRangeDesc(axis: Axis): string {
 function getAxisTimeLengthDesc(axis: Axis): string {
     const chart = axis.chart,
         range: Record<string, number> = {},
-        min = axis.dataMin || axis.min || 0,
-        max = axis.dataMax || axis.max || 0;
+        min = axis.dataMin ?? axis.min ?? 0,
+        max = axis.dataMax ?? axis.max ?? 0;
     let rangeUnit = 'Seconds';
 
     range.Seconds = (max - min) / 1000;
@@ -223,8 +223,8 @@ function getAxisFromToDescription(axis: Axis): string {
             ''
         ),
         extremes: Record<string, number> = {
-            min: axis.dataMin || axis.min || 0,
-            max: axis.dataMax || axis.max || 0
+            min: axis.dataMin ?? axis.min ?? 0,
+            max: axis.dataMax ?? axis.max ?? 0
         },
         format = function (key: ('max'|'min')): string {
             return axis.dateTime ?


### PR DESCRIPTION
## Summary

- preserve zero-valued data bounds in category, numeric, and datetime accessibility range descriptions
- fall back to rendered axis bounds only when data bounds are nullish
- cover zero-based categories, numeric data, and Unix-epoch datetime data
- narrow an existing translation assertion to its intended axis-name phrase because restored range text legitimately contains the default English unit word

## Breaking changes

None.

## Verification

- exact baseline failed all three new assertions with an empty range, `-0.1..10`, and about 24.2 hours
- fixed focused utilities/i18n suites pass 2/2
- all 15 modified accessibility browser suites and all 418 Node tests pass
- current scripts build, source/sample ESLint, commit hook, and `git diff --check` pass

Fixes #25259
