### PR TITLE
bugfix/25092-supports-passive-zonejs

### DIFF
--- a/tests/highcharts/globals/globals.spec.ts
+++ b/tests/highcharts/globals/globals.spec.ts
@@ -1,8 +1,66 @@
+import type { Page } from '@playwright/test';
+
 import { test, expect } from '~/fixtures.ts';
 
 // Equivalent of test/typescript-karma/Core/Globals.test.js
 // The original test is for AMD loading of Highcharts package. This is a Playwright equivalent
 // that verifies Highcharts loads correctly via script tag.
+
+/**
+ * Loads Highcharts behind a wrapped `EventTarget.addEventListener` that
+ * records the options a `touchstart` listener was registered with. When
+ * `copyOptions` is set, the wrapper forwards a shallow copy instead of the
+ * original object, the way zone.js >= 0.14.7 does (#25092).
+ */
+async function loadWithListenerSpy(page: Page, copyOptions: boolean) {
+    await page.setContent(`
+        <!DOCTYPE html>
+        <html>
+            <head>
+                <script>
+                    const nativeAdd = EventTarget.prototype.addEventListener;
+
+                    EventTarget.prototype.addEventListener = function (
+                        type,
+                        listener,
+                        options
+                    ) {
+                        const forwarded = ${copyOptions} &&
+                            typeof options === 'object' && options !== null ?
+                            { ...options } : options;
+
+                        if (type === 'touchstart') {
+                            window.touchstartOptions = forwarded;
+                        }
+
+                        return nativeAdd.call(this, type, listener, forwarded);
+                    };
+                </script>
+                <script src="https://code.highcharts.com/highcharts.src.js"></script>
+            </head>
+            <body></body>
+        </html>
+    `, { waitUntil: 'networkidle' });
+
+    return page.evaluate(() => {
+        const testWindow = window as any,
+            Highcharts = testWindow.Highcharts,
+            removeEvent = Highcharts.addEvent(
+                document.createElement('div'),
+                'touchstart',
+                (): void => {}
+            );
+
+        try {
+            return {
+                supportsPassiveEvents: Highcharts.supportsPassiveEvents,
+                passive: testWindow.touchstartOptions?.passive
+            };
+        } finally {
+            removeEvent();
+        }
+    });
+}
 
 test.describe('Globals', () => {
     test('Highcharts object is available via script tag', async ({ page }) => {
@@ -30,5 +88,21 @@ test.describe('Globals', () => {
         expect(result.isObject, 'Highcharts should be an object').toBe(true);
         expect(result.hasChartMethod, 'Highcharts should have chart method').toBe(true);
         expect(result.hasProduct, 'Highcharts should have product property').toBe(true);
+    });
+
+    test('Passive events are detected', async ({ page }) => {
+        const result = await loadWithListenerSpy(page, false);
+
+        expect(result.supportsPassiveEvents).toBe(true);
+        expect(result.passive).toBe(true);
+    });
+
+    test('Passive events are detected through copied options', async ({
+        page
+    }) => {
+        const result = await loadWithListenerSpy(page, true);
+
+        expect(result.supportsPassiveEvents).toBe(true);
+        expect(result.passive).toBe(true);
     });
 });

--- a/tools/webpacks/check-namespace-exposure.mjs
+++ b/tools/webpacks/check-namespace-exposure.mjs
@@ -42,8 +42,7 @@ const ALLOWLIST = new Set([
     'boards',
     'doc',
     'noop',
-    'isMS',
-    'supportsPassiveEvents'
+    'isMS'
 ]);
 
 const exportPatterns = [

--- a/ts/Core/Globals.ts
+++ b/ts/Core/Globals.ts
@@ -202,14 +202,16 @@ namespace Globals {
             // Checks whether the browser supports passive events, (#11353).
             let supportsPassive = false;
 
-            // Object.defineProperty doesn't work on IE as well as passive
-            // events - instead of using polyfill, we can exclude IE totally.
+            // Accessors don't work on IE as well as passive events - instead
+            // of using polyfill, we can exclude IE totally. The getter has to
+            // be enumerable, or wrappers that shallow-copy the options never
+            // read it (#25092).
             if (!isMS) {
-                const opts = Object.defineProperty({}, 'passive', {
-                    get: function (): void {
-                        supportsPassive = true;
+                const opts: AddEventListenerOptions = {
+                    get passive(): boolean {
+                        return (supportsPassive = true);
                     }
-                });
+                };
 
                 if (win.addEventListener && win.removeEventListener) {
                     win.addEventListener('testPassive', noop, opts);

--- a/ts/Dashboards/Globals.ts
+++ b/ts/Dashboards/Globals.ts
@@ -106,28 +106,6 @@ export const noop = function (): void {};
 export const isMS = /(edge|msie|trident)/i
     .test((win.navigator && win.navigator.userAgent) || '') && !win.opera;
 
-export const supportsPassiveEvents = (function (): boolean {
-    // Checks whether the browser supports passive events, (#11353).
-    let supportsPassive = false;
-
-    // Object.defineProperty doesn't work on IE as well as passive
-    // events - instead of using polyfill, we can exclude IE totally.
-    if (!isMS) {
-        const opts = Object.defineProperty({}, 'passive', {
-            get: function (): void {
-                supportsPassive = true;
-            }
-        });
-
-        if (win.addEventListener && win.removeEventListener) {
-            win.addEventListener('testPassive', noop, opts);
-            win.removeEventListener('testPassive', noop, opts);
-        }
-    }
-
-    return supportsPassive;
-}());
-
 const Globals = {
     boards,
     classNamePrefix,
@@ -136,7 +114,6 @@ const Globals = {
     guiElementType,
     isMS,
     noop,
-    supportsPassiveEvents,
     version,
     win
 };


### PR DESCRIPTION
Fixed #25092, passive events went undetected when listener options were copied.