### PR TITLE
bugfix/chart-credits-can-link-executable-js

### DIFF
--- a/samples/unit-tests/chart/credits-href-filtering/demo.css
+++ b/samples/unit-tests/chart/credits-href-filtering/demo.css
@@ -1,0 +1,5 @@
+#container {
+    width: 600px;
+    height: 400px;
+    margin: 0 auto;
+}

--- a/samples/unit-tests/chart/credits-href-filtering/demo.details
+++ b/samples/unit-tests/chart/credits-href-filtering/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/chart/credits-href-filtering/demo.html
+++ b/samples/unit-tests/chart/credits-href-filtering/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container"></div>

--- a/samples/unit-tests/chart/credits-href-filtering/demo.js
+++ b/samples/unit-tests/chart/credits-href-filtering/demo.js
@@ -1,0 +1,57 @@
+QUnit.test('Credits href should be run through the allow list', function (
+    assert
+) {
+    const errors = [],
+        unbindError = Highcharts.addEvent(
+            Highcharts,
+            'displayError',
+            function (e) {
+                errors.push(e.code);
+                // Keep the console clean
+                e.preventDefault();
+            }
+        );
+
+    try {
+        const chart = Highcharts.chart('container', {
+            credits: {
+                // eslint-disable-next-line no-script-url
+                href: 'javascript:window.creditsXss = true;',
+                text: 'Credits'
+            },
+            series: [{
+                data: [1, 2, 3]
+            }]
+        });
+
+        assert.ok(
+            errors.indexOf(33) !== -1,
+            'A warning should be reported for a disallowed credits URL'
+        );
+
+        chart.credits.element.dispatchEvent(
+            new MouseEvent('click', { bubbles: true })
+        );
+
+        assert.strictEqual(
+            window.creditsXss,
+            void 0,
+            'Clicking the credits should not run a javascript: URL'
+        );
+
+        errors.length = 0;
+
+        chart.credits.update({
+            href: 'https://www.example.com'
+        });
+
+        assert.strictEqual(
+            errors.indexOf(33),
+            -1,
+            'An allowed credits URL should pass through the filter'
+        );
+    } finally {
+        unbindError();
+        delete window.creditsXss;
+    }
+});

--- a/samples/unit-tests/chart/credits-href-filtering/demo.js
+++ b/samples/unit-tests/chart/credits-href-filtering/demo.js
@@ -1,7 +1,8 @@
 QUnit.test('Credits href should be run through the allow list', function (
     assert
 ) {
-    const errors = [],
+    const done = assert.async(),
+        errors = [],
         unbindError = Highcharts.addEvent(
             Highcharts,
             'displayError',
@@ -12,27 +13,29 @@ QUnit.test('Credits href should be run through the allow list', function (
             }
         );
 
-    try {
-        const chart = Highcharts.chart('container', {
-            credits: {
-                // eslint-disable-next-line no-script-url
-                href: 'javascript:window.creditsXss = true;',
-                text: 'Credits'
-            },
-            series: [{
-                data: [1, 2, 3]
-            }]
-        });
+    const chart = Highcharts.chart('container', {
+        credits: {
+            // eslint-disable-next-line no-script-url
+            href: 'javascript:window.creditsXss = true;',
+            text: 'Credits'
+        },
+        series: [{
+            data: [1, 2, 3]
+        }]
+    });
 
-        assert.ok(
-            errors.indexOf(33) !== -1,
-            'A warning should be reported for a disallowed credits URL'
-        );
+    assert.ok(
+        errors.indexOf(33) !== -1,
+        'A warning should be reported for a disallowed credits URL'
+    );
 
-        chart.credits.element.dispatchEvent(
-            new MouseEvent('click', { bubbles: true })
-        );
+    chart.credits.element.dispatchEvent(
+        new MouseEvent('click', { bubbles: true })
+    );
 
+    // Navigation to a javascript: URL runs in a later task, so the result is
+    // only visible asynchronously
+    setTimeout(function () {
         assert.strictEqual(
             window.creditsXss,
             void 0,
@@ -50,8 +53,9 @@ QUnit.test('Credits href should be run through the allow list', function (
             -1,
             'An allowed credits URL should pass through the filter'
         );
-    } finally {
+
         unbindError();
         delete window.creditsXss;
-    }
+        done();
+    }, 100);
 });

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -3149,6 +3149,13 @@ class Chart {
 
         if (creds.enabled && !this.credits) {
 
+            // Run the user-supplied URL through the allow list, so that
+            // references like `javascript:` can't be executed from the
+            // credits label
+            const href = creds.href ?
+                AST.filterUserAttributes({ href: creds.href }).href :
+                void 0;
+
             /**
              * The chart's credits label. The label has an `update` method that
              * allows setting new options as per the
@@ -3171,8 +3178,8 @@ class Chart {
                         'creditsClick',
                         e as Event,
                         (): void => {
-                            if (creds.href) {
-                                win.location.href = creds.href;
+                            if (href) {
+                                win.location.href = href;
                             }
                         }
                     );
@@ -4780,6 +4787,10 @@ namespace Chart {
 
         /**
          * The URL for the credits label.
+         *
+         * URLs that do not start with one of the
+         * [AST.allowedReferences](https://api.highcharts.com/class-reference/Highcharts.AST#.allowedReferences),
+         * for example `javascript:` URLs, are ignored.
          *
          * @sample {highcharts} highcharts/credits/href/
          *         Custom URL and text

--- a/ts/Core/Defaults.ts
+++ b/ts/Core/Defaults.ts
@@ -3100,6 +3100,10 @@ const defaultOptions: DefaultOptions = {
         /**
          * The URL for the credits label.
          *
+         * URLs that do not start with one of the
+         * [AST.allowedReferences](https://api.highcharts.com/class-reference/Highcharts.AST#.allowedReferences),
+         * for example `javascript:` URLs, are ignored.
+         *
          * @sample {highcharts} highcharts/credits/href/
          *         Custom URL and text
          * @sample {highmaps} maps/credits/customized/


### PR DESCRIPTION
Fixed, chart credits could link to executable JS

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1218199995201374