### PR TITLE
bugfix/25267-contour-coalesce-initialization

### DIFF
--- a/test/ts-node-unit-tests/tests/Series/Contour/ContourSeries.test.ts
+++ b/test/ts-node-unit-tests/tests/Series/Contour/ContourSeries.test.ts
@@ -1,0 +1,79 @@
+import { strictEqual } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import '../../../../../ts/masters/highcharts.src';
+import ContourSeries from '../../../../../ts/Series/Contour/ContourSeries';
+
+describe('ContourSeries', () => {
+    it('should coalesce draws while WebGPU initializes', async () => {
+        const globals = globalThis as unknown as {
+                window?: Window;
+            },
+            hadWindow = Object.hasOwn(globals, 'window'),
+            originalWindow = globals.window,
+            series = Object.create(
+                ContourSeries.prototype
+            ) as ContourSeries;
+
+        let resolveRun!: () => void,
+            runCount = 0;
+        const runPromise = new Promise<void>((resolve): void => {
+            resolveRun = resolve;
+        });
+
+        globals.window = { devicePixelRatio: 1 } as Window;
+
+        Object.assign(series, {
+            canvas: {
+                style: {}
+            },
+            chart: {
+                inverted: false
+            },
+            foreignObject: {
+                height: {
+                    baseVal: {
+                        value: 100
+                    }
+                },
+                width: {
+                    baseVal: {
+                        value: 100
+                    }
+                }
+            },
+            group: {},
+            run: (): Promise<void> => {
+                runCount++;
+                return runPromise;
+            },
+            xAxis: {
+                len: 100
+            },
+            yAxis: {
+                len: 100
+            }
+        });
+
+        try {
+            series.drawPoints();
+            const renderPromise = series.renderPromise;
+
+            series.drawPoints();
+
+            strictEqual(runCount, 1);
+            strictEqual(series.renderPromise, renderPromise);
+
+            resolveRun();
+            await renderPromise;
+
+            strictEqual(series.renderPromise, void 0);
+        } finally {
+            if (hadWindow) {
+                globals.window = originalWindow;
+            } else {
+                delete globals.window;
+            }
+        }
+    });
+});

--- a/ts/Series/Contour/ContourSeries.ts
+++ b/ts/Series/Contour/ContourSeries.ts
@@ -228,9 +228,14 @@ export default class ContourSeries extends ScatterSeries {
 
         if (this.renderFrame) {
             this.renderFrame();
-        } else {
-            /* eslint-disable @typescript-eslint/no-floating-promises */
-            this.run();
+        } else if (this.renderPromise === void 0) {
+            this.renderPromise = (async (): Promise<void> => {
+                try {
+                    await this.run();
+                } finally {
+                    this.renderPromise = void 0;
+                }
+            })();
         }
     }
 


### PR DESCRIPTION
## Summary

- retain one ContourSeries WebGPU initialization promise while `run()` is pending
- skip duplicate adapter/device/buffer/pipeline initialization from repeated draws
- clear pending state in `finally` so later draws or retries are not blocked
- cover call count, stable shared promise identity, and completion cleanup

## Breaking changes

None.

## Verification

- deterministic baseline: two immediate draws against deferred `run()` produced two calls and no stored promise
- fixed focused Node regression passes 1/1; full Node suite passes 419/419
- current and ES5 builds, source/test ESLint, full commit hook, and `git diff --check` pass
- regression restores the prior global `window` value or absence

Fixes #25267
