### PR TITLE
bugfix/25090-bad-csv-export-with-no-data

### DIFF
--- a/samples/unit-tests/export-data/basics/demo.js
+++ b/samples/unit-tests/export-data/basics/demo.js
@@ -1295,6 +1295,44 @@ QUnit.test('Toggle data table (#13690)', function (assert) {
         'The table should re-render after a data update, #14320.'
     );
     chart.exporting.hideData();
+
+    // No series left to export, #25090
+    chart.series[0].remove();
+
+    assert.strictEqual(
+        chart.exporting.getCSV(),
+        '',
+        'A chart without series should produce no CSV content.'
+    );
+
+    let warning;
+    const removeEvent = Highcharts.addEvent(
+        Highcharts,
+        'displayError',
+        e => {
+            warning = e.code;
+        }
+    );
+
+    chart.exporting.downloadCSV();
+
+    assert.strictEqual(
+        warning,
+        'Warning: No data to export',
+        'The CSV download should be skipped with a warning, instead of ' +
+            'writing a file containing only a byte order mark, #25090.'
+    );
+
+    warning = void 0;
+    chart.exporting.downloadXLS();
+
+    assert.strictEqual(
+        warning,
+        'Warning: No data to export',
+        'The XLS download should be skipped with a warning, #25090.'
+    );
+
+    removeEvent();
 });
 
 QUnit.test('Point without y data, but with value (#13785)', function (assert) {

--- a/ts/Extensions/Annotations/AnnotationChart.ts
+++ b/ts/Extensions/Annotations/AnnotationChart.ts
@@ -216,7 +216,8 @@ function chartCallback(
                 {}).columnHeaderFormatter,
             // If second row doesn't have xValues
             // then it is a title row thus multiple level header is in use.
-            multiLevelHeaders = !event.dataRows[1].xValues,
+            // The row is missing altogether when the chart has no data, #25090.
+            multiLevelHeaders = !event.dataRows[1]?.xValues,
             annotationHeader = (
                 chart.options.lang &&
                 chart.options.lang.exportData &&

--- a/ts/Extensions/ExportData/ExportData.ts
+++ b/ts/Extensions/ExportData/ExportData.ts
@@ -63,6 +63,7 @@ import {
     isNumber,
     pushUnique
 } from '../../Shared/Utilities.js';
+import { error } from '../../Core/Utilities.js';
 
 /* *
  *
@@ -597,6 +598,11 @@ namespace ExportData {
     function downloadCSV(
         this: Exporting
     ): void {
+        if (!this.chart.series.some(isExportableSeries)) {
+            error('Warning: No data to export', false, this.chart);
+            return;
+        }
+
         this.wrapLoading((): void => {
             const csv = this.getCSV(true);
 
@@ -623,6 +629,11 @@ namespace ExportData {
     function downloadXLS(
         this: Exporting
     ): void {
+        if (!this.chart.series.some(isExportableSeries)) {
+            error('Warning: No data to export', false, this.chart);
+            return;
+        }
+
         this.wrapLoading((): void => {
             const uri = 'data:application/vnd.ms-excel;base64,',
                 template =
@@ -893,11 +904,7 @@ namespace ExportData {
                 mockSeries: ExportDataSeries,
                 j: number;
 
-            if (
-                series.options.includeInDataExport !== false &&
-                !series.options.isInternal &&
-                series.visible !== false // #55
-            ) {
+            if (isExportableSeries(series)) {
 
                 // Build a lookup for X axis index and the position of the first
                 // series that belongs to that X axis. Includes -1 for non-axis
@@ -1500,6 +1507,24 @@ namespace ExportData {
         this: Exporting
     ): void {
         this.toggleDataTable(false);
+    }
+
+    /**
+     * Whether the series contributes columns to the exported data.
+     *
+     * @internal
+     *
+     * @requires modules/exporting
+     * @requires modules/export-data
+     */
+    function isExportableSeries(
+        series: Series
+    ): boolean {
+        return (
+            series.options.includeInDataExport !== false &&
+            !series.options.isInternal &&
+            series.visible !== false // #55
+        );
     }
 
     /**


### PR DESCRIPTION
Fixed #25090, CSV/XLS export produced a BOM-only file when the chart had no data.