### PR TITLE
bugfix/25273-treegrid-built-in-parent-ids

### DIFF
--- a/samples/unit-tests/gantt/treegrid/demo.js
+++ b/samples/unit-tests/gantt/treegrid/demo.js
@@ -125,6 +125,47 @@ QUnit.test('Indentation', function (assert) {
     );
 });
 
+QUnit.test('Built-in-named parent IDs', function (assert) {
+    const chart = Highcharts.chart('container', {
+            yAxis: {
+                type: 'treegrid'
+            },
+            series: [{
+                type: 'scatter',
+                data: [{
+                    id: 'toString',
+                    name: 'Parent 1',
+                    x: 1
+                }, {
+                    id: 'child-1',
+                    name: 'Child 1',
+                    parent: 'toString',
+                    x: 2
+                }, {
+                    id: '__proto__',
+                    name: 'Parent 2',
+                    x: 3
+                }, {
+                    id: 'child-2',
+                    name: 'Child 2',
+                    parent: '__proto__',
+                    x: 4
+                }]
+            }]
+        }),
+        tree = chart.yAxis[0].treeGrid.tree,
+        parents = tree.children;
+
+    assert.deepEqual(
+        parents.map(parent => [parent.id, parent.children[0].id]),
+        [
+            ['toString', 'child-1'],
+            ['__proto__', 'child-2']
+        ],
+        'Both built-in-named parents should keep their children'
+    );
+});
+
 QUnit.test('Tree.getNode', function (assert) {
     var getNode = Highcharts.Axis.prototype.utils.getNode,
         mapOfIdToChildren = {

--- a/ts/Gantt/Tree.ts
+++ b/ts/Gantt/Tree.ts
@@ -76,29 +76,29 @@ function getListOfParents(
     data: Array<TreePointOptionsObject>
 ): Record<string, Array<TreePointOptionsObject>> {
     const root = '',
-        ids: string[] = [],
-        listOfParents = data.reduce((
-            prev,
-            curr
-        ): Record<string, Array<TreePointOptionsObject>> => {
-            const { parent = '', id } = curr;
+        ids = new Set<string>(),
+        listOfParents = Object.create(null) as Record<
+            string,
+            Array<TreePointOptionsObject>
+        >;
 
-            if (typeof prev[parent] === 'undefined') {
-                prev[parent] = [];
-            }
+    data.forEach((item): void => {
+        const { parent = '', id } = item;
 
-            prev[parent].push(curr);
+        if (typeof listOfParents[parent] === 'undefined') {
+            listOfParents[parent] = [];
+        }
 
-            if (id) {
-                ids.push(id);
-            }
+        listOfParents[parent].push(item);
 
-            return prev;
-        }, {} as Record<string, Array<TreePointOptionsObject>>);
+        if (id) {
+            ids.add(id);
+        }
+    });
 
     Object.keys(listOfParents).forEach(
         (node: string): void => {
-            if ((node !== root) && (ids.indexOf(node) === -1)) {
+            if ((node !== root) && !ids.has(node)) {
                 const adoptedByRoot = listOfParents[node].map(
                     function (orphan): TreePointOptionsObject {
                         const { ...parentExcluded } = orphan; // #15196


### PR DESCRIPTION
## Summary

- group tree-grid parents in a prototype-free dictionary
- collect hierarchy data in one direct pass instead of a reduction
- track existing non-empty point IDs with a Set instead of repeated linear searches
- cover `toString` and `__proto__` parent-child relationships through a public chart

## Breaking changes

None.

## Verification

- exact baseline focused QUnit failed with `prev[parent].push is not a function`
- fixed focused TreeGrid QUnit passes
- source/sample ESLint, mapped 23 accessibility/Gantt QUnits, full commit hook, `git diff --check`, and all 418 Node tests pass

Fixes #25273