### PR TITLE
Bugfix/25063-condemned-points-cause-errors-with-mapview

### DIFF
--- a/samples/unit-tests/pointer/hover/demo.js
+++ b/samples/unit-tests/pointer/hover/demo.js
@@ -305,3 +305,34 @@ QUnit.test('Polar chart without stickyTracking, #17359.', function (assert) {
         'The tooltip should not be displayed when not hovering over the series.'
     );
 });
+
+QUnit.test('Should not hover condemned points (#25063)', function (assert) {
+    const chart = Highcharts.chart('container', {
+            chart: {
+                animation: true
+            },
+            tooltip: {
+                enabled: true
+            },
+            series: [{
+                data: [2, 3, 4]
+            }]
+        }),
+        controller = new TestController(chart),
+        point = chart.series[0].points[1],
+        x = chart.plotLeft + point.plotX,
+        y = chart.plotTop + point.plotY;
+
+    chart.renderer.globalAnimation = {
+        duration: 100
+    };
+
+    point.destroy();
+    controller.moveTo(x, y);
+
+    assert.notStrictEqual(
+        chart.hoverPoint,
+        point,
+        'Condemned point is not hovered'
+    );
+});

--- a/samples/unit-tests/series/render/demo.js
+++ b/samples/unit-tests/series/render/demo.js
@@ -1,0 +1,47 @@
+QUnit.test(
+    'Should not draw destroyed condemned points',
+    function (assert) {
+        const done = assert.async(),
+            animDuration = 10,
+            chart = Highcharts.chart('container', {
+                chart: {
+                    animation: {
+                        duration: animDuration
+                    }
+                },
+                series: [{
+                    data: [1, 2]
+                }]
+            }),
+            series = chart.series[0];
+
+        chart.renderer.globalAnimation = {
+            duration: animDuration
+        };
+
+        series.removePoint(0, false);
+
+        setTimeout(function () {
+            let error;
+
+            try {
+                series.render();
+            } catch (e) {
+                error = e;
+            }
+
+            assert.ok(
+                !error,
+                'Chart renders without trying to draw the destroyed point'
+            );
+
+            assert.strictEqual(
+                series.condemnedPoints[0].graphic,
+                undefined,
+                'Do not add graphic during render to already destroyed point'
+            );
+
+            done();
+        }, animDuration * 2);
+    }
+);

--- a/ts/Core/Pointer.ts
+++ b/ts/Core/Pointer.ts
@@ -1793,8 +1793,9 @@ class Pointer {
                 chart.hoverPoint.firePointEvent('mouseOut');
             }
 
-            // Hover point may have been destroyed in the event handlers (#7127)
-            if (!hoverPoint.series) {
+            // Hover point may have been destroyed (#7127) or condemned (#25063)
+            // in the event handlers.
+            if (!hoverPoint.series || hoverPoint.condemned) {
                 return;
             }
 

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -3139,7 +3139,9 @@ class Series {
      */
     public drawPoints(points?: Array<Point>): void {
 
-        points ||= this.points.concat(this.condemnedPoints);
+        points ||= this.points.concat(
+            this.condemnedPoints.filter((p): boolean => !p.destroyed)
+        );
 
         const series = this,
             chart = series.chart,


### PR DESCRIPTION
Fixed #25063, prevented condemned points from being added to chart `hoverPoints` and attempts to draw already destroyed points.