### PR TITLE
bugfix/tick-label-default-position

### DIFF
--- a/samples/unit-tests/axis/labels-usehtml/demo.js
+++ b/samples/unit-tests/axis/labels-usehtml/demo.js
@@ -760,3 +760,29 @@ QUnit.test(
         );
     }
 );
+
+QUnit.test('HTML tick labels should have an initial position', function (
+    assert
+) {
+    const chart = Highcharts.chart('container', {
+            xAxis: {
+                labels: {
+                    useHTML: true
+                }
+            },
+            series: [{
+                data: [1]
+            }]
+        }),
+        axis = chart.xAxis[0],
+        tick = axis.ticks[axis.tickPositions[0]],
+        label = tick.createLabel('Test', axis.options.labels);
+
+    assert.deepEqual(
+        [label.attr('x'), label.attr('y')],
+        [0, 0],
+        'The label should not be initialized with NaN coordinates'
+    );
+
+    label.destroy();
+});

--- a/ts/Core/Axis/Tick.ts
+++ b/ts/Core/Axis/Tick.ts
@@ -458,8 +458,8 @@ class Tick {
                 renderer
                     .text(
                         str,
-                        xy?.x,
-                        xy?.y,
+                        xy?.x ?? 0,
+                        xy?.y ?? 0,
                         labelOptions.useHTML
                     )
                     .add(axis.labelGroup) :


### PR DESCRIPTION
Fixed #25277, invalid SVG transforms for rotated HTML axis labels.

## Summary
- Default missing tick label coordinates to zero.
- Prevent HTML tick labels from being initialized with `NaN` coordinates.
- Add regression coverage for HTML tick labels created without explicit coordinates.

## Test plan
- [x] `QUNIT_TEST_PATH=unit-tests/axis/labels-usehtml npx playwright test --project=setup-highcharts --project=qunit`
- [x] Confirmed the new test fails before the fix and passes with it.

Made with [Cursor](https://cursor.com)