### PR TITLE
bugfix/25261-exporting-zero-symbol-options

### DIFF
--- a/samples/unit-tests/exporting/buttons/demo.js
+++ b/samples/unit-tests/exporting/buttons/demo.js
@@ -226,6 +226,34 @@ QUnit.test('View/hide data table button, #14338.', function (assert) {
     );
 });
 
+QUnit.test('Export buttons preserve zero symbol options', function (assert) {
+    const chart = Highcharts.chart('container', {
+            exporting: {
+                buttons: {
+                    contextButton: {
+                        symbolSize: 0,
+                        symbolStrokeWidth: 0
+                    }
+                }
+            },
+            series: [{
+                data: [1]
+            }]
+        }),
+        symbol = chart.exporting.svgElements[1];
+
+    assert.strictEqual(
+        symbol.width,
+        0,
+        'The configured zero symbol size is preserved'
+    );
+    assert.strictEqual(
+        symbol.attr('stroke-width'),
+        0,
+        'The configured zero stroke width is preserved'
+    );
+});
+
 QUnit.test(
     'When chart initialized with the table, show a proper button for hiding ' +
     'the table, #14352.',

--- a/ts/Extensions/Exporting/Exporting.ts
+++ b/ts/Extensions/Exporting/Exporting.ts
@@ -984,7 +984,7 @@ export class Exporting {
             ),
             onclick = btnOptions.onclick,
             menuItems = btnOptions.menuItems,
-            symbolSize = btnOptions.symbolSize || 12;
+            symbolSize = btnOptions.symbolSize ?? 12;
         let symbol;
 
         if (btnOptions.enabled === false || !btnOptions.theme) {
@@ -1093,7 +1093,7 @@ export class Exporting {
                 symbol.attr({
                     stroke: btnOptions.symbolStroke,
                     fill: btnOptions.symbolFill,
-                    'stroke-width': btnOptions.symbolStrokeWidth || 1
+                    'stroke-width': btnOptions.symbolStrokeWidth ?? 1
                 });
             }
         }


### PR DESCRIPTION
## Summary

- preserve explicit zero exporting-button `symbolSize` and `symbolStrokeWidth`
- retain defaults 12 and 1 only when their options are nullish
- cover the rendered SVG width and stroke width through the public chart API

## Breaking changes

None. Only explicitly configured zero values change.

## Verification

- exact baseline returned width 12 and stroke width 1; fixed focused exporting/buttons QUnit passed 1/1
- current and ES5 scripts builds, source/sample ESLint, all 418 Node tests, commit hook, and `git diff --check` pass
- the focused Playwright test was run explicitly because the modified-test mapper reports no mapped tests for this path

Fixes #25261
