### PR TITLE
bugfix/25263-data-series-converter-alignment

### DIFF
--- a/test/ts-node-unit-tests/tests/Core/Series/DataSeriesConverter.test.ts
+++ b/test/ts-node-unit-tests/tests/Core/Series/DataSeriesConverter.test.ts
@@ -1,0 +1,83 @@
+import { describe, it } from 'node:test';
+import { deepStrictEqual, strictEqual } from 'node:assert';
+
+import DataSeriesConverter from '../../../../../ts/Core/Series/DataSeriesConverter.js';
+
+describe('DataSeriesConverter', () => {
+    it('should preserve zero coordinates and values across series', () => {
+        const converter = new DataSeriesConverter();
+
+        converter.updateTable([{
+            id: 'first',
+            options: {
+                data: [[0, 5], [1, 6]]
+            }
+        }, {
+            id: 'second',
+            options: {
+                data: [[1, 0], [0, 7]]
+            }
+        }, {
+            id: 'third',
+            options: {
+                data: [{ x: 2, y: 9 }, { x: 0, y: 8 }]
+            }
+        }] as any);
+
+        strictEqual(
+            converter.table.getRowCount(),
+            3,
+            'Shared zero coordinates should reuse the first table row'
+        );
+        deepStrictEqual(
+            converter.getSeriesData('second'),
+            [{ x: 0, y: 7 }, { x: 1, y: 0 }],
+            'Zero values should be merged into their matching coordinate rows'
+        );
+        deepStrictEqual(
+            converter.getSeriesData('third'),
+            [{ x: 0, y: 8 }, { x: 2, y: 9 }],
+            'Object-form zero coordinates should not fall back to data indexes'
+        );
+    });
+
+    it('should merge multi-value points into existing rows', () => {
+        const converter = new DataSeriesConverter();
+
+        converter.updateTable([{
+            id: 'line',
+            options: {
+                data: [[0, 1], [1, 2]]
+            }
+        }, {
+            id: 'range',
+            pointArrayMap: ['low', 'high'],
+            options: {
+                data: [[1, 10, 20]]
+            }
+        }] as any);
+
+        deepStrictEqual(
+            converter.getSeriesData('range'),
+            [{ x: 1, low: 10, high: 20 }],
+            'Every value column should merge into the matching coordinate row'
+        );
+    });
+
+    it('should preserve null points at their data indexes', () => {
+        const converter = new DataSeriesConverter();
+
+        converter.updateTable([{
+            id: 'line',
+            options: {
+                data: [1, null, 2]
+            }
+        }] as any);
+
+        deepStrictEqual(
+            converter.getSeriesData('line'),
+            [{ x: 0, y: 1 }, { x: 1, y: null }, { x: 2, y: 2 }],
+            'Null points should remain aligned between neighboring values'
+        );
+    });
+});

--- a/ts/Core/Series/DataSeriesConverter.ts
+++ b/ts/Core/Series/DataSeriesConverter.ts
@@ -246,7 +246,7 @@ class DataSeriesConverter {
                     columns = {};
                     needsArrayMap = pointArrayMapLength > 1;
 
-                    if (typeof elem === 'number') {
+                    if (typeof elem === 'number' || elem === null) {
                         columns[y] = elem;
                         columns.x = j;
                     } else if (elem instanceof Array) {
@@ -290,17 +290,19 @@ class DataSeriesConverter {
                             columns[y] = elem.y;
                         }
 
-                        columns.x = elem.x || j;
+                        columns.x = defined(elem.x) ? elem.x : j;
                     }
 
                     id = '' + columns.x;
                     rowIndex = table.getRowIndexBy('id', id);
 
-                    if (!rowIndex) {
+                    if (!defined(rowIndex)) {
                         columns.id = id;
                         table.setRows([columns], void 0, void 0, eventDetail);
-                    } else if (columns[y]) {
-                        table.setCell(y, rowIndex, columns[y], eventDetail);
+                    } else {
+                        table.setRows(
+                            [columns], rowIndex, void 0, eventDetail
+                        );
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- distinguish row index zero and object-form x zero from missing values
- merge complete point rows at existing coordinates, preserving scalar and every multi-value `pointArrayMap` column
- keep literal null points aligned at their data indexes
- add direct Node regressions for zero values, range-series rows, and null points

## Breaking changes

None.

## Verification

- exact baseline produced four rows instead of three, dropped zero Y, relocated object x zero, omitted range low/high data, and lost the null point
- fixed focused regressions pass 3/3
- full Node suite passes 421/421; mapped browser suites pass 391/391
- current/ES5 builds, source/test lint, exact-tree commit hook, and `git diff --check` pass

Fixes #25263
