### PR TITLE
bugfix/tooltip-split-wrong-boxes

### DIFF
--- a/samples/unit-tests/tooltip/split/demo.js
+++ b/samples/unit-tests/tooltip/split/demo.js
@@ -384,6 +384,50 @@ QUnit.test('Split tooltip in floated container (#13943),', function (assert) {
 });
 
 QUnit.test(
+    'Split tooltip boxes are distributed per pane, not chart-wide',
+    function (assert) {
+        const chart = Highcharts.chart('container', {
+            xAxis: [
+                { width: '50%' },
+                { left: '50%', width: '50%' }
+            ],
+            tooltip: {
+                split: true
+            },
+            series: [
+                // Left pane: 3 points at the same value, so their boxes
+                // collide and distribute() has to spread them apart.
+                { xAxis: 0, data: [[0, 50]] },
+                { xAxis: 0, data: [[0, 50]] },
+                { xAxis: 0, data: [[0, 50]] },
+                // Right pane: 1 point at the same value as the left pane
+                // points, but in a separate pane, so it can't visually
+                // collide with them.
+                { xAxis: 1, data: [[0, 50]] }
+            ]
+        });
+
+        const rightPoint = chart.series[3].points[0],
+            leftPoints = chart.series.slice(0, 3).map(s => s.points[0]);
+
+        // Show the right pane's tooltip alone first, to get its natural,
+        // undistorted position.
+        chart.tooltip.refresh([rightPoint]);
+        const naturalY = chart.series[3].tt.attr('y');
+
+        // Show it again, now together with the crowded left pane.
+        chart.tooltip.refresh([...leftPoints, rightPoint]);
+
+        assert.strictEqual(
+            chart.series[3].tt.attr('y'),
+            naturalY,
+            'The right pane\'s tooltip should stay in place, unaffected ' +
+                'by the collisions in the unrelated left pane'
+        );
+    }
+);
+
+QUnit.test(
     'Split tooltip on flags, having noSharedTooltip flag',
     function (assert) {
         var chart = Highcharts.chart('container', {

--- a/samples/unit-tests/tooltip/split/demo.js
+++ b/samples/unit-tests/tooltip/split/demo.js
@@ -384,50 +384,6 @@ QUnit.test('Split tooltip in floated container (#13943),', function (assert) {
 });
 
 QUnit.test(
-    'Split tooltip boxes are distributed per pane, not chart-wide',
-    function (assert) {
-        const chart = Highcharts.chart('container', {
-            xAxis: [
-                { width: '50%' },
-                { left: '50%', width: '50%' }
-            ],
-            tooltip: {
-                split: true
-            },
-            series: [
-                // Left pane: 3 points at the same value, so their boxes
-                // collide and distribute() has to spread them apart.
-                { xAxis: 0, data: [[0, 50]] },
-                { xAxis: 0, data: [[0, 50]] },
-                { xAxis: 0, data: [[0, 50]] },
-                // Right pane: 1 point at the same value as the left pane
-                // points, but in a separate pane, so it can't visually
-                // collide with them.
-                { xAxis: 1, data: [[0, 50]] }
-            ]
-        });
-
-        const rightPoint = chart.series[3].points[0],
-            leftPoints = chart.series.slice(0, 3).map(s => s.points[0]);
-
-        // Show the right pane's tooltip alone first, to get its natural,
-        // undistorted position.
-        chart.tooltip.refresh([rightPoint]);
-        const naturalY = chart.series[3].tt.attr('y');
-
-        // Show it again, now together with the crowded left pane.
-        chart.tooltip.refresh([...leftPoints, rightPoint]);
-
-        assert.strictEqual(
-            chart.series[3].tt.attr('y'),
-            naturalY,
-            'The right pane\'s tooltip should stay in place, unaffected ' +
-                'by the collisions in the unrelated left pane'
-        );
-    }
-);
-
-QUnit.test(
     'Split tooltip on flags, having noSharedTooltip flag',
     function (assert) {
         var chart = Highcharts.chart('container', {
@@ -505,10 +461,7 @@ QUnit.test(
 QUnit.test('positioning', assert => {
     const axisHeight = 150;
     const data = [85, 82, 84, 87, 92];
-    const {
-        series: [series1, series2],
-        yAxis: [, /* yAxis1 */ yAxis2]
-    } = Highcharts.stockChart('container', {
+    const chart = Highcharts.stockChart('container', {
         chart: {
             height: axisHeight * 3
         },
@@ -542,6 +495,8 @@ QUnit.test('positioning', assert => {
             { data: data, yAxis: 1 }
         ]
     });
+    const [series1, series2] = chart.series;
+    const yAxis2 = chart.yAxis[1];
     const isInsideAxis = ({ pos, len }, { anchorY }) =>
         pos <= anchorY && anchorY <= pos + len;
 
@@ -559,6 +514,37 @@ QUnit.test('positioning', assert => {
         isInsideAxis(yAxis2, tooltip),
         'Should have Series 2 tooltip anchorY aligned within yAxis when ' +
         'point is inside plot area'
+    );
+
+    // Add a 2nd xAxis pane with one series colliding with series1 and one
+    // lone series, to check boxes are distributed per pane, not chart-wide.
+    chart.update({
+        xAxis: [
+            { width: '50%' },
+            { left: '50%', width: '50%' }
+        ],
+        series: [
+            { data: [[3, 87]], yAxis: 0 },
+            { data: [[3, 87]], yAxis: 1 },
+            { xAxis: 0, data: [[3, 87]] },
+            { xAxis: 1, data: [[3, 87]] }
+        ]
+    }, true, true);
+    const leftPoint = chart.series[2].points[0];
+    const rightPoint = chart.series[3].points[0];
+
+    // Show the right pane's tooltip alone first, to get its natural position.
+    chart.tooltip.refresh([rightPoint]);
+    const naturalY = chart.series[3].tt.attr('y');
+
+    // Show it again, now together with the crowded left pane.
+    chart.tooltip.refresh([series1.points[0], leftPoint, rightPoint]);
+
+    assert.strictEqual(
+        chart.series[3].tt.attr('y'),
+        naturalY,
+        'The right pane\'s tooltip should stay in place, unaffected by ' +
+            'the collisions in the unrelated crowded left pane'
     );
 });
 

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -59,6 +59,7 @@ import {
     merge,
     pushUnique,
     splat,
+    stableSort,
     syncTimeout
 } from '../Shared/Utilities.js';
 
@@ -1529,6 +1530,8 @@ class Tooltip {
             labels = [false, labels];
         }
         // Create the individual labels for header and points, ignore footer
+        // Boxes grouped by xAxis (pane), for per-pane distribute() below.
+        const paneGroups = new Map<number, Array<BoxObject>>();
         let boxes = labels.slice(0, points.length + 1).reduce(function (
             boxes: Array<BoxObject>,
             str: (boolean|string),
@@ -1576,21 +1579,30 @@ class Tooltip {
                             point,
                             tooltip,
                             [anchorX, anchorY]
-                        );
+                        ),
+                        box: BoxObject = {
+                            // 0-align to the top, 1-align to the bottom
+                            align: hasFixedPosition ? 0 : void 0,
+                            anchorX,
+                            anchorY,
+                            boxWidth,
+                            point,
+                            rank: (boxPosition as any).rank ??
+                                (isHeader ? 1 : 0),
+                            size,
+                            target: boxPosition.y,
+                            tt,
+                            x: boxPosition.x
+                        },
+                        // Bucket by pane (xAxis) as boxes are created, so
+                        // renderSplit doesn't need a second pass over
+                        // `boxes` just to group them before distribute().
+                        key = point.series?.xAxis?.index || 0,
+                        group = paneGroups.get(key) || [];
 
-                    boxes.push({
-                        // 0-align to the top, 1-align to the bottom
-                        align: hasFixedPosition ? 0 : void 0,
-                        anchorX,
-                        anchorY,
-                        boxWidth,
-                        point,
-                        rank: (boxPosition as any).rank ?? (isHeader ? 1 : 0),
-                        size,
-                        target: boxPosition.y,
-                        tt,
-                        x: boxPosition.x
-                    });
+                    boxes.push(box);
+                    group.push(box);
+                    paneGroups.set(key, group);
                 } else {
                     // Hide tooltips which anchorY is outside the visible plot
                     // area
@@ -1639,7 +1651,12 @@ class Tooltip {
         tooltip.cleanSplit();
 
         // Distribute and put in place
-        distribute(boxes, adjustedPlotHeight);
+        paneGroups.forEach((group): void => {
+            distribute(group, adjustedPlotHeight);
+        });
+        // Restore the global target order distribute() used to produce, now
+        // that it only sorts within each pane.
+        stableSort(boxes, (a, b): number => a.target - b.target);
         const boxExtremes = {
             left: chartLeft,
             right: chartLeft

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -1530,8 +1530,8 @@ class Tooltip {
             labels = [false, labels];
         }
         // Create the individual labels for header and points, ignore footer
-        // Boxes grouped by xAxis (pane), for per-pane distribute() below.
-        const paneGroups = new Map<number, Array<BoxObject>>();
+        // Boxes grouped by pane position, for per-pane distribute() below.
+        const paneGroups = new Map<string, Array<BoxObject>>();
         let boxes = labels.slice(0, points.length + 1).reduce(function (
             boxes: Array<BoxObject>,
             str: (boolean|string),
@@ -1597,7 +1597,8 @@ class Tooltip {
                         // Bucket by pane (xAxis) as boxes are created, so
                         // renderSplit doesn't need a second pass over
                         // `boxes` just to group them before distribute().
-                        key = point.series?.xAxis?.index || 0,
+                        xAxis = point.series?.xAxis,
+                        key = xAxis ? `${xAxis.pos}+${xAxis.len}` : '0',
                         group = paneGroups.get(key) || [];
 
                     boxes.push(box);
@@ -1651,12 +1652,16 @@ class Tooltip {
         tooltip.cleanSplit();
 
         // Distribute and put in place
-        paneGroups.forEach((group): void => {
-            distribute(group, adjustedPlotHeight);
-        });
-        // Restore the global target order distribute() used to produce, now
-        // that it only sorts within each pane.
-        stableSort(boxes, (a, b): number => a.target - b.target);
+        if (paneGroups.size <= 1) {
+            // Single pane: sorts `boxes` in place, no extra work needed.
+            distribute(boxes, adjustedPlotHeight);
+        } else {
+            paneGroups.forEach((group): void => {
+                distribute(group, adjustedPlotHeight);
+            });
+            // Restore target order on boxes` too, needed by boxExtremes below.
+            stableSort(boxes, (a, b): number => a.target - b.target);
+        }
         const boxExtremes = {
             left: chartLeft,
             right: chartLeft


### PR DESCRIPTION
Fixed wrong `tooltip.split` box positions in multi-pane charts, pushed out of place by boxes in an unrelated pane.

Fix related to the multi-security grid demo: https://github.com/highcharts/highcharts/pull/24886