### PR TITLE
bugfix/25265-contour-zero-color-extremes

### DIFF
--- a/test/ts-node-unit-tests/tests/Series/Contour/ContourSeries.test.ts
+++ b/test/ts-node-unit-tests/tests/Series/Contour/ContourSeries.test.ts
@@ -1,0 +1,40 @@
+import { deepStrictEqual } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import '../../../../../ts/masters/highcharts.src';
+import ContourSeries from '../../../../../ts/Series/Contour/ContourSeries';
+
+describe('ContourSeries', () => {
+    it('should preserve zero color axis extremes', () => {
+        const series = Object.create(
+                ContourSeries.prototype
+            ) as ContourSeries,
+            getValueAxisExtremes = (
+                series as unknown as {
+                    getValueAxisExtremes: () => number[];
+                }
+            ).getValueAxisExtremes.bind(series);
+
+        Object.assign(series, {
+            colorAxis: {
+                min: 0,
+                max: 100
+            },
+            points: [{ value: 10 }, { value: 20 }],
+            valueMin: NaN,
+            valueMax: NaN
+        });
+
+        deepStrictEqual(getValueAxisExtremes(), [0, 100]);
+
+        Object.assign(series, {
+            colorAxis: {
+                min: -100,
+                max: 0
+            },
+            points: [{ value: -20 }, { value: -10 }]
+        });
+
+        deepStrictEqual(getValueAxisExtremes(), [-100, 0]);
+    });
+});

--- a/ts/Series/Contour/ContourSeries.ts
+++ b/ts/Series/Contour/ContourSeries.ts
@@ -34,6 +34,7 @@ import SVGRenderer from '../../Core/Renderer/SVG/SVGRenderer.js';
 import {
     diffObjects,
     extend,
+    isNumber,
     merge,
     normalizeTickInterval
 } from '../../Shared/Utilities.js';
@@ -767,10 +768,10 @@ export default class ContourSeries extends ScatterSeries {
         const series = this;
 
         let min = series.valueMin;
-        if (isNaN(min || NaN)) {
+        if (!isNumber(min)) {
             min = series.colorAxis?.min;
 
-            if (isNaN(min || NaN)) {
+            if (!isNumber(min)) {
                 min = Math.min(...series.points.map(
                     (point): number => point.value || 0
                 ));
@@ -778,10 +779,10 @@ export default class ContourSeries extends ScatterSeries {
         }
 
         let max = series.valueMax;
-        if (isNaN(max || NaN)) {
+        if (!isNumber(max)) {
             max = series.colorAxis?.max;
 
-            if (isNaN(max || NaN)) {
+            if (!isNumber(max)) {
                 max = Math.max(...series.points.map(
                     (point): number => point.value || 0
                 ));


### PR DESCRIPTION
## Summary

- preserve numeric zero while resolving ContourSeries value/color-axis extremes
- use the existing numeric predicate at each series → color-axis → data fallback stage
- cover both zero minimum and zero maximum ranges directly

## Breaking changes

None.

## Verification

- exact baseline returned `[10,100]` instead of `[0,100]` and similarly contracted the max-zero case
- fixed focused Node regression passes 1/1; full Node suite passes 419/419
- current and ES5 builds pass sequentially; source/test ESLint, full commit hook, and `git diff --check` pass
- an initial parallel build/test collision in generated Webpack output was discarded; the clean sequential rerun passed

Fixes #25265
