### PR TITLE
bugfix/25271-treemap-built-in-parent-ids

### DIFF
--- a/samples/unit-tests/series-sunburst/data-id/demo.js
+++ b/samples/unit-tests/series-sunburst/data-id/demo.js
@@ -51,3 +51,46 @@ QUnit.test('series.data.id: custom id', function (assert) {
         'series.points[1] has a property id with value of "2"'
     );
 });
+
+QUnit.test('series.data.id: built-in object property names', function (assert) {
+    let duplicateIdWarnings = 0;
+    const removeErrorEvent = Highcharts.addEvent(
+        Highcharts,
+        'displayError',
+        function (event) {
+            if (event.code === 31) {
+                duplicateIdWarnings++;
+                event.preventDefault();
+            }
+        }
+    );
+
+    try {
+        const chart = Highcharts.chart('container', {
+                series: [{
+                    type: 'sunburst',
+                    data: [{
+                        id: 'toString',
+                        value: 1
+                    }, {
+                        id: '__proto__',
+                        value: 1
+                    }]
+                }]
+            }),
+            protoId = '__proto__';
+
+        assert.ok(
+            chart.series[0].nodeMap.toString &&
+                chart.series[0].nodeMap[protoId],
+            'Both built-in-named nodes should be available'
+        );
+        assert.strictEqual(
+            duplicateIdWarnings,
+            0,
+            'Distinct built-in-named nodes should not report duplicate IDs'
+        );
+    } finally {
+        removeErrorEvent();
+    }
+});

--- a/samples/unit-tests/series-treemap/members/demo.js
+++ b/samples/unit-tests/series-treemap/members/demo.js
@@ -114,6 +114,52 @@ QUnit.test('getListOfParents', function (assert) {
     );
 });
 
+QUnit.test('Built-in-named parent IDs', function (assert) {
+    const chart = Highcharts.chart('container', {
+        series: [{
+            type: 'treemap',
+            data: [{
+                id: 'toString'
+            }, {
+                id: 'child-1',
+                parent: 'toString',
+                value: 1
+            }, {
+                id: '__proto__'
+            }, {
+                id: 'child-2',
+                parent: '__proto__',
+                value: 1
+            }]
+        }]
+    });
+    const { nodeMap } = chart.series[0],
+        protoId = '__proto__';
+
+    assert.deepEqual(
+        [
+            nodeMap.toString.children[0].id,
+            nodeMap[protoId].children[0].id
+        ],
+        ['child-1', 'child-2'],
+        'Built-in object property names should work as parent IDs'
+    );
+
+    chart.series[0].update({
+        cluster: {
+            enabled: true,
+            minimumClusterSize: 1,
+            pixelWidth: 1000
+        }
+    });
+
+    assert.ok(
+        chart.series[0].nodeMap.toString &&
+            chart.series[0].nodeMap[protoId],
+        'Built-in-named parents should also work with grouping enabled'
+    );
+});
+
 QUnit.test('seriesTypes.treemap.pointClass.setState', function (assert) {
     var series = Highcharts.Series.types.treemap,
         setState = series.prototype.pointClass.prototype.setState,

--- a/ts/Series/Sunburst/SunburstSeries.ts
+++ b/ts/Series/Sunburst/SunburstSeries.ts
@@ -880,7 +880,7 @@ class SunburstSeries extends TreemapSeries {
         let mapIdToNode = series.nodeMap,
             mapOptionsToLevel: Record<string, SunburstSeriesLevelOptions>,
             nodeRoot = mapIdToNode && mapIdToNode[rootId],
-            nodeIds: Record<string, boolean> = {};
+            nodeIds = Object.create(null) as Record<string, boolean>;
 
         series.shapeRoot = nodeRoot && nodeRoot.shapeArgs;
 

--- a/ts/Series/Treemap/TreemapSeries.ts
+++ b/ts/Series/Treemap/TreemapSeries.ts
@@ -456,7 +456,10 @@ class TreemapSeries extends ScatterSeries {
             minimumClusterSize = cluster?.minimumClusterSize || 5;
 
         if (cluster?.enabled) {
-            const parentGroups: {[key: string]: TreemapNode[]} = {};
+            const parentGroups = Object.create(null) as Record<
+                string,
+                TreemapNode[]
+            >;
 
             const checkIfHide = (node: TreemapNode): void => {
                 if (node?.point?.shapeArgs) {
@@ -549,7 +552,7 @@ class TreemapSeries extends ScatterSeries {
                 }
             }
 
-            series.nodeMap = {};
+            series.nodeMap = Object.create(null);
             series.nodeList = [];
             series.parentList = parentList;
             const tree = series.buildTree('', -1, 0, series.parentList);
@@ -1126,21 +1129,20 @@ class TreemapSeries extends ScatterSeries {
     ): TreemapSeries.ListOfParentsObject {
         const arr = isArray(data) ? data : [],
             ids = isArray(existingIds) ? existingIds : [],
-            listOfParents = arr.reduce(function (
-                prev: TreemapSeries.ListOfParentsObject,
-                curr: TreemapPoint,
-                i: number
-            ): TreemapSeries.ListOfParentsObject {
-                const parent = (curr.parent ?? '');
+            listOfParents = Object.create(
+                null
+            ) as TreemapSeries.ListOfParentsObject;
 
-                if (typeof prev[parent] === 'undefined') {
-                    prev[parent] = [];
-                }
-                prev[parent].push(i);
-                return prev;
-            }, {
-                '': [] // Root of tree
-            });
+        listOfParents[''] = []; // Root of tree
+
+        arr.forEach(function (curr: TreemapPoint, i: number): void {
+            const parent = (curr.parent ?? '');
+
+            if (typeof listOfParents[parent] === 'undefined') {
+                listOfParents[parent] = [];
+            }
+            listOfParents[parent].push(i);
+        });
 
         // If parent does not exist, hoist parent to root of tree.
         for (const parent of Object.keys(listOfParents)) {
@@ -1170,7 +1172,7 @@ class TreemapSeries extends ScatterSeries {
 
         series.parentList = series.getListOfParents(this.data, allIds);
 
-        series.nodeMap = {};
+        series.nodeMap = Object.create(null);
         series.nodeList = [];
         return series.buildTree('', -1, 0, series.parentList || {});
     }


### PR DESCRIPTION
## Summary

- build Treemap parent, node, and optional grouping lookups without Object prototypes
- isolate Sunburst duplicate-ID tracking from inherited property names
- simplify Treemap parent collection to a direct pass
- cover built-in-named Treemap parent/child relations, grouping, Sunburst lookup, and warning behavior

## Breaking changes

None.

## Verification

- exact baseline mapped Treemap QUnit crashed with `prev[parent].push is not a function`
- fixed mapped Treemap and Sunburst regressions pass
- current and ES5 builds, source/sample ESLint, full commit hook with 50 mapped browser tests, `git diff --check`, and all 418 Node tests pass

Fixes #25271