### PR TITLE
tools/pin-remaining-firefox-versions

### DIFF
--- a/.github/scripts/disableFirefoxUpdates.js
+++ b/.github/scripts/disableFirefoxUpdates.js
@@ -1,0 +1,39 @@
+const {
+    accessSync,
+    constants,
+    mkdirSync,
+    statSync,
+    writeFileSync
+} = require('node:fs');
+const {
+    dirname,
+    join,
+    resolve
+} = require('node:path');
+
+const firefoxPath = process.env.FIREFOX_PATH;
+
+if (!firefoxPath) {
+    console.error('FIREFOX_PATH is required.');
+    process.exit(1);
+}
+
+const resolvedFirefoxPath = resolve(firefoxPath);
+
+try {
+    if (!statSync(resolvedFirefoxPath).isFile()) {
+        throw new Error();
+    }
+    accessSync(resolvedFirefoxPath, constants.X_OK);
+} catch {
+    console.error('FIREFOX_PATH must point to an executable file.');
+    process.exit(1);
+}
+
+const distributionPath = join(dirname(resolvedFirefoxPath), 'distribution');
+
+mkdirSync(distributionPath, { recursive: true });
+writeFileSync(
+    join(distributionPath, 'policies.json'),
+    '{ "policies": { "DisableAppUpdate": true } }\n'
+);

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -219,6 +219,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Use Firefox 153.0.4
+        id: nightly-firefox
+        uses: browser-actions/setup-firefox@0bc507ddf224827e3b1af68e014d5e42ab93e795 # v1
+        with:
+          firefox-version: '153.0.4'
+
+      - name: Disable Firefox updates
+        env:
+          FIREFOX_PATH: ${{ steps.nightly-firefox.outputs.firefox-path }}
+        run: node .github/scripts/disableFirefoxUpdates.js
+
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -22,6 +22,18 @@ jobs:
       BROWSER_COUNT: 2
     steps:
       - uses: actions/checkout@v6
+
+      - name: Use Firefox 153.0.4
+        id: release-firefox
+        uses: browser-actions/setup-firefox@0bc507ddf224827e3b1af68e014d5e42ab93e795 # v1
+        with:
+          firefox-version: '153.0.4'
+
+      - name: Disable Firefox updates
+        env:
+          FIREFOX_PATH: ${{ steps.release-firefox.outputs.firefox-path }}
+        run: node .github/scripts/disableFirefoxUpdates.js
+
       - uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'

--- a/.github/workflows/visual-compare-changed-samples.yml
+++ b/.github/workflows/visual-compare-changed-samples.yml
@@ -73,6 +73,19 @@ jobs:
           printf 'has_products=%s\n' "$has_products" >> "$GITHUB_OUTPUT"
           printf 'product_globs=%s\n' "$product_globs" >> "$GITHUB_OUTPUT"
 
+      - name: Use Firefox 153.0.4
+        if: ${{ steps.changed_samples.outputs.has_products == 'true' }}
+        id: changed-samples-firefox
+        uses: browser-actions/setup-firefox@0bc507ddf224827e3b1af68e014d5e42ab93e795 # v1
+        with:
+          firefox-version: '153.0.4'
+
+      - name: Disable Firefox updates
+        if: ${{ steps.changed_samples.outputs.has_products == 'true' }}
+        env:
+          FIREFOX_PATH: ${{ steps.changed-samples-firefox.outputs.firefox-path }}
+        run: node .github/scripts/disableFirefoxUpdates.js
+
       - name: Use Node.js lts/*
         if: ${{ steps.changed_samples.outputs.has_products == 'true' }}
         uses: actions/setup-node@v6

--- a/.github/workflows/visual-compare.yml
+++ b/.github/workflows/visual-compare.yml
@@ -144,11 +144,7 @@ jobs:
       - name: Disable Firefox updates
         env:
           FIREFOX_PATH: ${{ steps.reference-firefox.outputs.firefox-path }}
-        run: |
-          firefox_dir="$(dirname "$FIREFOX_PATH")"
-          mkdir -p "$firefox_dir/distribution"
-          printf '%s\n' '{ "policies": { "DisableAppUpdate": true } }' \
-            > "$firefox_dir/distribution/policies.json"
+        run: node .github/scripts/disableFirefoxUpdates.js
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6
@@ -182,11 +178,7 @@ jobs:
       - name: Disable Firefox updates
         env:
           FIREFOX_PATH: ${{ steps.candidate-firefox.outputs.firefox-path }}
-        run: |
-          firefox_dir="$(dirname "$FIREFOX_PATH")"
-          mkdir -p "$firefox_dir/distribution"
-          printf '%s\n' '{ "policies": { "DisableAppUpdate": true } }' \
-            > "$firefox_dir/distribution/policies.json"
+        run: node .github/scripts/disableFirefoxUpdates.js
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6


### PR DESCRIPTION
Follup-up from https://github.com/highcharts/highcharts/pull/25097

Note that `.github/workflows/visual-compare.yml` is expected to fail until the new script is on master