### PR TITLE
bugfix/22682-a11y-navigation

### DIFF
--- a/samples/unit-tests/accessibility/accessibility-exporting/demo.js
+++ b/samples/unit-tests/accessibility/accessibility-exporting/demo.js
@@ -207,3 +207,57 @@ QUnit.test(
         }
     }
 );
+
+QUnit.test(
+    'Screen reader section inside a shadow root (#22682)',
+    function (assert) {
+        // The a11y module looks its elements up in the document, which does not
+        // cross a shadow boundary unless scoped to the chart's root node
+        const host = document.createElement('div');
+
+        document.body.appendChild(host);
+
+        const shadowRoot = host.attachShadow({ mode: 'open' }),
+            renderTo = document.createElement('div'),
+            description = document.createElement('div');
+
+        // The default linkedDescription selector expects the description to be
+        // the chart container's next sibling
+        description.className = 'highcharts-description';
+        description.textContent = 'Description of the chart.';
+        shadowRoot.appendChild(renderTo);
+        shadowRoot.appendChild(description);
+
+        const chart = Highcharts.chart(renderTo, {
+                series: [{
+                    data: [1, 2, 3]
+                }]
+            }),
+            tabindexOf = selector => {
+                const el = shadowRoot.querySelector(selector);
+                return el && el.getAttribute('tabindex');
+            };
+
+        assert.strictEqual(
+            tabindexOf('[id^="hc-linkto-highcharts-data-table-"]'),
+            '-1',
+            'The data table button should be removed from the tab sequence'
+        );
+
+        assert.strictEqual(
+            tabindexOf('[id^="highcharts-a11y-sonify-data-btn-"]'),
+            '-1',
+            'The play as sound button should be removed from the tab sequence'
+        );
+
+        assert.strictEqual(
+            chart.accessibility.components.infoRegions
+                .linkedDescriptionElement,
+            description,
+            'The linked description should resolve inside the shadow root'
+        );
+
+        chart.destroy();
+        host.remove();
+    }
+);

--- a/ts/Accessibility/Components/InfoRegionsComponent.ts
+++ b/ts/Accessibility/Components/InfoRegionsComponent.ts
@@ -55,6 +55,7 @@ const {
     addClass,
     getElement,
     getHeadingTagNameForElement,
+    getShadowRoot,
     stripHTMLTagsFromString,
     visuallyHideElement
 } = HU;
@@ -400,7 +401,12 @@ class InfoRegionsComponent extends AccessibilityComponent {
         }
 
         const query = format(linkedDescOption, this.chart),
-            queryMatch = doc.querySelectorAll(query);
+            shadowRoot = getShadowRoot(this.chart.renderTo),
+            shadowMatch = shadowRoot?.querySelectorAll(query),
+            // The description may also live outside the shadow root (#22682)
+            queryMatch = shadowMatch?.length ?
+                shadowMatch :
+                doc.querySelectorAll(query);
 
         if (queryMatch.length === 1) {
             return queryMatch[0] as any;
@@ -672,7 +678,7 @@ class InfoRegionsComponent extends AccessibilityComponent {
      */
     public getEndOfChartMarkerText(): string {
         const endMarkerId = `highcharts-end-of-chart-marker-${this.chart.index}`,
-            endMarker = getElement(endMarkerId);
+            endMarker = getElement(endMarkerId, this.chart.renderTo);
 
         if (endMarker) {
             return endMarker.outerHTML;
@@ -731,8 +737,10 @@ class InfoRegionsComponent extends AccessibilityComponent {
     public initSonifyButton(
         sonifyButtonId: string
     ): void {
-        const el = this.sonifyButton = getElement(sonifyButtonId);
         const chart = this.chart;
+        const el = this.sonifyButton = getElement(
+            sonifyButtonId, chart.renderTo
+        );
         const defaultHandler = (e: Event): void => {
             if (el) {
                 el.setAttribute('aria-hidden', 'true');
@@ -785,14 +793,16 @@ class InfoRegionsComponent extends AccessibilityComponent {
     public initDataTableButton(
         tableButtonId: string
     ): void {
-        const el = this.viewDataTableButton = getElement(tableButtonId),
-            chart = this.chart,
+        const chart = this.chart,
+            el = this.viewDataTableButton = getElement(
+                tableButtonId, chart.renderTo
+            ),
             tableId = tableButtonId.replace('hc-linkto-', '');
 
         if (el) {
             attr(el, {
                 tabindex: -1,
-                'aria-expanded': !!getElement(tableId)
+                'aria-expanded': !!getElement(tableId, chart.renderTo)
             });
 
             el.onclick = chart.options.accessibility

--- a/ts/Accessibility/KeyboardNavigation.ts
+++ b/ts/Accessibility/KeyboardNavigation.ts
@@ -195,7 +195,7 @@ class KeyboardNavigation {
      */
     public updateExitAnchor(): void {
         const endMarkerId = `highcharts-end-of-chart-marker-${this.chart.index}`,
-            endMarker = getElement(endMarkerId);
+            endMarker = getElement(endMarkerId, this.chart.renderTo);
 
         this.removeExitAnchor();
 

--- a/ts/Accessibility/Utils/HTMLUtilities.ts
+++ b/ts/Accessibility/Utils/HTMLUtilities.ts
@@ -183,13 +183,26 @@ function escapeStringForHTML(str: string): string {
 
 
 /**
- * Get an element by ID
+ * Get the shadow root the element lives in, if any. Lookups in the main
+ * document do not cross a shadow boundary. (#22682)
+ * @private
+ */
+function getShadowRoot(el?: DOMElementType): (ShadowRoot|undefined) {
+    const root = el?.getRootNode() as ShadowRoot|undefined;
+
+    return root?.host ? root : void 0;
+}
+
+
+/**
+ * Get an element by ID, from the reference element's shadow root if it has one.
  * @private
  */
 function getElement(
-    id: string
+    id: string,
+    referenceElement?: DOMElementType
 ): (DOMElementType|null) {
-    return doc.getElementById(id);
+    return (getShadowRoot(referenceElement) || doc).getElementById(id);
 }
 
 
@@ -402,6 +415,7 @@ const HTMLUtilities = {
     getElement,
     getFakeMouseEvent,
     getHeadingTagNameForElement,
+    getShadowRoot,
     removeChildNodes,
     removeClass,
     removeElement,


### PR DESCRIPTION
Fixed #22682, view as data table button was tabbable in shadow DOM.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209444979817493