### PR TITLE
Added boostShape for area and arearange (#24688)

### DIFF
--- a/docs/advanced-chart-features/boost-module.md
+++ b/docs/advanced-chart-features/boost-module.md
@@ -91,7 +91,7 @@ The Boost module contains a WebGL renderer that replaces parts of the SVG render
 
 * The largest caveat is that rectangles for column and bar charts are always drawn as a single 1 pixel wide line. This will likely not be the desired outcome when zoomed in to the level where each column/bar is visible as an individual entity. Thus, column and bar charts are more suited to series-level boosting.
 * The area of areaspline series is drawn as 1px columns. This works well with the intended way of using the Boost module, which is that it kicks in when the number of data points crosses the `boostThreshold`. But if the boost threshold is set too low, an areaspline chart will look like a column chart. This is a limitation that we are considering fixing. In addition to this, the _line_ itself is not rendered in areaspline series.
-* Area and arearange series can be rendered as filled areas by setting `boostShape` to `triangles`. Leaving the shape at the default `lines` keeps the legacy 1px stick rendering.
+* Area, areaspline and arearange series can be rendered as filled areas by setting `boostShape` to `triangles`. Leaving the shape at the default `lines` keeps the legacy 1px stick rendering.
 * Marker shapes, apart from circles, are not supported.
 * Dash style for lines is not supported.
 * Stacking, and negative colors are not supported.

--- a/docs/advanced-chart-features/boost-module.md
+++ b/docs/advanced-chart-features/boost-module.md
@@ -90,7 +90,8 @@ Caveats
 The Boost module contains a WebGL renderer that replaces parts of the SVG renderer. Additionally, it bypasses and simplifies some of the resource-hungry aspects of handling big data. As such, certain features are not available for boosted charts. Most of these features deal with interactivity, such as animation support. But there are a few that relate to visuals as well.
 
 * The largest caveat is that rectangles for column and bar charts are always drawn as a single 1 pixel wide line. This will likely not be the desired outcome when zoomed in to the level where each column/bar is visible as an individual entity. Thus, column and bar charts are more suited to series-level boosting.
-* The area of area and areaspline series are drawn as 1px columns. This works well with the intended way of using the Boost module, which is that it kicks in when the number of data points crosses the `boostThreshold`. But if the boost threshold is set too low, an area and areaspline charts will look like a column chart. This is a limitation that we are considering fixing. In addition to this, the _line_ itself is not rendered in area and areaspline series.
+* The area of areaspline series is drawn as 1px columns. This works well with the intended way of using the Boost module, which is that it kicks in when the number of data points crosses the `boostThreshold`. But if the boost threshold is set too low, an areaspline chart will look like a column chart. This is a limitation that we are considering fixing. In addition to this, the _line_ itself is not rendered in areaspline series.
+* Area and arearange series can be rendered as filled areas by setting `boostShape` to `triangles`. Leaving the shape at the default `lines` keeps the legacy 1px stick rendering.
 * Marker shapes, apart from circles, are not supported.
 * Dash style for lines is not supported.
 * Stacking, and negative colors are not supported.

--- a/tests/highcharts/boost/boost.spec.ts
+++ b/tests/highcharts/boost/boost.spec.ts
@@ -1,8 +1,88 @@
+import type { Page } from '@playwright/test';
+
 import { test, expect, createChart } from '~/fixtures.ts';
 
 // Equivalent of test/typescript-karma/masters/modules/boost.test.js
 
 const boostModules = { modules: ['modules/boost.src.js'] };
+
+async function boostedAreaSampleHasContent(
+    page: Page,
+    seriesType: 'area' | 'arearange',
+    boostShape: 'lines' | 'triangles'
+): Promise<boolean> {
+    const data = Array.from({ length: 24 }, (_, i) => {
+        if (seriesType === 'arearange') {
+            const low = 20 + Math.sin(i / 8) * 4;
+
+            return [i * 25, low, low + 18];
+        }
+
+        return [
+            i * 27 + 10,
+            70 + Math.sin(i / 8) * 8
+        ];
+    });
+
+    const chart = await createChart(
+        page,
+        {
+            boost: {
+                useGPUTranslations: true,
+                seriesThreshold: 1
+            },
+            chart: {
+                animation: false
+            },
+            yAxis: {
+                min: 0,
+                max: 100
+            },
+            series: [{
+                type: seriesType,
+                boostShape,
+                data,
+                boostThreshold: 1
+            }]
+        },
+        {
+            ...boostModules,
+            css: '#container { width: 600px; height: 400px; }'
+        }
+    );
+
+    return chart.evaluate((c, sampleValue) => {
+        const canvas = (c as any).boost?.canvas;
+        if (!canvas) {
+            return false;
+        }
+
+        const tmp = document.createElement('canvas');
+        tmp.width = canvas.width;
+        tmp.height = canvas.height;
+
+        const ctx = tmp.getContext('2d');
+        if (!ctx) {
+            return false;
+        }
+
+        ctx.drawImage(canvas, 0, 0);
+
+        const sampleX = Math.floor(c.plotLeft + c.plotWidth * 0.5);
+        const sampleY = Math.floor(
+            c.plotTop + c.yAxis[0].toPixels(sampleValue, true)
+        );
+        const sample = ctx.getImageData(sampleX - 4, sampleY - 4, 8, 8);
+
+        for (let i = 3; i < sample.data.length; i += 4) {
+            if (sample.data[i] > 10) {
+                return true;
+            }
+        }
+
+        return false;
+    }, seriesType === 'arearange' ? 29 : 50);
+}
 
 test.describe('Boost Module', () => {
     test('Highcharts boost composition', async ({ page }) => {
@@ -146,5 +226,65 @@ test.describe('Boost Module', () => {
             result.hasContentInBottomRight,
             'Boost should render content in bottom-right (full chart), not only top-left quarter'
         ).toBe(true);
+    });
+
+    test('Boosted arearange renders a filled band in triangles mode', async ({
+        page
+    }) => {
+        const hasContent = await boostedAreaSampleHasContent(
+            page,
+            'arearange',
+            'triangles'
+        );
+
+        expect(
+            hasContent,
+            'Boosted arearange should fill the band in triangles mode'
+        ).toBe(true);
+    });
+
+    test('Boosted arearange keeps the center empty in lines mode', async ({
+        page
+    }) => {
+        const hasContent = await boostedAreaSampleHasContent(
+            page,
+            'arearange',
+            'lines'
+        );
+
+        expect(
+            hasContent,
+            'Boosted arearange in lines mode should not fill the band center'
+        ).toBe(false);
+    });
+
+    test('Boosted area renders a filled band in triangles mode', async ({
+        page
+    }) => {
+        const hasContent = await boostedAreaSampleHasContent(
+            page,
+            'area',
+            'triangles'
+        );
+
+        expect(
+            hasContent,
+            'Boosted area should fill the center in triangles mode'
+        ).toBe(true);
+    });
+
+    test('Boosted area keeps the center empty in lines mode', async ({
+        page
+    }) => {
+        const hasContent = await boostedAreaSampleHasContent(
+            page,
+            'area',
+            'lines'
+        );
+
+        expect(
+            hasContent,
+            'Boosted area should not fill the center in lines mode'
+        ).toBe(false);
     });
 });

--- a/tests/highcharts/boost/boost.spec.ts
+++ b/tests/highcharts/boost/boost.spec.ts
@@ -8,7 +8,7 @@ const boostModules = { modules: ['modules/boost.src.js'] };
 
 async function boostedAreaSampleHasContent(
     page: Page,
-    seriesType: 'area' | 'arearange',
+    seriesType: 'area' | 'areaspline' | 'arearange',
     boostShape: 'lines' | 'triangles'
 ): Promise<boolean> {
     const data = Array.from({ length: 24 }, (_, i) => {
@@ -285,6 +285,36 @@ test.describe('Boost Module', () => {
         expect(
             hasContent,
             'Boosted area should not fill the center in lines mode'
+        ).toBe(false);
+    });
+
+    test('Boosted areaspline renders a filled band in triangles mode', async ({
+        page
+    }) => {
+        const hasContent = await boostedAreaSampleHasContent(
+            page,
+            'areaspline',
+            'triangles'
+        );
+
+        expect(
+            hasContent,
+            'Boosted areaspline should fill the center in triangles mode'
+        ).toBe(true);
+    });
+
+    test('Boosted areaspline keeps the center empty in lines mode', async ({
+        page
+    }) => {
+        const hasContent = await boostedAreaSampleHasContent(
+            page,
+            'areaspline',
+            'lines'
+        );
+
+        expect(
+            hasContent,
+            'Boosted areaspline should not fill the center in lines mode'
         ).toBe(false);
     });
 });

--- a/tests/highcharts/boost/boost.spec.ts
+++ b/tests/highcharts/boost/boost.spec.ts
@@ -5,11 +5,15 @@ import { test, expect, createChart } from '~/fixtures.ts';
 // Equivalent of test/typescript-karma/masters/modules/boost.test.js
 
 const boostModules = { modules: ['modules/boost.src.js'] };
+const boostMoreModules = {
+    modules: ['highcharts-more.src.js', ...boostModules.modules]
+};
 
 async function boostedAreaSampleHasContent(
     page: Page,
     seriesType: 'area' | 'areaspline' | 'arearange',
-    boostShape: 'lines' | 'triangles'
+    boostShape: 'lines' | 'triangles',
+    moduleConfig = boostModules
 ): Promise<boolean> {
     const data = Array.from({ length: 24 }, (_, i) => {
         if (seriesType === 'arearange') {
@@ -46,7 +50,7 @@ async function boostedAreaSampleHasContent(
             }]
         },
         {
-            ...boostModules,
+            ...moduleConfig,
             css: '#container { width: 600px; height: 400px; }'
         }
     );
@@ -234,7 +238,8 @@ test.describe('Boost Module', () => {
         const hasContent = await boostedAreaSampleHasContent(
             page,
             'arearange',
-            'triangles'
+            'triangles',
+            boostMoreModules
         );
 
         expect(
@@ -249,7 +254,8 @@ test.describe('Boost Module', () => {
         const hasContent = await boostedAreaSampleHasContent(
             page,
             'arearange',
-            'lines'
+            'lines',
+            boostMoreModules
         );
 
         expect(

--- a/ts/Extensions/Boost/Boost.ts
+++ b/ts/Extensions/Boost/Boost.ts
@@ -490,4 +490,17 @@ export default Boost;
  * @apioption  plotOptions.series.boostBlending
  */
 
+/**
+ * Sets the shape used when drawing boosted area and arearange series.
+ *
+ * By default, these series are drawn as one pixel wide lines. Set this option
+ * to `triangles` to draw the boosted area as a filled surface.
+ *
+ * @type       {string}
+ * @default    lines
+ * @validvalue ["lines", "triangles"]
+ * @requires   modules/boost
+ * @apioption  plotOptions.series.boostShape
+ */
+
 ''; // Adds doclets above to transpiled file

--- a/ts/Extensions/Boost/BoostOptions.ts
+++ b/ts/Extensions/Boost/BoostOptions.ts
@@ -17,6 +17,7 @@
 
 
 export type BoostBlendingValue = ('add'|'darken'|'multiply');
+export type BoostShapeValue = ('lines'|'triangles');
 
 export interface BoostDebugOptions {
     /**
@@ -281,6 +282,16 @@ declare module '../../Core/Series/SeriesOptions' {
          * @requires   modules/boost
          */
         boostBlending?: BoostBlendingValue;
+
+        /**
+         * Sets the shape used when drawing boosted area and arearange series.
+         *
+         * By default, these series are drawn as one pixel wide lines. Set this
+         * option to `triangles` to draw the boosted area as a filled surface.
+         *
+         * @requires modules/boost
+         */
+        boostShape?: BoostShapeValue;
 
         /**
          * Set the point threshold for when a series should enter boost mode.

--- a/ts/Extensions/Boost/WGLRenderer.ts
+++ b/ts/Extensions/Boost/WGLRenderer.ts
@@ -274,6 +274,7 @@ class WGLRenderer {
                 s *= 6;
             } else if (
                 series.type === 'area' ||
+                series.type === 'areaspline' ||
                 series.type === 'arearange'
             ) {
                 s *= drawMode === 'TRIANGLES' ? 6 : 2;
@@ -423,6 +424,7 @@ class WGLRenderer {
     private static seriesDrawMode(series: Series): WGLDrawModeValue {
         if (
             series.type === 'area' ||
+            series.type === 'areaspline' ||
             series.type === 'arearange'
         ) {
             const boostShape = series.options.boostShape as (
@@ -503,6 +505,7 @@ class WGLRenderer {
             colors = chart.options.colors || [],
             isBandSeries = (
                 series.type === 'area' ||
+                series.type === 'areaspline' ||
                 series.type === 'arearange'
             ),
             drawAsBand = isBandSeries && inst.drawMode === 'TRIANGLES',
@@ -1016,7 +1019,11 @@ class WGLRenderer {
                     yAxis.logarithmic
                 ) {
                     low = Math.max(
-                        (typeof threshold !== 'undefined' ? threshold as number : yMin as number),
+                        (
+                            typeof threshold !== 'undefined' ?
+                                threshold as number :
+                                yMin as number
+                        ),
                         yMin as number
                     );
                 }

--- a/ts/Extensions/Boost/WGLRenderer.ts
+++ b/ts/Extensions/Boost/WGLRenderer.ts
@@ -62,6 +62,13 @@ interface WGLPoint extends Point {
 }
 
 /** @internal */
+interface WGLBandPoint {
+    x: number;
+    low: number;
+    high: number;
+}
+
+/** @internal */
 interface WGLRendererCallbackFunction {
     (renderer: WGLRenderer): void;
 }
@@ -242,6 +249,7 @@ class WGLRenderer {
 
     /** @internal */
     private static seriesPointCount(series: Series): number {
+        const drawMode = WGLRenderer.seriesDrawMode(series);
         let isStacked: boolean,
             xData: Array<number>,
             s: number;
@@ -264,6 +272,11 @@ class WGLRenderer {
                 s *= 12;
             } else if (series.type === 'heatmap') {
                 s *= 6;
+            } else if (
+                series.type === 'area' ||
+                series.type === 'arearange'
+            ) {
+                s *= drawMode === 'TRIANGLES' ? 6 : 2;
             } else if (asBar[series.type]) {
                 s *= 2;
             }
@@ -406,6 +419,24 @@ class WGLRenderer {
         vbuffer && vbuffer.allocate(s);
     }
 
+    /** @internal */
+    private static seriesDrawMode(series: Series): WGLDrawModeValue {
+        if (
+            series.type === 'area' ||
+            series.type === 'arearange'
+        ) {
+            const boostShape = series.options.boostShape as (
+                string|undefined
+            );
+
+            return boostShape?.toLowerCase() === 'triangles' ?
+                'TRIANGLES' :
+                'LINES';
+        }
+
+        return WGLDrawMode[series.type] || 'LINE_STRIP';
+    }
+
     /**
      * Clear the depth and color buffer
      * @internal
@@ -468,9 +499,14 @@ class WGLRenderer {
             cullXThreshold = 1,
             cullYThreshold = 1,
             chartDestroyed = typeof chart.index === 'undefined',
-            drawAsBar = asBar[series.type],
             pixelRatio = this.getPixelRatio(),
-            colors = chart.options.colors || [];
+            colors = chart.options.colors || [],
+            isBandSeries = (
+                series.type === 'area' ||
+                series.type === 'arearange'
+            ),
+            drawAsBand = isBandSeries && inst.drawMode === 'TRIANGLES',
+            drawAsBar = asBar[series.type] && !drawAsBand;
 
         let plotWidth = series.chart.plotWidth,
             lastX: number = false as any,
@@ -500,6 +536,8 @@ class WGLRenderer {
             gapSize: number = false as any,
             vlen = 0,
             colorIndex = 0;
+
+        let previousBandPoint: (WGLBandPoint|undefined);
 
         if (options.boostData && options.boostData.length > 0) {
             return;
@@ -681,6 +719,26 @@ class WGLRenderer {
             vertice(x + w, y + h);
             pushColor(color);
             vertice(x + w, y);
+        };
+
+        const pushBandSegment = (
+            fromPoint: WGLBandPoint,
+            toPoint: WGLBandPoint,
+            color?: Color.RGBA
+        ): void => {
+            pushColor(color);
+            vertice(fromPoint.x, fromPoint.low, false, 0);
+            pushColor(color);
+            vertice(fromPoint.x, fromPoint.high, false, 0);
+            pushColor(color);
+            vertice(toPoint.x, toPoint.high, false, 0);
+
+            pushColor(color);
+            vertice(fromPoint.x, fromPoint.low, false, 0);
+            pushColor(color);
+            vertice(toPoint.x, toPoint.high, false, 0);
+            pushColor(color);
+            vertice(toPoint.x, toPoint.low, false, 0);
         };
 
         // Create the first segment
@@ -918,6 +976,7 @@ class WGLRenderer {
 
             if (!connectNulls && (x === null || y === null)) {
                 beginSegment();
+                previousBandPoint = void 0;
                 continue;
             }
 
@@ -941,6 +1000,26 @@ class WGLRenderer {
                 x = (d as any).x;
                 y = (d as any).stackY;
                 low = (y as any) - (d as any).y;
+            } else if (drawAsBand) {
+                low = low || 0;
+
+                if ((low as any) === false || typeof low === 'undefined') {
+                    if (y < 0) {
+                        low = y;
+                    } else {
+                        low = 0;
+                    }
+                }
+
+                if (
+                    (!isRange && !isStacked) ||
+                    yAxis.logarithmic
+                ) {
+                    low = Math.max(
+                        (typeof threshold !== 'undefined' ? threshold as number : yMin as number),
+                        yMin as number
+                    );
+                }
             }
 
             if (
@@ -949,7 +1028,9 @@ class WGLRenderer {
                 yMax !== null &&
                 typeof yMax !== 'undefined'
             ) {
-                isYInside = y >= yMin && y <= yMax;
+                isYInside = isNumber(low) ?
+                    Math.max(low, y) >= yMin && Math.min(low, y) <= yMax :
+                    y >= yMin && y <= yMax;
             }
 
             // Do not render points outside the zoomed range (#19701)
@@ -971,6 +1052,12 @@ class WGLRenderer {
                 continue;
             }
 
+            if (drawAsBand && (low === null || typeof low === 'undefined')) {
+                beginSegment();
+                previousBandPoint = void 0;
+                continue;
+            }
+
             // Cull points outside the extremes
 
             // Continue if `sdata` has only one point as `nextInside` asserts
@@ -982,6 +1069,7 @@ class WGLRenderer {
                 )
             ) {
                 beginSegment();
+                previousBandPoint = void 0;
                 continue;
             }
 
@@ -1006,6 +1094,7 @@ class WGLRenderer {
 
             if (gapSize && x - px > gapSize) {
                 beginSegment();
+                previousBandPoint = void 0;
             }
 
             // Note: Boost requires that zones are sorted!
@@ -1043,6 +1132,9 @@ class WGLRenderer {
                 inst.skipTranslation = true;
                 x = xAxis.toPixels(x, true);
                 y = yAxis.toPixels(y, true);
+                if (drawAsBand && isNumber(low)) {
+                    low = yAxis.toPixels(low, true);
+                }
 
                 // Make sure we're not drawing outside of the chart area.
                 // See #6594. Update: this is no longer required as far as I
@@ -1105,6 +1197,25 @@ class WGLRenderer {
                     ++skipped;
                 }
 
+                continue;
+            }
+
+            if (drawAsBand && isNumber(low)) {
+                const bandPoint = {
+                    x,
+                    low,
+                    high: y
+                };
+
+                if (previousBandPoint) {
+                    pushBandSegment(previousBandPoint, bandPoint, pcolor);
+                }
+
+                previousBandPoint = bandPoint;
+                lastX = x;
+                lastY = y;
+                hadPoints = true;
+                firstPoint = false;
                 continue;
             }
 
@@ -1260,7 +1371,7 @@ class WGLRenderer {
                 s.options.marker.enabled !== false :
                 false,
             showMarkers: true,
-            drawMode: WGLDrawMode[s.type] || 'LINE_STRIP'
+            drawMode: WGLRenderer.seriesDrawMode(s)
         };
 
         if (s.index >= series.length) {


### PR DESCRIPTION
## Summary

Add `boostShape` for boosted area, arearange and areaspline series.

This introduces a new series-level Boost option that controls how boosted area, arearange and areaspline series are drawn. By default, they keep the legacy 1px line-style rendering. Setting `boostShape: 'triangles'` switches boosted bands to filled triangle geometry so the area is rendered as a proper filled shape.

## Changes

- Added `plotOptions.series.boostShape` to the Boost typings and API doclets.
- Updated the WebGL renderer to resolve `lines` vs `triangles` for area, arearange and areaspline series.
- Kept the legacy Boost rendering path unchanged unless `boostShape` explicitly requests triangles.
- Added Boost tests for area, arearange and areaspline in both shapes.
- Updated the Boost documentation to describe the new option.
- Added a small browser-openable sample for manual verification.
