### PR TITLE
bugfix/prototype-pollution-in-series-data

### DIFF
--- a/samples/unit-tests/series/data-prototype-pollution/demo.css
+++ b/samples/unit-tests/series/data-prototype-pollution/demo.css
@@ -1,0 +1,4 @@
+#container {
+    width: 600px;
+    margin: 0 auto;
+}

--- a/samples/unit-tests/series/data-prototype-pollution/demo.details
+++ b/samples/unit-tests/series/data-prototype-pollution/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/series/data-prototype-pollution/demo.html
+++ b/samples/unit-tests/series/data-prototype-pollution/demo.html
@@ -1,0 +1,6 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container"></div>

--- a/samples/unit-tests/series/data-prototype-pollution/demo.js
+++ b/samples/unit-tests/series/data-prototype-pollution/demo.js
@@ -1,6 +1,6 @@
 QUnit.test('Data options must not pollute shared objects', function (assert) {
-    // JSON.parse creates `__proto__` and `constructor` as own keys, unlike
-    // object literals
+    // JSON.parse keeps `__proto__` and `constructor` as own keys, unlike
+    // object literals where they are intercepted by the parser
     const data = JSON.parse(
         '[{"y":1,"__proto__":{"polluted":"yes"}},' +
         '{"y":2,"constructor":{"polluted":"yes"}}]'
@@ -8,10 +8,12 @@ QUnit.test('Data options must not pollute shared objects', function (assert) {
 
     const chart = Highcharts.chart('container', {
         series: [{
-            type: 'column',
-            data: data
+            type: 'column'
         }]
     });
+
+    // Skip the redraw to isolate the building of the data columns
+    chart.series[0].setData(data, false);
 
     assert.strictEqual(
         {}[0],
@@ -32,19 +34,14 @@ QUnit.test('Data options must not pollute shared objects', function (assert) {
     );
 
     assert.deepEqual(
-        chart.series[0].points.map(point => point.y),
-        [1, 2],
-        'The valid part of the data should still render'
-    );
-
-    assert.deepEqual(
         Object.keys(chart.series[0].dataTable.columns),
         ['y'],
         'No columns should be created for the unsafe keys'
     );
 
-    assert.ok(
-        chart.series[0].points[0] instanceof Highcharts.Point,
-        'The point should keep its prototype'
+    assert.deepEqual(
+        Array.from(chart.series[0].getColumn('y')),
+        [1, 2],
+        'The valid part of the data should still be applied'
     );
 });

--- a/samples/unit-tests/series/data-prototype-pollution/demo.js
+++ b/samples/unit-tests/series/data-prototype-pollution/demo.js
@@ -1,0 +1,50 @@
+QUnit.test('Data options must not pollute shared objects', function (assert) {
+    // JSON.parse creates `__proto__` and `constructor` as own keys, unlike
+    // object literals
+    const data = JSON.parse(
+        '[{"y":1,"__proto__":{"polluted":"yes"}},' +
+        '{"y":2,"constructor":{"polluted":"yes"}}]'
+    );
+
+    const chart = Highcharts.chart('container', {
+        series: [{
+            type: 'column',
+            data: data
+        }]
+    });
+
+    assert.strictEqual(
+        {}[0],
+        undefined,
+        'Object.prototype should not be written to'
+    );
+
+    assert.strictEqual(
+        {}.polluted,
+        undefined,
+        'Object.prototype should not have picked up the payload'
+    );
+
+    assert.strictEqual(
+        Object[0],
+        undefined,
+        'The Object constructor should not be written to'
+    );
+
+    assert.deepEqual(
+        chart.series[0].points.map(point => point.y),
+        [1, 2],
+        'The valid part of the data should still render'
+    );
+
+    assert.deepEqual(
+        Object.keys(chart.series[0].dataTable.columns),
+        ['y'],
+        'No columns should be created for the unsafe keys'
+    );
+
+    assert.ok(
+        chart.series[0].points[0] instanceof Highcharts.Point,
+        'The point should keep its prototype'
+    );
+});

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -1050,23 +1050,6 @@ class Point {
             }
         }
 
-        // Data keys like `__proto__` and `constructor` must not be carried
-        // on, as assigning them would modify `Object.prototype` or the
-        // `Object` constructor and thereby affect unrelated objects on the
-        // page
-        if (
-            Object.hasOwnProperty.call(ret, '__proto__') ||
-            Object.hasOwnProperty.call(ret, 'constructor')
-        ) {
-            const safeOptions = {} as AnyRecord;
-            for (const key of Object.keys(ret)) {
-                if (key !== '__proto__' && key !== 'constructor') {
-                    safeOptions[key] = ret[key];
-                }
-            }
-            ret = safeOptions;
-        }
-
         // Handle nested keys, e.g. ['color.pattern.image'], but only if we're
         // using keys or `dataTable`
         if (keys || !series.options.data) {

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -1050,6 +1050,23 @@ class Point {
             }
         }
 
+        // Data keys like `__proto__` and `constructor` must not be carried
+        // on, as assigning them would modify `Object.prototype` or the
+        // `Object` constructor and thereby affect unrelated objects on the
+        // page
+        if (
+            Object.hasOwnProperty.call(ret, '__proto__') ||
+            Object.hasOwnProperty.call(ret, 'constructor')
+        ) {
+            const safeOptions = {} as AnyRecord;
+            for (const key of Object.keys(ret)) {
+                if (key !== '__proto__' && key !== 'constructor') {
+                    safeOptions[key] = ret[key];
+                }
+            }
+            ret = safeOptions;
+        }
+
         // Handle nested keys, e.g. ['color.pattern.image'], but only if we're
         // using keys or `dataTable`
         if (keys || !series.options.data) {

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -2016,6 +2016,13 @@ class Series {
                     .call({ series: this }, data[i]);
 
                 for (const key of Object.keys(ptOptions)) {
+                    // Assigning these would write through to
+                    // `Object.prototype` or the `Object` constructor instead
+                    // of creating a column, and thereby affect unrelated
+                    // objects on the page
+                    if (key === '__proto__' || key === 'constructor') {
+                        continue;
+                    }
                     columns[key] ||= new Array(dataLength);
                     columns[key][i] = (ptOptions as any)[key];
                 }


### PR DESCRIPTION
Fixed prototype pollution in point data options.


PR number #25316 should be merged first, that PR contains a guard in `extend` against prototype pollution and we need it to totally prevent pollution on point objects.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1218199995201363