### PR TITLE
bugfix/25299-a11y-mock-graphic-not-cleaned-on-setdata

### DIFF
--- a/samples/unit-tests/accessibility/null-points/demo.js
+++ b/samples/unit-tests/accessibility/null-points/demo.js
@@ -44,7 +44,11 @@ QUnit.test('Dynamic null points', function (assert) {
     const chart = Highcharts.chart('container', {
             series: [
                 {
-                    data: [1, null, null, 2, 3, 4, 5, 6]
+                    // Explicit x, so that setData below can match the points
+                    data: [
+                        [0, 1], [1, null], [2, null], [3, 2],
+                        [4, 3], [5, 4], [6, 5], [7, 6]
+                    ]
                 }
             ]
         }),
@@ -87,5 +91,18 @@ QUnit.test('Dynamic null points', function (assert) {
         nullPoint.graphic.attr('y'),
         'NaN',
         'Point graphic y shouldn\'t be NaN.'
+    );
+
+    series.setData([[0, 1], [1, 3], [2, 4]]);
+
+    assert.notOk(
+        nullPoint.hasMockGraphic,
+        'Point restored through setData should not keep the dummy marker, ' +
+        '#25299.'
+    );
+    assert.strictEqual(
+        nullPoint.graphic.element.tagName,
+        'path',
+        'Point restored through setData should have a marker element, #25299.'
     );
 });

--- a/samples/unit-tests/accessibility/null-points/demo.js
+++ b/samples/unit-tests/accessibility/null-points/demo.js
@@ -85,6 +85,16 @@ QUnit.test('Dynamic null points', function (assert) {
         'point.'
     );
 
+    // Without a redraw in between, so that the marker is not re-created
+    nullPoint.update({
+        y: null
+    }, false);
+
+    assert.ok(
+        nullPoint.graphic,
+        'Updating a null point to null should keep the dummy marker, #12718.'
+    );
+
     nullPoint.select(true, true);
 
     assert.notStrictEqual(

--- a/ts/Accessibility/Components/SeriesComponent/SeriesComponent.ts
+++ b/ts/Accessibility/Components/SeriesComponent/SeriesComponent.ts
@@ -34,7 +34,10 @@ import ForcedMarkers from './ForcedMarkers.js';
 import NewDataAnnouncer from './NewDataAnnouncer.js';
 import Series from '../../../Core/Series/Series.js';
 import SeriesDescriber from './SeriesDescriber.js';
-const { describeSeries } = SeriesDescriber;
+const {
+    compose: composeSeriesDescriber,
+    describeSeries
+} = SeriesDescriber;
 import SeriesKeyboardNavigation from './SeriesKeyboardNavigation.js';
 
 
@@ -71,6 +74,7 @@ class SeriesComponent extends AccessibilityComponent {
     ): void {
         NewDataAnnouncer.compose(SeriesClass);
         ForcedMarkers.compose(SeriesClass);
+        composeSeriesDescriber(PointClass);
         SeriesKeyboardNavigation.compose(ChartClass, PointClass, SeriesClass);
     }
 

--- a/ts/Accessibility/Components/SeriesComponent/SeriesDescriber.ts
+++ b/ts/Accessibility/Components/SeriesComponent/SeriesDescriber.ts
@@ -44,6 +44,8 @@ const {
     format,
     numberFormat
 } = F;
+import H from '../../../Core/Globals.js';
+const { composed } = H;
 import HTMLUtilities from '../../Utils/HTMLUtilities.js';
 const {
     reverseChildNodes,
@@ -53,7 +55,9 @@ import {
     defined,
     find,
     isString,
-    isNumber
+    isNumber,
+    pushUnique,
+    wrap
 } from '../../../Shared/Utilities.js';
 
 
@@ -76,6 +80,41 @@ declare module '../../../Core/Series/PointBase' {
  *  Functions
  *
  * */
+
+/**
+ * @private
+ */
+function compose(
+    PointClass: typeof Point
+): void {
+
+    if (pushUnique(composed, 'A11y.SD')) {
+        wrap(PointClass.prototype, 'applyOptions', pointApplyOptions);
+    }
+
+}
+
+
+/**
+ * Discard the mock graphic once the point is no longer null, so that the
+ * series can draw a real marker for it, #25299.
+ * @private
+ */
+function pointApplyOptions(
+    this: Point,
+    proceed: Point['applyOptions'],
+    ...args: Parameters<Point['applyOptions']>
+): Point {
+    const point = proceed.apply(this, args);
+
+    if (point.hasMockGraphic && !point.isNull) {
+        point.graphic = point.graphic?.destroy();
+        delete point.hasMockGraphic;
+    }
+
+    return point;
+}
+
 
 /**
  * @private
@@ -754,6 +793,7 @@ function describeSeries(
  * */
 
 const SeriesDescriber = {
+    compose,
     defaultPointDescriptionFormatter,
     defaultSeriesDescriptionFormatter,
     describeSeries

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -645,6 +645,12 @@ class Point {
 
             point.isNull = point.isValid && !point.isValid();
 
+            // Discard the a11y mock graphic when no longer null (#25299)
+            if (point.hasMockGraphic && !point.isNull) {
+                point.graphic = point.graphic?.destroy();
+                delete point.hasMockGraphic;
+            }
+
             // #9233, #10874
             point.formatPrefix = point.isNull ? 'null' : 'point';
         }

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -1318,8 +1318,6 @@ class Point {
                 point.graphic = graphic.destroy();
             }
 
-            const index = point.index;
-
             if (isObject(options, true)) {
                 // Destroy so we can get new elements
                 if (graphic?.element) {
@@ -1336,7 +1334,8 @@ class Point {
                 }
             }
 
-            const pointOptions = point.optionsToObject(options) as AnyRecord;
+            const index = point.index,
+                pointOptions = point.optionsToObject(options) as AnyRecord;
 
             if (!series.hasProcessedDataTable) {
                 // Record changes in the data table (#24451)

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -645,12 +645,6 @@ class Point {
 
             point.isNull = point.isValid && !point.isValid();
 
-            // Discard the a11y mock graphic when no longer null (#25299)
-            if (point.hasMockGraphic && !point.isNull) {
-                point.graphic = point.graphic?.destroy();
-                delete point.hasMockGraphic;
-            }
-
             // #9233, #10874
             point.formatPrefix = point.isNull ? 'null' : 'point';
         }
@@ -1318,17 +1312,13 @@ class Point {
 
             point.applyOptions(options);
 
-            // Update visuals, #4146
-            // Handle mock graphic elements for a11y, #12718
-            const hasMockGraphic = graphic && point.hasMockGraphic,
-                index = point.index;
-            const shouldDestroyGraphic = point.y === null ?
-                !hasMockGraphic :
-                hasMockGraphic;
-            if (graphic && shouldDestroyGraphic) {
+            // Update visuals, #4146. The a11y mock graphic is exempt, it is
+            // maintained by the accessibility module, #12718.
+            if (graphic && point.y === null && !point.hasMockGraphic) {
                 point.graphic = graphic.destroy();
-                delete point.hasMockGraphic;
             }
+
+            const index = point.index;
 
             if (isObject(options, true)) {
                 // Destroy so we can get new elements


### PR DESCRIPTION
Fixed #25299, points restored from null stayed invisible on `setData`.