### PR TITLE
bugfix/25275-venn-built-in-set-ids

### DIFF
--- a/samples/unit-tests/series-venn/members/demo.js
+++ b/samples/unit-tests/series-venn/members/demo.js
@@ -569,6 +569,36 @@ QUnit.test('processVennData', function (assert) {
         [],
         'should remove relations that has invalid values in sets.'
     );
+
+    data = [{
+        sets: ['toString'],
+        value: 2
+    }, {
+        sets: ['__proto__'],
+        value: 3
+    }, {
+        sets: ['toString', '__proto__'],
+        value: 1
+    }];
+
+    const relations = processVennData(data, defaultSplitter),
+        layout = vennSeries.layout(relations);
+
+    assert.deepEqual(
+        relations.map(relation => relation.sets),
+        [
+            ['toString'],
+            ['__proto__'],
+            ['__proto__', 'toString']
+        ],
+        'should accept set names matching built-in object properties.'
+    );
+
+    assert.deepEqual(
+        Object.keys(layout.mapOfIdToShape),
+        ['toString', '__proto__', '__proto__,toString'],
+        'should create every built-in-named set and intersection shape.'
+    );
 });
 
 QUnit.test('sortByTotalOverlap', function (assert) {

--- a/ts/Series/Venn/VennSeries.ts
+++ b/ts/Series/Venn/VennSeries.ts
@@ -285,8 +285,14 @@ class VennSeries extends ScatterSeries {
             mapOfIdToShape: Record<string, (CircleObject|IntersectionObject)>;
             mapOfIdToLabelValues: Record<string, (VennLabelValuesObject)>;
         }) {
-        const mapOfIdToShape: Record<string, (CircleObject|IntersectionObject)> = {};
-        const mapOfIdToLabelValues: Record<string, (VennLabelValuesObject)> = {};
+        const mapOfIdToShape: Record<
+                string,
+                (CircleObject|IntersectionObject)
+            > = Object.create(null),
+            mapOfIdToLabelValues: Record<
+                string,
+                VennLabelValuesObject
+            > = Object.create(null);
 
         // Calculate best initial positions by using greedy layout.
         if (relations.length > 0) {

--- a/ts/Series/Venn/VennUtils.ts
+++ b/ts/Series/Venn/VennUtils.ts
@@ -116,7 +116,8 @@ function addOverlapToSets(
     relations: Array<VennRelationObject>
 ): Array<VennRelationObject> {
     // Calculate the amount of overlap per set.
-    const mapOfIdToProps: Record<string, VennPropsObject> = {};
+    const mapOfIdToProps: Record<string, VennPropsObject> =
+        Object.create(null);
 
     relations
         // Filter out relations consisting of 2 sets.
@@ -423,7 +424,7 @@ function isSet(
 function isValidRelation(
     x: (VennPointOptions|VennRelationObject)
 ): boolean {
-    const map: Record<string, boolean> = {};
+    const map: Record<string, boolean> = Object.create(null);
 
     return (
         isObject(x) &&
@@ -464,7 +465,7 @@ function layoutGreedyVenn(
     relations: Array<VennRelationObject>
 ): Record<string, CircleObject> {
     const positionedSets: Array<VennRelationObject> = [],
-        mapOfIdToCircles: Record<string, CircleObject> = {};
+        mapOfIdToCircles: Record<string, CircleObject> = Object.create(null);
 
     // Define a circle for each set.
     relations
@@ -879,7 +880,7 @@ function processVennData(
             };
         }
         return mapOfIdToRelation;
-    }, {});
+    }, Object.create(null));
 
     validSets.reduce(function (
         combinations: Array<string>,


### PR DESCRIPTION
## Summary

- use prototype-free dictionaries for Venn validation, relation preprocessing, overlap/layout circle lookup, and final shape/label lookup
- accept public set names such as `toString` and `__proto__` without inherited-property collisions
- cover both named sets, their intersection relation, and all three generated shapes

## Breaking changes

None.

## Verification

- exact baseline focused QUnit returned no relations or shapes and failed both assertions
- fixed focused Venn QUnit passes
- source/test ESLint, full commit hook, `git diff --check`, and all 418 Node tests pass
- the hook reported no mapped browser tests for this sample, so its focused QUnit was run manually

Fixes #25275