### PR TITLE
bugfix/25330-export-data-null-series-data

### DIFF
--- a/samples/unit-tests/export-data/basics/demo.js
+++ b/samples/unit-tests/export-data/basics/demo.js
@@ -1797,3 +1797,26 @@ QUnit.test('Lang thousandsSep and decimalPoint in table', function (assert) {
         'lang.decimalPoint should be applied in the data table (#24845).'
     );
 });
+
+QUnit.test('Export after addPoint into cropped series', function (assert) {
+    const chart = Highcharts.stockChart('container', {
+        navigator: { enabled: false },
+        scrollbar: { enabled: false },
+        rangeSelector: { enabled: false },
+        xAxis: { min: 500, max: 600 },
+        series: [{
+            data: Array.from({ length: 1000 }, (_, i) => [i, i])
+        }]
+    });
+
+    // Inserting a point in the middle of a cropped series leaves a null
+    // slot in series.data until that point is generated
+    chart.series[0].addPoint([10.5, 1]);
+
+    const rows = chart.exporting.getDataRows();
+    assert.strictEqual(
+        rows.length,
+        1002,
+        'Data export should include the added point and not throw'
+    );
+});

--- a/ts/Extensions/ExportData/ExportData.ts
+++ b/ts/Extensions/ExportData/ExportData.ts
@@ -852,8 +852,12 @@ namespace ExportData {
                 xAxis: Axis
             ): string[] {
                 const pointArrayMap = series.pointArrayMap || ['y'],
+                    // `series.data` may hold null slots after `addPoint`
+                    // inserted a point that has not been generated yet.
+                    // The null guard is licensed under the MIT license.
+                    // Author: David Califf
                     namedPoints = series.data.some((d): (string | false) =>
-                        (typeof d.y !== 'undefined') && d.name
+                        !!d && (typeof d.y !== 'undefined') && d.name
                     );
 
                 // If there are points with a name, we also want the x value in


### PR DESCRIPTION
Fixed #25330, exporting chart data to CSV or a table threw an error after `addPoint` had inserted a point into a cropped series.

---
`Series.addPoint` splices a `null` into `series.data` when it inserts a point mid-series or into a series with processed data. On a cropped series that slot is never filled by `generatePoints`, and `getPointArray` in the export-data module then throws from `series.data.some(...)`. This guards that callback against `null`; `getDataRows` already exports from `series.options.data` and tolerates a missing `series.data[pIdx]`.

Adds a unit test to `samples/unit-tests/export-data/basics` that inserts a point into a cropped stock series and exports it.
