### PR TITLE
bugfix/25279-dumbbell-low-marker

### DIFF
--- a/samples/unit-tests/accessibility/forced-markers/demo.js
+++ b/samples/unit-tests/accessibility/forced-markers/demo.js
@@ -237,6 +237,21 @@ QUnit.test('Dynamic markers on update', function (assert) {
     assert.strictEqual(hasVisibleMarker(pointA), true, 'Series marker visible');
     assert.strictEqual(hasMarker(pointB), true, 'Point marker exists');
     assert.strictEqual(hasVisibleMarker(pointB), false, 'Point marker hidden');
+
+    series.update({
+        marker: {
+            enabled: false
+        },
+        lowMarker: {
+            enabled: true
+        }
+    });
+
+    assert.strictEqual(
+        pointA.graphics[0].opacity !== 0,
+        true,
+        'Explicitly enabled lowMarker should be visible (#25279).'
+    );
 });
 
 // #16624, temporarily skipped due to #23783

--- a/samples/unit-tests/accessibility/forced-markers/demo.js
+++ b/samples/unit-tests/accessibility/forced-markers/demo.js
@@ -248,10 +248,11 @@ QUnit.test('Dynamic markers on update', function (assert) {
     });
 
     assert.strictEqual(
-        pointA.graphics[0].opacity !== 0,
+        hasVisibleMarker(pointA),
         true,
         'Explicitly enabled lowMarker should be visible (#25279).'
     );
+
 });
 
 // #16624, temporarily skipped due to #23783

--- a/ts/Accessibility/Components/SeriesComponent/ForcedMarkers.ts
+++ b/ts/Accessibility/Components/SeriesComponent/ForcedMarkers.ts
@@ -110,6 +110,12 @@ namespace ForcedMarkersComposition {
                 states: {
                     normal: {
                         opacity: 0
+                    },
+                    hover: {
+                        opacity: 0
+                    },
+                    select: {
+                        opacity: 0
                     }
                 }
             }

--- a/ts/Accessibility/Components/SeriesComponent/ForcedMarkers.ts
+++ b/ts/Accessibility/Components/SeriesComponent/ForcedMarkers.ts
@@ -126,14 +126,14 @@ namespace ForcedMarkersComposition {
         const lowMarker = (series.options as any).lowMarker;
 
         if (
-            lowMarker?.enabled === true &&
+            lowMarker && lowMarker?.enabled !== false &&
             typeof lowMarker.states?.normal?.opacity !== 'number'
         ) {
             merge(true, lowMarker, {
                 states: {
                     normal: {
                         opacity: series.resetA11yMarkerOptions?.states
-                            ?.normal?.opacity ?? 1
+                            ?.normal?.opacity
                     }
                 }
             });

--- a/ts/Accessibility/Components/SeriesComponent/ForcedMarkers.ts
+++ b/ts/Accessibility/Components/SeriesComponent/ForcedMarkers.ts
@@ -110,16 +110,34 @@ namespace ForcedMarkersComposition {
                 states: {
                     normal: {
                         opacity: 0
-                    },
-                    hover: {
-                        opacity: 0
-                    },
-                    select: {
-                        opacity: 0
                     }
                 }
             }
         });
+    }
+
+
+    /**
+     * The normal state opacity of lowMarker on Arearange-like series is
+     * handled if zero opacity was forced on the main marker(#25279).
+     * @private
+     */
+    function restoreLowMarkerOpacity(series: SeriesComposition): void {
+        const lowMarker = (series.options as any).lowMarker;
+
+        if (
+            lowMarker?.enabled === true &&
+            typeof lowMarker.states?.normal?.opacity !== 'number'
+        ) {
+            merge(true, lowMarker, {
+                states: {
+                    normal: {
+                        opacity: series.resetA11yMarkerOptions?.states
+                            ?.normal?.opacity ?? 1
+                    }
+                }
+            });
+        }
     }
 
 
@@ -208,6 +226,23 @@ namespace ForcedMarkersComposition {
                 ]('highcharts-a11y-markers-hidden');
             }
 
+            // Unforce lowMarker zero opacity if enabled
+            // in styled mode (#25279).
+            const lowMarker = (series.options as any).lowMarker;
+            if (lowMarker) {
+                const lowMarkerVisible = !!series.a11yMarkersForced &&
+                    lowMarker.enabled === true;
+
+                series.points.forEach((point): void => {
+                    const lowGraphic = point.graphics?.[0];
+                    if (lowGraphic) {
+                        lowGraphic[
+                            lowMarkerVisible ? 'addClass' : 'removeClass'
+                        ]('highcharts-a11y-marker-visible');
+                    }
+                });
+            }
+
             // Do we need to handle individual points?
             if (hasIndividualPointMarkerOptions(series)) {
                 series.points.forEach((point): void => {
@@ -256,6 +291,7 @@ namespace ForcedMarkersComposition {
             if (options.marker?.enabled === false) {
                 series.a11yMarkersForced = true;
                 forceZeroOpacityMarkerOptions(series.options);
+                restoreLowMarkerOpacity(series);
             }
 
             if (hasIndividualPointMarkerOptions(series)) {

--- a/ts/Series/AreaRange/AreaRangeSeries.ts
+++ b/ts/Series/AreaRange/AreaRangeSeries.ts
@@ -525,6 +525,33 @@ class AreaRangeSeries extends AreaSeries {
 
             series.options.marker = merge(marker, lowMarker);
 
+            // A11y forces marker opacity to 0 when disabled.
+            // That force should not affect the `lowMarker`
+            // unless it, too, is disabled (#25279).
+            const a11ySeries = series as unknown as {
+                a11yMarkersForced?: boolean;
+                resetA11yMarkerOptions?: PointMarkerOptions;
+            };
+
+            if (a11ySeries.a11yMarkersForced && lowMarker.enabled === true) {
+                const resetStates = a11ySeries.resetA11yMarkerOptions
+                    ?.states;
+
+                series.options.marker = merge(series.options.marker, {
+                    states: {
+                        normal: {
+                            opacity: resetStates?.normal?.opacity ?? 1
+                        },
+                        hover: {
+                            opacity: resetStates?.hover?.opacity ?? 1
+                        },
+                        select: {
+                            opacity: resetStates?.select?.opacity ?? 1
+                        }
+                    }
+                });
+            }
+
             if (lowMarker.symbol) {
                 series.symbol = lowMarker.symbol;
             }

--- a/ts/Series/AreaRange/AreaRangeSeries.ts
+++ b/ts/Series/AreaRange/AreaRangeSeries.ts
@@ -525,33 +525,6 @@ class AreaRangeSeries extends AreaSeries {
 
             series.options.marker = merge(marker, lowMarker);
 
-            // A11y forces marker opacity to 0 when disabled.
-            // That force should not affect the `lowMarker`
-            // unless it, too, is disabled (#25279).
-            const a11ySeries = series as unknown as {
-                a11yMarkersForced?: boolean;
-                resetA11yMarkerOptions?: PointMarkerOptions;
-            };
-
-            if (a11ySeries.a11yMarkersForced && lowMarker.enabled === true) {
-                const resetStates = a11ySeries.resetA11yMarkerOptions
-                    ?.states;
-
-                series.options.marker = merge(series.options.marker, {
-                    states: {
-                        normal: {
-                            opacity: resetStates?.normal?.opacity ?? 1
-                        },
-                        hover: {
-                            opacity: resetStates?.hover?.opacity ?? 1
-                        },
-                        select: {
-                            opacity: resetStates?.select?.opacity ?? 1
-                        }
-                    }
-                });
-            }
-
             if (lowMarker.symbol) {
                 series.symbol = lowMarker.symbol;
             }


### PR DESCRIPTION
Fixed #25279, explicitly enabled `lowMarker` was forced invisible by `marker` and the accessibility module.