### PR TITLE
fix: restore styled-mode HTML tooltip and label text styling

### DIFF
--- a/css/highcharts.css
+++ b/css/highcharts.css
@@ -325,9 +325,13 @@
 }
 
 .highcharts-tooltip text,
-.highcharts-tooltip foreignObject div:not(foreignObject > div) {
+.highcharts-tooltip foreignObject > div {
     fill: var(--highcharts-neutral-color-80);
     font-size: 0.8em;
+}
+
+.highcharts-tooltip foreignObject > div {
+    color: var(--highcharts-neutral-color-80);
 }
 
 .highcharts-tooltip .highcharts-header {
@@ -485,7 +489,7 @@ g.highcharts-series,
 }
 
 .highcharts-data-label text,
-.highcharts-data-label div,
+.highcharts-data-label foreignObject > div,
 text.highcharts-data-label {
     font-size: 0.7em;
     font-weight: bold;
@@ -499,6 +503,10 @@ text.highcharts-data-label {
 .highcharts-data-label text,
 text.highcharts-data-label {
     fill: var(--highcharts-neutral-color-80);
+}
+
+.highcharts-data-label foreignObject > div {
+    color: var(--highcharts-neutral-color-80);
 }
 
 .highcharts-data-label-connector {
@@ -644,18 +652,27 @@ text.highcharts-data-label {
 }
 
 .highcharts-legend-item > text,
-.highcharts-legend-item div {
+.highcharts-legend-item foreignObject > div {
     fill: var(--highcharts-neutral-color-80);
     font-size: 0.8em;
     cursor: pointer;
     stroke-width: 0;
 }
 
+.highcharts-legend-item foreignObject > div {
+    color: var(--highcharts-neutral-color-80);
+}
+
 .highcharts-legend-item:hover text {
     fill: var(--highcharts-neutral-color-100);
 }
 
+.highcharts-legend-item:hover foreignObject > div {
+    color: var(--highcharts-neutral-color-100);
+}
+
 .highcharts-legend-item-hidden * {
+    color: var(--highcharts-neutral-color-60) !important;
     fill: var(--highcharts-neutral-color-60) !important;
     stroke: var(--highcharts-neutral-color-60) !important;
     transition: fill 250ms;

--- a/docs/chart-design-and-style/style-by-css.md
+++ b/docs/chart-design-and-style/style-by-css.md
@@ -275,6 +275,8 @@ The label next to the crosshair in Highcharts Stock. 
 
 The data label. Use _.highcharts-data-label-box_ to style the border or background, and _.highcharts-data-label text_ for text styling. Use the _dataLabels.className_ option to set specific class names for individual items. Replaces background, border, color and style options for [series.dataLabels](https://api.highcharts.com/highcharts/plotOptions.series.dataLabels).
 
+For SVG text, set `fill` on `.highcharts-data-label text`. With `dataLabels.useHTML`, set `color` on `.highcharts-data-label foreignObject > div`. This selects the root HTML text element, where the default `0.7em` font size is applied once. Nested content inherits its color and font size unless overridden.
+
 [Demo of styling data labels](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/css/series-datalabels/).
 
 ```
@@ -480,6 +482,8 @@ The box and border for the legend. Replaces [legend.backgroundColor](https://ap
 
 Styles for each individual legend item. Replaces [legend.itemStyle](https://api.highcharts.com/highcharts/legend.itemStyle), and [legend.itemHoverStyle](https://api.highcharts.com/highcharts/legend.itemHoverStyle) when the _:hover_ pseudo-class is added.
 
+For SVG text, set `fill` on `.highcharts-legend-item > text`. With `legend.useHTML`, set `color` on `.highcharts-legend-item foreignObject > div`. The root HTML text element uses `0.8em`, and nested content inherits this size. HTML text also follows the legend's hover and hidden colors; hidden items retain their hidden color and line-through decoration while hovered.
+
 [Demo of legend styling](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/css/legend/).
 
 ```
@@ -638,10 +642,11 @@ Styles for the Highcharts Stock scrollbar. The thumb is the actual bar. The butt
 .highcharts-tooltip
 .highcharts-tooltip-box
 .highcharts-tooltip text
+.highcharts-tooltip foreignObject > div
 .highcharts-tooltip-header
 ```
 
-Styles for the tooltip. The tooltip box is the shape or path where the background and border can be set. Text styles should be applied to the text element.
+Styles for the tooltip. The tooltip box is the shape or path where the background and border can be set. For SVG text, apply text styles to `.highcharts-tooltip text` and use `fill` for its color. With `tooltip.useHTML`, use `.highcharts-tooltip foreignObject > div` and set `color` instead. This selects the root HTML text element and applies the default `0.8em` font size once, allowing nested content to inherit without repeated scaling. The `.highcharts-header` class applies a further `0.8em` reduction to header text.
 
 [Demo of tooltip styling](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/css/tooltip-border-background/).
 

--- a/samples/unit-tests/styled-mode/css/demo.js
+++ b/samples/unit-tests/styled-mode/css/demo.js
@@ -20,7 +20,6 @@ QUnit.test('CSS variables should be set', function (assert) {
         }
     );
 
-
     container.querySelector('.highcharts-background').style.transition = 'none';
 
     assert.ok(
@@ -85,3 +84,258 @@ QUnit.skip(
         );
         container.classList.remove('highcharts-light');
     });
+
+QUnit.test('Styled HTML text color and size (#25323)', function (assert) {
+    const container = document.getElementById('container'),
+        originalClass = container.className,
+        style = document.createElement('style'),
+        nested = '<div>Outer<div>Inner</div></div>',
+        chart = Highcharts.chart(container, {
+            chart: {
+                styledMode: true
+            },
+            tooltip: {
+                useHTML: true,
+                format: 'Tooltip'
+            },
+            legend: {
+                useHTML: true
+            },
+            plotOptions: {
+                series: {
+                    dataLabels: {
+                        enabled: true,
+                        useHTML: true,
+                        format: 'Label'
+                    }
+                }
+            },
+            series: [{
+                name: 'Series',
+                data: [1, 2]
+            }]
+        });
+
+    style.textContent = '.highcharts-container { color: rgb(255, 0, 255); }' +
+        '.highcharts-legend-item * { transition: none !important; }' +
+        '.highcharts-tooltip .custom-html-text { color: rgb(0, 128, 0); }';
+    document.head.appendChild(style);
+
+    function checkText(element, ratio, useHTML, message) {
+        const computed = getComputedStyle(element),
+            baseSize = parseFloat(getComputedStyle(chart.container).fontSize);
+
+        assert.strictEqual(
+            computed[useHTML ? 'color' : 'fill'],
+            getComputedStyle(chart.yAxis[0].labelGroup.element).fill,
+            message + ': neutral text color'
+        );
+        assert.close(
+            parseFloat(computed.fontSize),
+            baseSize * ratio,
+            0.01,
+            message + ': relative font size'
+        );
+        if (useHTML) {
+            assert.strictEqual(
+                element.parentNode.nodeName,
+                'foreignObject',
+                message + ': renderer-owned HTML root'
+            );
+            element.querySelectorAll('div').forEach(div => {
+                assert.strictEqual(
+                    getComputedStyle(div).color,
+                    computed.color,
+                    message + ': nested div inherits text color'
+                );
+                assert.strictEqual(
+                    getComputedStyle(div).fontSize,
+                    computed.fontSize,
+                    message + ': nested div inherits size once'
+                );
+            });
+        }
+    }
+
+    try {
+        ['highcharts-light', 'highcharts-dark'].forEach(mode => {
+            container.classList.remove('highcharts-light', 'highcharts-dark');
+            container.classList.add(mode);
+            [16, 20].forEach(fontSize => {
+                chart.container.style.fontSize = fontSize + 'px';
+                [true, false].forEach(useHTML => {
+                    chart.update({
+                        tooltip: { useHTML, format: 'Tooltip' },
+                        legend: { useHTML },
+                        plotOptions: {
+                            series: {
+                                dataLabels: { useHTML, format: 'Label' }
+                            }
+                        },
+                        series: [{ name: 'Series' }]
+                    });
+                    chart.tooltip.refresh(chart.series[0].points[0]);
+                    const series = chart.series[0],
+                        message = mode + ', ' + fontSize + ', HTML=' + useHTML;
+
+                    checkText(
+                        chart.tooltip.label.text.element,
+                        0.8, useHTML, message + ': tooltip'
+                    );
+                    checkText(
+                        series.legendItem.label.element,
+                        0.8, useHTML, message + ': legend'
+                    );
+                    checkText(
+                        series.points[0].dataLabel.text.element,
+                        0.7, useHTML, message + ': data label'
+                    );
+
+                    if (useHTML) {
+                        chart.update({
+                            tooltip: {
+                                format: nested +
+                                    '<span class="highcharts-header">Header' +
+                                    '</span><span style="color: red">' +
+                                    'Custom</span>'
+                            },
+                            plotOptions: {
+                                series: { dataLabels: { format: nested } }
+                            },
+                            series: [{ name: nested }]
+                        });
+                        chart.tooltip.refresh(series.points[0]);
+                        const text = chart.tooltip.label.text.element,
+                            legend = chart.series[0].legendItem.label.element;
+
+                        checkText(
+                            text, 0.8, true, message + ': nested tooltip'
+                        );
+                        checkText(
+                            legend, 0.8, true, message + ': nested legend'
+                        );
+                        checkText(
+                            chart.series[0].points[0].dataLabel.text.element,
+                            0.7, true, message + ': nested data label'
+                        );
+                        assert.close(
+                            parseFloat(getComputedStyle(
+                                text.querySelector('.highcharts-header')
+                            ).fontSize),
+                            fontSize * 0.8 * 0.8,
+                            0.01,
+                            'Tooltip header reduction applies once'
+                        );
+                        text.classList.add('custom-html-text');
+                        assert.strictEqual(
+                            getComputedStyle(text).color,
+                            'rgb(0, 128, 0)',
+                            'Author CSS can override HTML text color'
+                        );
+                        assert.strictEqual(
+                            getComputedStyle(text.lastChild).color,
+                            'rgb(255, 0, 0)',
+                            'Nested inline color is respected'
+                        );
+
+                        chart.series[0].hide();
+                        assert.strictEqual(
+                            getComputedStyle(legend).color,
+                            getComputedStyle(chart.yAxis[0].axisTitle.element)
+                                .fill,
+                            'Hidden HTML legend uses neutral-color-60'
+                        );
+                        assert.ok(
+                            getComputedStyle(legend).textDecorationLine
+                                .includes('line-through'),
+                            'Hidden HTML legend has a line through it'
+                        );
+                        chart.series[0].show();
+                        checkText(legend, 0.8, true, 'Restored HTML legend');
+                    }
+                });
+            });
+        });
+    } finally {
+        chart.destroy();
+        container.className = originalClass;
+        style.remove();
+    }
+});
+
+QUnit.test('Shared, split and outside HTML tooltip text (#25323)', assert => {
+    const container = document.getElementById('container'),
+        originalClass = container.className,
+        originalBodyClass = document.body.className;
+
+    ['highcharts-light', 'highcharts-dark'].forEach(mode => {
+        [false, true].forEach(outside => {
+            [false, true].forEach(split => {
+                container.classList.remove(
+                    'highcharts-light', 'highcharts-dark'
+                );
+                container.classList.add(mode);
+                document.body.classList.remove(
+                    'highcharts-light', 'highcharts-dark'
+                );
+                document.body.classList.add(mode);
+                const chart = Highcharts.chart(container, {
+                    chart: {
+                        styledMode: true
+                    },
+                    tooltip: {
+                        useHTML: true,
+                        shared: true,
+                        split,
+                        outside,
+                        headerFormat: 'Header',
+                        pointFormat: 'Point'
+                    },
+                    series: [{ data: [1, 2] }, { data: [2, 3] }]
+                });
+
+                try {
+                    chart.tooltip.refresh(chart.series.map(s => s.points[0]));
+                    const root = outside ?
+                            chart.tooltip.container : chart.container,
+                        labels = root.querySelectorAll(
+                            '.highcharts-tooltip foreignObject > div'
+                        ),
+                        baseSize = parseFloat(getComputedStyle(root).fontSize);
+
+                    root.style.color = 'rgb(255, 0, 255)';
+                    assert.strictEqual(
+                        labels.length, split ? 3 : 1,
+                        'Every tooltip label has an HTML root'
+                    );
+                    labels.forEach(label => {
+                        assert.strictEqual(
+                            getComputedStyle(label).color,
+                            getComputedStyle(chart.yAxis[0].labelGroup.element)
+                                .fill,
+                            mode + ': tooltip text uses neutral-color-80'
+                        );
+                        assert.close(
+                            parseFloat(getComputedStyle(label).fontSize),
+                            baseSize * 0.8,
+                            0.01,
+                            'Tooltip font size is reduced once'
+                        );
+                    });
+                    if (outside) {
+                        assert.ok(
+                            root.classList.contains(mode),
+                            'Outside tooltip inherits the theme class'
+                        );
+                    }
+                    chart.tooltip.update({ formatter: () => '' });
+                    chart.tooltip.refresh(chart.series.map(s => s.points[0]));
+                } finally {
+                    chart.destroy();
+                    container.className = originalClass;
+                    document.body.className = originalBodyClass;
+                }
+            });
+        });
+    });
+});


### PR DESCRIPTION
In `css/highcharts.css`, target the renderer-owned tooltip `foreignObject > div` for HTML `color: var(--highcharts-neutral-color-80)` and the existing `0.8em` typography, retaining SVG `fill` and avoiding relative font sizes on every nested content div. In styled mode, `tooltip.useHTML` renders text in a div directly inside an SVG `foreignObject`, but the tooltip CSS explicitly excludes that div.

Reproduce before fixing: create a styled chart with plain HTML tooltip text, HTML legend text, and HTML data labels; refresh the tooltip programmatically and assert that the generated text div is a direct child of `foreignObject`; For both `.highcharts-light` and `.highcharts-dark`, compare computed HTML `color` with the resolved neutral-color-80 value (for example, matching equivalent SVG text's computed fill). Set an intentionally different inherited page/container text color so an accidental inheritance pass is impossible.

Fixes #25323
