### PR TITLE
bugfix/25269-node-lookup-built-in-ids

### DIFF
--- a/samples/unit-tests/series-sankey/sankey/demo.js
+++ b/samples/unit-tests/series-sankey/sankey/demo.js
@@ -164,6 +164,25 @@ QUnit.test('Sankey', function (assert) {
     );
 });
 
+QUnit.test('Built-in-named node IDs', function (assert) {
+    const chart = Highcharts.chart('container', {
+        series: [{
+            type: 'sankey',
+            keys: ['from', 'to', 'weight'],
+            data: [
+                ['toString', 'middle', 1],
+                ['middle', '__proto__', 1]
+            ]
+        }]
+    });
+
+    assert.deepEqual(
+        chart.series[0].nodes.map(node => node.id).sort(),
+        ['__proto__', 'middle', 'toString'].sort(),
+        'Built-in object property names should work as node IDs'
+    );
+});
+
 QUnit.test('Sankey nodeFormat, nodeFormatter', function (assert) {
     var chart = Highcharts.chart('container', {
         chart: {

--- a/ts/Series/NodesComposition.ts
+++ b/ts/Series/NodesComposition.ts
@@ -292,7 +292,10 @@ namespace NodesComposition {
         this: SeriesComposition
     ): void {
         const chart = this.chart,
-            nodeLookup = {} as Record<string, PointComposition>;
+            nodeLookup = Object.create(null) as Record<
+                string,
+                PointComposition
+            >;
 
         seriesProto.generatePoints.call(this);
 


### PR DESCRIPTION
## Summary

- use a prototype-free lookup for nodes created by the shared node composition
- allow public node IDs such as `toString` and `__proto__` without colliding with inherited object properties
- cover the failure with a focused Sankey browser regression

## Breaking changes

None.

## Verification

- deterministic baseline reproduced the Sankey crash for built-in-named IDs
- fixed focused mapped QUnit regression passes
- current and ES5 builds, source/sample ESLint, full commit hook, `git diff --check`, and all 418 Node tests pass

Fixes #25269